### PR TITLE
feat: automatic releases sized by PR title

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,73 @@
+name: Auto release
+
+# Cuts a release automatically when a PR merges to master, sized by the
+# conventional-commit prefix of the PR title:
+#
+#   feat!: / fix!: / any `type!:`  → major
+#   feat:                          → minor
+#   fix: / perf: / refactor:       → patch
+#   anything else (chore:, docs:, ci:, free-form, "[skip release]") → no release
+#
+# The version bump lands as a commit on master plus a `v<version>` tag, and
+# the Release builds workflow is dispatched on that tag to build and publish
+# the installers.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Decide version bump from the PR title
+        id: bump
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # The regexes live in variables: bash cannot parse `[^)]` inside
+          # an inline [[ =~ ]] expression.
+          major_re='^[a-z]+(\([^)]*\))?!:'
+          minor_re='^feat(\([^)]*\))?:'
+          patch_re='^(fix|perf|refactor)(\([^)]*\))?:'
+          bump=""
+          if [[ "$TITLE" == *"[skip release]"* ]]; then
+            bump=""
+          elif [[ "$TITLE" =~ $major_re ]]; then
+            bump=major
+          elif [[ "$TITLE" =~ $minor_re ]]; then
+            bump=minor
+          elif [[ "$TITLE" =~ $patch_re ]]; then
+            bump=patch
+          fi
+          echo "bump=$bump" >> "$GITHUB_OUTPUT"
+          echo "PR title: $TITLE → bump: ${bump:-none}"
+
+      - name: Bump version, commit and tag
+        if: steps.bump.outputs.bump != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version "${{ steps.bump.outputs.bump }}" -m "release: v%s"
+          git push origin master --follow-tags
+
+      - name: Trigger release builds
+        if: steps.bump.outputs.bump != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Tags pushed with the workflow's GITHUB_TOKEN do not fire on:push
+          # workflows (GitHub recursion guard), so dispatch the build
+          # workflow on the new tag explicitly.
+          gh workflow run release.yml \
+            --ref "v$(node -p 'require("./package.json").version')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -17,7 +20,9 @@ jobs:
         with:
           node-version: 22
       - run: npm install
-      - run: npm run dist
+      # On a tag, publish installers to the GitHub release; a plain
+      # workflow_dispatch on a branch only uploads CI artifacts.
+      - run: npx electron-builder --publish ${{ startsWith(github.ref, 'refs/tags/v') && 'always' || 'never' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Common tasks are wrapped in a Makefile — run `make help` to list them:
 | `make dist` | Build installers for the current platform |
 | `make dist-linux` / `dist-mac` / `dist-win` | Per-platform packages |
 | `make dist-win-docker` | Cross-build Windows packages from Linux via Docker+Wine |
+| `make release` | Cut a release manually (`BUMP=patch\|minor\|major`) |
 | `make install-stt` | Create the stt-server virtualenv and install it (uv) |
 | `make run-stt` | Run the local Parakeet STT server |
 | `make clean` | Remove build output |
@@ -63,6 +64,29 @@ npm run dist:win               # run on Windows, or: make dist-win-docker
 
 Output lands in `dist/`. Release builds for all three platforms run in CI on
 tag pushes (`v*`) — see [.github/workflows/release.yml](.github/workflows/release.yml).
+
+## Releasing
+
+Releases are cut **automatically when a PR merges to master**, sized by the
+conventional-commit prefix of the PR title
+([.github/workflows/auto-release.yml](.github/workflows/auto-release.yml)):
+
+| PR title | Release |
+| --- | --- |
+| `feat!: …` (any `type!:`) | major |
+| `feat: …` | minor |
+| `fix: …`, `perf: …`, `refactor: …` | patch |
+| anything else (`chore:`, `docs:`, free-form, `[skip release]`) | none |
+
+The workflow bumps `package.json`, commits `release: vX.Y.Z` to master, tags
+it, and dispatches the release builds, which publish the installers to a
+GitHub release.
+
+To cut a release manually instead:
+
+```bash
+make release BUMP=minor    # patch | minor | major (default patch)
+```
 
 ## Architecture
 

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,16 @@ dist-win-docker: ## Cross-build Windows packages from Linux via Docker+Wine
 		electronuserland/builder:wine \
 		/bin/bash -c "npm install && npm run dist:win"
 
+# ----- releasing -------------------------------------------------------------
+
+# Releases also happen automatically when a PR merges to master, sized by the
+# PR title (see .github/workflows/auto-release.yml). This target is the manual
+# path: bump version, commit, tag, push — CI builds and publishes installers.
+.PHONY: release
+release: ## Cut a release: bump, tag, push (BUMP=patch|minor|major, default patch)
+	npm version $(or $(BUMP),patch)
+	git push origin master --follow-tags
+
 # ----- speech-to-text server (Python) ---------------------------------------
 
 .PHONY: install-stt

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,6 +6,12 @@ directories:
   output: dist
   buildResources: build
 
+# Where `electron-builder --publish` uploads installers. releaseType: release
+# publishes immediately (not a draft) so tag builds are fully automatic.
+publish:
+  provider: github
+  releaseType: release
+
 files:
   - main/**/*
   - renderer/**/*


### PR DESCRIPTION
## Summary

Merging a PR to master now cuts a release automatically — no manual tagging, no manual uploads.

- **New `auto-release` workflow**: on PR merge, the conventional-commit prefix of the PR title decides the version bump — `feat!:` (any `type!:`) → major, `feat:` → minor, `fix:`/`perf:`/`refactor:` → patch, anything else or `[skip release]` → no release. It bumps `package.json`, commits `release: vX.Y.Z` to master, tags it, and dispatches the build workflow on the tag (explicit dispatch because tags pushed with `GITHUB_TOKEN` don't fire `on: push` workflows).
- **Release builds now publish**: tag builds run `electron-builder --publish always`, so each OS job uploads its installers straight to the GitHub release (previously only CI artifacts were uploaded and the releases page stayed empty). `releaseType: release` publishes immediately; switch to `draft` for a review step.
- **`make release BUMP=patch|minor|major`** for manual cuts (default patch).
- Release process documented in CONTRIBUTING.md.

## Notes for the reviewer

- The bump-decision regexes were tested against a matrix of title shapes (scoped, breaking, free-form, `[skip release]`). They live in shell variables because bash can't parse `[^)]` inside an inline `[[ =~ ]]`.
- The auto-release workflow pushes directly to master; if branch protection is ever enabled there, Actions needs bypass permission (or switch to a PAT).
- **Merging this PR with this title should itself cut v0.2.0** (minor), releasing the setup wizard from #1. Add `[skip release]` to the title before merging if that's not wanted yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)