### PR TITLE
fix: release builds publish all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   build:
     strategy:
+      # One platform failing must not cancel the other platforms' uploads.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Private, hotkey-driven voice dictation for your desktop. Speech-to-text with NVIDIA Parakeet, cleanup with any OpenAI-compatible LLM.",
   "main": "main/main.js",
   "license": "MIT",
-  "author": "Earheart contributors",
+  "author": {
+    "name": "Earheart contributors",
+    "email": "lucadanielcostin@gmail.com"
+  },
   "homepage": "https://github.com/cleanunicorn/earheart",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

The v0.2.0 release only got the Linux AppImage. Run [27427800138](https://github.com/cleanunicorn/earheart/actions/runs/27427800138) shows why:

1. The deb target failed: `Please specify author 'email' in the application package.json` (the deb maintainer field requires an email). The AppImage had already been published because electron-builder uploads each artifact as it's built.
2. The matrix defaults to fail-fast, so the Linux failure **cancelled** the macOS and Windows jobs before they could publish anything.

## Changes

- `package.json`: author is now `{ name, email }` — satisfies the deb maintainer requirement.
- `release.yml`: `fail-fast: false`, so one platform failing can't cancel the others' uploads.

Verified locally: `electron-builder --linux deb` now succeeds (previously failed with the same error as CI).

Merging this (`fix:` title) auto-cuts **v0.2.1**, which should publish AppImage, deb, dmg, zip, NSIS installer and portable exe. The broken v0.2.0 release can be deleted afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)