### PR TITLE
feat: option in Settings to re-run the setup wizard

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -39,6 +39,12 @@ function init({ applyHotkey, onSettingsChanged }) {
     return { settings: saved, hotkey: hotkeyResult };
   });
 
+  // Settings → Advanced: re-run the setup wizard on demand. The wizard
+  // itself doesn't change anything until it is completed.
+  ipcMain.handle("wizard:open", () => {
+    windows.openWizard();
+  });
+
   // Skipping still persists the defaults so the wizard only ever runs once.
   ipcMain.handle("wizard:skip", () => {
     const saved = settings.save(settings.get());

--- a/main/windows.js
+++ b/main/windows.js
@@ -152,6 +152,13 @@ function sendToOverlay(channel, payload) {
 
 function openSettings({ fromWizard = false } = {}) {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
+    if (fromWizard) {
+      // The wizard was re-run while Settings was already open: reload so
+      // the form picks up the choices the wizard just saved.
+      settingsWindow.loadFile(path.join(RENDERER, "settings.html"), {
+        query: { wizard: "1" },
+      });
+    }
     settingsWindow.show();
     settingsWindow.focus();
     return settingsWindow;

--- a/preload.js
+++ b/preload.js
@@ -26,6 +26,7 @@ const INVOKE = new Set([
   "settings:save",
   "wizard:complete",
   "wizard:skip",
+  "wizard:open",
   "stt:test",
   "cleanup:test",
   "history:list",

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -186,6 +186,16 @@
           <input id="max-seconds" type="number" min="10" max="3600" step="10" />
         </div>
         <div class="field">
+          <label>Setup wizard</label>
+          <div class="row">
+            <button id="open-wizard" class="ghost">Run the setup wizard again…</button>
+          </div>
+          <p class="hint">
+            Walks through hotkey, microphone, speech-to-text and cleanup from
+            scratch. Nothing changes until you finish the wizard.
+          </p>
+        </div>
+        <div class="field">
           <label>About</label>
           <p class="hint">
             Earheart <span id="version"></span> — private, hotkey-driven voice

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -289,7 +289,11 @@ earheart.on("history:changed", () => {
   if ($("tab-history").classList.contains("active")) renderHistory();
 });
 
-/* ---------- setup wizard hand-off ---------- */
+/* ---------- setup wizard ---------- */
+
+$("open-wizard").addEventListener("click", () => {
+  earheart.invoke("wizard:open");
+});
 
 // Opened right after the setup wizard: tell the user their choices are
 // already filled in and saving as-is is fine.


### PR DESCRIPTION
## What

Adds a **"Run the setup wizard again…"** button to Settings → Advanced. It opens the setup wizard through a new whitelisted `wizard:open` IPC channel.

- The wizard already prefills every step from current settings and persists nothing until you click finish, so opening it is always safe — this just exposes it.
- Fixed a stale-form issue in the hand-off: if the wizard completes while the Settings window is still open, `openSettings({ fromWizard })` used to just focus the existing window, leaving the form showing pre-wizard values. It now reloads the page (with the "pre-configured by the wizard" banner) so the form matches what the wizard saved.

## Testing

- End-to-end headless check: opened Settings under Xvfb, clicked the new button through the real preload/IPC path, and verified the wizard window appears — passes.
- `npm test` — 5/5 pass
- `xvfb-run electron . --smoke-test` — boots clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)