### PR TITLE
feat: in-process STT/cleanup engines with model download manager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 jobs:
   app:
-    runs-on: ubuntu-latest
+    # The in-process engines ship per-platform native binaries, so exercise
+    # install + tests + boot on all three target OSes, not just Linux.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,8 +21,21 @@ jobs:
           node-version: 22
       - run: npm install
       - run: npm test
+      # Electron needs a display; Linux runners are headless so wrap with xvfb.
       - name: Smoke test (headless)
+        if: runner.os == 'Linux'
         run: xvfb-run -a npx electron . --smoke-test --no-sandbox
+      - name: Smoke test
+        if: runner.os != 'Linux'
+        run: npx electron . --smoke-test --no-sandbox
+      # Boot the engine utilityProcess worker and round-trip a ping, so a broken
+      # worker or native-addon load surfaces here rather than at runtime.
+      - name: Engine worker boot (headless)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a npx electron scripts/engine-smoke.js --no-sandbox
+      - name: Engine worker boot
+        if: runner.os != 'Linux'
+        run: npx electron scripts/engine-smoke.js --no-sandbox
 
   stt-server:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing to Earheart
 
-Earheart is intentionally small and hackable: plain JavaScript, zero runtime
-npm dependencies, no bundler. The Python STT server is ~200 lines. If you can
-read Electron docs, you can read this whole codebase in an afternoon.
+Earheart is intentionally small and hackable: plain JavaScript, only a couple
+of runtime npm dependencies (the native STT and cleanup engines), no bundler.
+The Python STT server is ~200 lines. If you can read Electron docs, you can
+read this whole codebase in an afternoon.
 
 ## Development setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,17 +102,30 @@ main/                    Electron main process
   services/stt.js        OpenAI-compatible transcription client
   services/cleanup.js    OpenAI-compatible chat client
   services/server-manager.js  optional local STT server autostart
+  engines/               in-process STT + cleanup (no separate executable)
+    registry.js          downloadable model catalogue
+    model-manager.js     streaming, atomic, checksum-verified downloads
+    engine-worker.js     utilityProcess: sherpa-onnx (STT) + node-llama-cpp
+    host.js / index.js   parent-side worker lifecycle + facade
   output/deliver.js      clipboard + per-OS paste keystroke injection
 renderer/                overlay (mic capture → 16 kHz WAV), settings UI,
-                         first-run wizard
-stt-server/              Python: FastAPI + onnx-asr Parakeet server
+                         first-run wizard (incl. model download step)
+stt-server/              Python: FastAPI + onnx-asr Parakeet server (optional)
 ```
+
+The pipeline routes each stage to the in-process engine or the HTTP client
+based on `stt.engine` / `cleanup.engine` ("builtin" | "server" | "remote").
+The native runtimes are loaded lazily inside the worker, so the app boots and
+the HTTP paths keep working even if a model isn't downloaded.
 
 Design constraints worth keeping:
 
-- **Zero runtime npm dependencies** in the app — Electron's built-ins and the
-  platform's own tools (PowerShell, AppleScript, xdotool/wtype) cover
-  everything.
+- **Few runtime npm dependencies.** The app stays close to Electron's built-ins
+  and the platform's own tools (PowerShell, AppleScript, xdotool/wtype). The
+  only runtime deps are the two native engines — `sherpa-onnx-node` (STT) and
+  `node-llama-cpp` (cleanup) — which ship prebuilt binaries and are unpacked
+  from the asar (`asarUnpack` in `electron-builder.yml`). Models are downloaded
+  at first run, not bundled.
 - **The overlay window owns the microphone.** The main process never touches
   audio; it receives a finished WAV from the renderer.
 - **Never lose the user's words.** If cleanup fails, deliver the raw

--- a/README.md
+++ b/README.md
@@ -21,12 +21,19 @@ with a speech-to-text service, optionally cleans the transcript up with a
 language model, and then **pastes the result into whatever app you're typing
 in** (or just copies it to your clipboard).
 
-Both processing steps are **modular, OpenAI-compatible HTTP services**, so you
-choose where your voice goes:
+Out of the box both steps run **inside the app, on your computer** — no
+separate program, no Python, no account. The setup wizard downloads a small
+[Parakeet](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) speech model and
+a small [Gemma](https://huggingface.co/google) cleanup model (with a progress
+bar) and runs them in-process. Nothing ever leaves your machine.
 
-- **Fully private**: run the bundled [Parakeet STT server](stt-server/) and an
-  [Ollama](https://ollama.com)/llama.cpp model locally — nothing ever leaves
-  your machine.
+Prefer to point Earheart elsewhere? Both steps are also **modular,
+OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
+
+- **Built-in (default)**: Parakeet + Gemma run in-process — fully private,
+  nothing to install.
+- **Local server**: run the [Parakeet STT server](stt-server/) and an
+  [Ollama](https://ollama.com)/llama.cpp model yourself.
 - **Mix and match**: local STT with a hosted LLM for cleanup, or any other
   combination. Switching is just a base URL in Settings.
 
@@ -67,20 +74,23 @@ Grab the latest installer for your platform from the
 > blocked by Gatekeeper. Right-click the app → **Open**, or allow it under
 > **System Settings → Privacy & Security → Open Anyway**.
 
-### For fully local dictation: install `uv`
+That's it — the built-in engines need nothing else installed. The first-run
+wizard downloads the speech and cleanup models for you.
 
-Out of the box Earheart transcribes with its bundled local
-[Parakeet STT server](stt-server/), which it launches as `uvx earheart-stt`.
-That needs [uv](https://docs.astral.sh/uv/getting-started/installation/)
-installed — one command:
+### Advanced: a local STT server with `uv`
+
+If you'd rather run the [Parakeet STT server](stt-server/) as a separate
+process (e.g. to share it with other tools or use a GPU), Earheart can launch
+it as `uvx earheart-stt`. That needs
+[uv](https://docs.astral.sh/uv/getting-started/installation/) installed:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh   # Linux / macOS
 winget install astral-sh.uv                       # Windows
 ```
 
-If you'd rather use a hosted transcription service (OpenAI, Groq, …) you can
-skip this — the setup wizard lets you enter its URL and API key instead.
+Or point Earheart at a hosted transcription service (OpenAI, Groq, …) — the
+setup wizard and Settings let you enter its URL and API key instead.
 
 ### Build from source
 
@@ -101,14 +111,16 @@ npm run dist     # installers for the current platform land in dist/
   <img src="docs/screenshots/wizard.png" width="560" alt="Earheart setup wizard" />
 </p>
 
-On first launch a short setup wizard asks where speech should become text and
-where the text should go — hotkey, microphone, speech-to-text, optional
-cleanup, output. The defaults give you fully local, private dictation: keep
-"On this computer" and Earheart starts the Parakeet server alongside the app.
+On first launch a short setup wizard walks through hotkey, microphone,
+speech-to-text, cleanup and output. The defaults give you fully local, private
+dictation that runs **inside the app**: keep "On this computer, built in" for
+both speech-to-text and cleanup.
 
-The first transcription downloads the Parakeet model (≈ 2.4 GB, or ≈ 660 MB
-with the `int8` variant), so it takes a few minutes — everything after that is
-faster than realtime, even on CPU.
+The wizard's last step downloads the models that run on your machine — a small
+Parakeet speech model (≈ 660 MB) and a small Gemma cleanup model (≈ 700 MB) —
+showing a progress bar as it goes. It's a one-time download; everything after
+that is faster than realtime, even on CPU. You can pick a larger, higher-
+quality cleanup model in the wizard or later in Settings → Cleanup.
 
 ### Optional: transcript cleanup
 
@@ -205,8 +217,8 @@ endpoints (e.g. OpenWhispr) or from scripts via the OpenAI SDK. See
 
 ## Contributing
 
-Want to hack on Earheart? It's plain JavaScript with zero runtime npm
-dependencies and no bundler, and the Python STT server is ~200 lines. See
+Want to hack on Earheart? It's plain JavaScript with no bundler and only two
+runtime dependencies (the native STT and cleanup engines). See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the development setup, architecture
 overview, and how to build installers.
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,6 +19,18 @@ files:
   - assets/**/*
   - package.json
 
+# The in-process engines ship native addons (.node) and shared libraries
+# (.so/.dylib/.dll) that the OS loader must read from real files on disk, not
+# from inside the asar archive. Unpack them so sherpa-onnx (STT) and
+# node-llama-cpp (cleanup) load at runtime. Production deps are bundled
+# automatically; models are downloaded at first run, not packaged.
+asarUnpack:
+  - "**/*.node"
+  - "node_modules/sherpa-onnx-node/**"
+  - "node_modules/sherpa-onnx-*/**"
+  - "node_modules/node-llama-cpp/**"
+  - "node_modules/@node-llama-cpp/**"
+
 linux:
   target:
     - AppImage

--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -1,0 +1,152 @@
+// Runs in an Electron utilityProcess: hosts the in-process STT (sherpa-onnx /
+// Parakeet) and cleanup (node-llama-cpp / Gemma) engines, off the main process
+// so a long inference or a native crash never freezes the UI.
+//
+// The native modules are required lazily and defensively: if they aren't
+// installed (or a model isn't downloaded yet) the worker answers with a clear
+// error and the caller falls back to the HTTP path — the app keeps working.
+//
+// Protocol: the parent posts { id, type, ...args }; we reply with
+// { id, ok: true, result } or { id, ok: false, error }.
+
+const path = require("node:path");
+const { wavToFloat32 } = require("../util/wav");
+
+const port = process.parentPort;
+
+let recognizer = null; // sherpa-onnx OfflineRecognizer
+let sttModelId = null;
+
+let llama = null; // node-llama-cpp instance
+let llamaModel = null;
+let llamaContext = null;
+let llamaSession = null;
+let cleanupModelPath = null;
+let cleanupSystemPrompt = null;
+
+function reply(id, promise) {
+  Promise.resolve(promise)
+    .then((result) => port.postMessage({ id, ok: true, result }))
+    .catch((err) => port.postMessage({ id, ok: false, error: String(err && err.message || err) }));
+}
+
+/* ---------------- speech-to-text (sherpa-onnx / Parakeet) ---------------- */
+
+async function loadStt({ dir, sherpa, modelId }) {
+  if (recognizer && sttModelId === modelId) return { ready: true };
+  let sherpaOnnx;
+  try {
+    sherpaOnnx = require("sherpa-onnx-node");
+  } catch (err) {
+    throw new Error(`sherpa-onnx-node not available: ${err.message}`);
+  }
+  recognizer = new sherpaOnnx.OfflineRecognizer({
+    featConfig: { sampleRate: 16000, featureDim: 80 },
+    modelConfig: {
+      transducer: {
+        encoder: path.join(dir, sherpa.encoder),
+        decoder: path.join(dir, sherpa.decoder),
+        joiner: path.join(dir, sherpa.joiner),
+      },
+      tokens: path.join(dir, sherpa.tokens),
+      numThreads: Math.max(1, Math.min(4, require("node:os").cpus().length - 1)),
+      provider: "cpu",
+      modelType: sherpa.modelType || "nemo_transducer",
+      debug: false,
+    },
+  });
+  sttModelId = modelId;
+  return { ready: true };
+}
+
+async function transcribe({ wav, language }) {
+  if (!recognizer) throw new Error("STT model not loaded");
+  const buf = Buffer.isBuffer(wav) ? wav : Buffer.from(wav);
+  const { samples, sampleRate } = wavToFloat32(buf);
+  const stream = recognizer.createStream();
+  stream.acceptWaveform({ sampleRate, samples });
+  recognizer.decode(stream);
+  const result = recognizer.getResult(stream);
+  return (result && result.text ? result.text : "").trim();
+  // `language` is accepted for parity with the HTTP API; Parakeet v3
+  // auto-detects, so it is not forwarded.
+}
+
+/* ---------------- cleanup (node-llama-cpp / Gemma) ---------------- */
+
+async function loadCleanup({ modelPath, contextSize }) {
+  if (llamaModel && cleanupModelPath === modelPath) return { ready: true };
+  // node-llama-cpp v3 is ESM-only; reach it via dynamic import from CommonJS.
+  let mod;
+  try {
+    mod = await import("node-llama-cpp");
+  } catch (err) {
+    throw new Error(`node-llama-cpp not available: ${err.message}`);
+  }
+  await disposeCleanup();
+  llama = llama || (await mod.getLlama());
+  llamaModel = await llama.loadModel({ modelPath });
+  llamaContext = await llamaModel.createContext({
+    contextSize: contextSize || 2048,
+  });
+  llamaSession = null;
+  cleanupModelPath = modelPath;
+  cleanupSystemPrompt = null;
+  return { ready: true };
+}
+
+async function clean({ transcript, systemPrompt, temperature }) {
+  if (!llamaContext) throw new Error("Cleanup model not loaded");
+  const mod = await import("node-llama-cpp");
+  // The system prompt is fixed for a session; rebuild when the user edits it.
+  if (!llamaSession || cleanupSystemPrompt !== systemPrompt) {
+    if (llamaSession && llamaSession.dispose) llamaSession.dispose();
+    llamaSession = new mod.LlamaChatSession({
+      contextSequence: llamaContext.getSequence(),
+      systemPrompt,
+    });
+    cleanupSystemPrompt = systemPrompt;
+  } else {
+    llamaSession.resetChatHistory();
+  }
+  const out = await llamaSession.prompt(transcript, {
+    temperature: temperature ?? 0.2,
+  });
+  return (out || "").trim();
+}
+
+async function disposeCleanup() {
+  try {
+    if (llamaSession && llamaSession.dispose) llamaSession.dispose();
+    if (llamaContext && llamaContext.dispose) await llamaContext.dispose();
+    if (llamaModel && llamaModel.dispose) await llamaModel.dispose();
+  } catch {
+    // Best effort; we're tearing down anyway.
+  }
+  llamaSession = null;
+  llamaContext = null;
+  llamaModel = null;
+  cleanupModelPath = null;
+  cleanupSystemPrompt = null;
+}
+
+/* ---------------- dispatch ---------------- */
+
+const HANDLERS = {
+  ping: async () => ({ pong: true }),
+  "load-stt": loadStt,
+  transcribe,
+  "load-cleanup": loadCleanup,
+  clean,
+  "unload-cleanup": disposeCleanup,
+};
+
+port.on("message", (event) => {
+  const { id, type, ...args } = event.data || {};
+  const handler = HANDLERS[type];
+  if (!handler) {
+    port.postMessage({ id, ok: false, error: `Unknown request: ${type}` });
+    return;
+  }
+  reply(id, handler(args));
+});

--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -8,6 +8,12 @@
 //
 // Protocol: the parent posts { id, type, ...args }; we reply with
 // { id, ok: true, result } or { id, ok: false, error }.
+//
+// Engine state (the recognizer, the llama context/session) is single-instance,
+// so requests are assumed to arrive one at a time. The dictation pipeline is a
+// state machine that runs a single transcribe/clean at once; Settings "test"
+// actions are the only other callers and are not expected to overlap a live
+// dictation.
 
 const path = require("node:path");
 const { wavToFloat32 } = require("../util/wav");
@@ -40,6 +46,17 @@ async function loadStt({ dir, sherpa, modelId }) {
   } catch (err) {
     throw new Error(`sherpa-onnx-node not available: ${err.message}`);
   }
+  // Free the previous recognizer before swapping models so we don't leak its
+  // native memory (the cleanup engine does the same via disposeCleanup).
+  if (recognizer && typeof recognizer.free === "function") {
+    try {
+      recognizer.free();
+    } catch {
+      // best effort
+    }
+  }
+  recognizer = null;
+  sttModelId = null;
   recognizer = new sherpaOnnx.OfflineRecognizer({
     featConfig: { sampleRate: 16000, featureDim: 80 },
     modelConfig: {

--- a/main/engines/host.js
+++ b/main/engines/host.js
@@ -1,0 +1,80 @@
+// Parent side of the engine worker. Lazily forks the utilityProcess, routes
+// request/reply messages by id, and restarts the worker if it dies. All of the
+// Electron-specific plumbing lives here so the rest of the app talks to plain
+// async functions.
+
+const path = require("node:path");
+
+let child = null;
+let nextId = 1;
+const pending = new Map();
+
+function spawn() {
+  if (child) return child;
+  // Required lazily so this module can be loaded in non-Electron unit tests.
+  const { utilityProcess } = require("electron");
+  child = utilityProcess.fork(path.join(__dirname, "engine-worker.js"), [], {
+    serviceName: "earheart-engines",
+    stdio: "inherit",
+  });
+  child.on("message", (msg) => {
+    const entry = msg && pending.get(msg.id);
+    if (!entry) return;
+    pending.delete(msg.id);
+    if (msg.ok) entry.resolve(msg.result);
+    else entry.reject(new Error(msg.error || "engine error"));
+  });
+  child.on("exit", () => {
+    child = null;
+    // Fail anything still in flight so callers fall back instead of hanging.
+    for (const entry of pending.values()) {
+      entry.reject(new Error("engine process exited"));
+    }
+    pending.clear();
+  });
+  return child;
+}
+
+/**
+ * Send a request to the worker and await its reply.
+ * @param {string} type
+ * @param {object} [args]
+ * @param {ArrayBuffer[]} [transfer] - buffers to move (not copy)
+ * @param {number} [timeoutMs]
+ */
+function request(type, args = {}, transfer = [], timeoutMs = 180000) {
+  const proc = spawn();
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error(`engine request '${type}' timed out`));
+      }
+    }, timeoutMs);
+    pending.set(id, {
+      resolve: (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      reject: (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    });
+    proc.postMessage({ id, type, ...args }, transfer);
+  });
+}
+
+function stop() {
+  if (child) {
+    try {
+      child.kill();
+    } catch {
+      // already gone
+    }
+    child = null;
+  }
+}
+
+module.exports = { request, stop };

--- a/main/engines/host.js
+++ b/main/engines/host.js
@@ -8,6 +8,14 @@ const path = require("node:path");
 let child = null;
 let nextId = 1;
 const pending = new Map();
+// Notified whenever the worker process goes away, so callers can drop any
+// state they were caching about what the (now gone) worker had loaded.
+const exitListeners = new Set();
+
+function onExit(fn) {
+  exitListeners.add(fn);
+  return fn;
+}
 
 function spawn() {
   if (child) return child;
@@ -31,6 +39,9 @@ function spawn() {
       entry.reject(new Error("engine process exited"));
     }
     pending.clear();
+    // A fresh worker has nothing loaded; let callers reset their caches so the
+    // next request re-loads the model instead of assuming it is still resident.
+    for (const fn of exitListeners) fn();
   });
   return child;
 }
@@ -77,4 +88,4 @@ function stop() {
   }
 }
 
-module.exports = { request, stop };
+module.exports = { request, stop, onExit };

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -1,0 +1,113 @@
+// High-level facade over the in-process engines: where models live on disk,
+// downloading them, and running transcription / cleanup through the worker.
+// The pipeline and IPC layers use only this module.
+
+const path = require("node:path");
+const { app } = require("electron");
+
+const registry = require("./registry");
+const manager = require("./model-manager");
+const host = require("./host");
+
+function modelsDir() {
+  return path.join(app.getPath("userData"), "models");
+}
+
+function resolve(kind, modelId) {
+  const model = registry.getModel(kind, modelId);
+  if (!model) throw new Error(`Unknown ${kind} model: ${modelId}`);
+  return model;
+}
+
+/* ---------------- model files ---------------- */
+
+function isInstalled(kind, modelId) {
+  return manager.isInstalled(modelsDir(), resolve(kind, modelId));
+}
+
+function download(kind, modelId, { onProgress, signal } = {}) {
+  return manager.download(modelsDir(), resolve(kind, modelId), { onProgress, signal });
+}
+
+function remove(kind, modelId) {
+  return manager.remove(modelsDir(), resolve(kind, modelId));
+}
+
+/* ---------------- speech-to-text ---------------- */
+
+let loadedStt = null;
+
+async function ensureStt(modelId) {
+  const model = resolve("stt", modelId);
+  if (!manager.isInstalled(modelsDir(), model)) {
+    throw new Error(`STT model "${modelId}" is not downloaded yet`);
+  }
+  if (loadedStt !== modelId) {
+    await host.request("load-stt", {
+      dir: manager.modelDir(modelsDir(), model),
+      sherpa: model.sherpa,
+      modelId,
+    });
+    loadedStt = modelId;
+  }
+}
+
+async function transcribe(wav, cfg) {
+  await ensureStt(cfg.builtin.model);
+  const bytes = Buffer.isBuffer(wav) ? wav : Buffer.from(wav);
+  // Transfer the audio's backing buffer instead of copying it across.
+  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const text = await host.request(
+    "transcribe",
+    { wav: ab, language: cfg.language || "" },
+    [ab]
+  );
+  return (text || "").trim();
+}
+
+/* ---------------- cleanup ---------------- */
+
+let loadedCleanup = null;
+
+async function ensureCleanup(modelId) {
+  const model = resolve("cleanup", modelId);
+  if (!manager.isInstalled(modelsDir(), model)) {
+    throw new Error(`Cleanup model "${modelId}" is not downloaded yet`);
+  }
+  if (loadedCleanup !== modelId) {
+    await host.request("load-cleanup", {
+      modelPath: path.join(manager.modelDir(modelsDir(), model), model.gguf.file),
+    });
+    loadedCleanup = modelId;
+  }
+}
+
+async function clean(transcript, cfg) {
+  await ensureCleanup(cfg.builtin.model);
+  const cleaned = await host.request("clean", {
+    transcript,
+    systemPrompt: cfg.systemPrompt,
+    temperature: cfg.temperature,
+  });
+  // Never let an empty cleanup eat the user's words.
+  return cleaned && cleaned.length > 0 ? cleaned : transcript;
+}
+
+function stop() {
+  loadedStt = null;
+  loadedCleanup = null;
+  host.stop();
+}
+
+module.exports = {
+  modelsDir,
+  isInstalled,
+  download,
+  remove,
+  ensureStt,
+  transcribe,
+  ensureCleanup,
+  clean,
+  stop,
+  registry,
+};

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -55,7 +55,8 @@ async function ensureStt(modelId) {
 async function transcribe(wav, cfg) {
   await ensureStt(cfg.builtin.model);
   const bytes = Buffer.isBuffer(wav) ? wav : Buffer.from(wav);
-  // Transfer the audio's backing buffer instead of copying it across.
+  // Copy out an exact-length ArrayBuffer and transfer (rather than clone) it to
+  // the worker, so the audio crosses the process boundary only once.
   const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   const text = await host.request(
     "transcribe",
@@ -98,6 +99,14 @@ function stop() {
   loadedCleanup = null;
   host.stop();
 }
+
+// If the worker dies (native crash, or our own stop()), it comes back empty.
+// Forget what we thought it had loaded so the next call re-loads the model
+// instead of sending inference to a worker that has no model resident.
+host.onExit(() => {
+  loadedStt = null;
+  loadedCleanup = null;
+});
 
 module.exports = {
   modelsDir,

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -1,0 +1,134 @@
+// Downloads and tracks the in-process models (STT + cleanup).
+//
+// Everything is keyed off a base directory (Electron's userData/models in the
+// app; a temp dir in tests) so this module has no Electron dependency and is
+// unit-testable against a local HTTP server.
+//
+// Each file is streamed to `<name>.part`, optionally checksum-verified, then
+// renamed into place — so a half-finished download never looks complete. A
+// model counts as installed once every file is present and a `.complete`
+// marker has been written.
+
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const crypto = require("node:crypto");
+const { Readable, Transform } = require("node:stream");
+const { pipeline } = require("node:stream/promises");
+
+const { totalBytes } = require("./registry");
+
+const MARKER = ".complete";
+
+function modelDir(baseDir, model) {
+  return path.join(baseDir, model.kind, model.id);
+}
+
+function filePath(baseDir, model, file) {
+  return path.join(modelDir(baseDir, model), file.name);
+}
+
+/** True once every file is on disk and the completion marker exists. */
+function isInstalled(baseDir, model) {
+  const dir = modelDir(baseDir, model);
+  if (!fs.existsSync(path.join(dir, MARKER))) return false;
+  return model.files.every((f) => fs.existsSync(path.join(dir, f.name)));
+}
+
+/** Free a model's disk space. */
+async function remove(baseDir, model) {
+  await fsp.rm(modelDir(baseDir, model), { recursive: true, force: true });
+}
+
+// A pass-through stream that counts bytes and (optionally) hashes them, so we
+// can report progress and verify integrity in a single pass over the data.
+function makeMeter(onChunk, hash) {
+  return new Transform({
+    transform(chunk, _enc, cb) {
+      if (hash) hash.update(chunk);
+      onChunk(chunk.length);
+      cb(null, chunk);
+    },
+  });
+}
+
+async function downloadFile(baseDir, model, file, { onBytes, signal }) {
+  const dir = modelDir(baseDir, model);
+  await fsp.mkdir(dir, { recursive: true });
+  const dest = path.join(dir, file.name);
+  const part = `${dest}.part`;
+
+  const res = await fetch(file.url, { signal });
+  if (!res.ok || !res.body) {
+    throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
+  }
+
+  const hash = file.sha256 ? crypto.createHash("sha256") : null;
+  await pipeline(
+    Readable.fromWeb(res.body),
+    makeMeter(onBytes, hash),
+    fs.createWriteStream(part),
+    { signal }
+  );
+
+  if (hash) {
+    const got = hash.digest("hex");
+    if (got !== file.sha256) {
+      await fsp.rm(part, { force: true });
+      throw new Error(`Checksum mismatch for ${file.name}`);
+    }
+  }
+  await fsp.rename(part, dest); // atomic: only a verified file lands in place
+}
+
+/**
+ * Download every file of a model, reporting aggregate progress.
+ *
+ * @param {string} baseDir
+ * @param {object} model - a registry entry
+ * @param {object} [opts]
+ * @param {(p: {received:number,total:number,fraction:number,file:string}) => void} [opts.onProgress]
+ * @param {AbortSignal} [opts.signal]
+ */
+async function download(baseDir, model, { onProgress, signal } = {}) {
+  // Denominator for the progress bar. Registry sizes are approximate, so clamp
+  // the reported fraction to <=1 and let the final event snap to 100%.
+  const total = totalBytes(model) || 1;
+  let received = 0;
+  const report = (file) =>
+    onProgress?.({
+      received,
+      total,
+      fraction: Math.min(received / total, 0.999),
+      file,
+    });
+
+  for (const file of model.files) {
+    const dest = filePath(baseDir, model, file);
+    // Skip files already pulled in by an earlier (interrupted) run.
+    if (fs.existsSync(dest)) {
+      received += file.bytes || 0;
+      report(file.name);
+      continue;
+    }
+    await downloadFile(baseDir, model, file, {
+      signal,
+      onBytes: (n) => {
+        received += n;
+        report(file.name);
+      },
+    });
+  }
+
+  await fsp.writeFile(path.join(modelDir(baseDir, model), MARKER), "");
+  onProgress?.({ received: total, total, fraction: 1, file: null });
+}
+
+module.exports = {
+  modelDir,
+  filePath,
+  isInstalled,
+  remove,
+  download,
+  MARKER,
+};

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -7,7 +7,9 @@
 // Each file is streamed to `<name>.part`, optionally checksum-verified, then
 // renamed into place — so a half-finished download never looks complete. A
 // model counts as installed once every file is present and a `.complete`
-// marker has been written.
+// marker has been written. The marker records each file's size as actually
+// written, so `isInstalled` can reject a model whose files were later truncated
+// (e.g. a disk filling up) rather than trusting mere file presence.
 
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
@@ -28,11 +30,44 @@ function filePath(baseDir, model, file) {
   return path.join(modelDir(baseDir, model), file.name);
 }
 
-/** True once every file is on disk and the completion marker exists. */
+// Read the completion marker. Returns the recorded {name: size} map, an empty
+// map for a legacy (pre-size) marker, or null when no marker is present.
+function readMarker(dir) {
+  let raw;
+  try {
+    raw = fs.readFileSync(path.join(dir, MARKER), "utf8");
+  } catch {
+    return null; // no marker: not installed
+  }
+  if (!raw) return {}; // legacy empty marker: presence-only
+  try {
+    const parsed = JSON.parse(raw);
+    return (parsed && parsed.files) || {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * True once the completion marker exists and every file is on disk at the size
+ * recorded when it was downloaded. The recorded sizes (not the registry's
+ * approximate `bytes`) are the source of truth, so a finished file that was
+ * later truncated is treated as not installed.
+ */
 function isInstalled(baseDir, model) {
   const dir = modelDir(baseDir, model);
-  if (!fs.existsSync(path.join(dir, MARKER))) return false;
-  return model.files.every((f) => fs.existsSync(path.join(dir, f.name)));
+  const sizes = readMarker(dir);
+  if (sizes === null) return false;
+  return model.files.every((f) => {
+    const p = path.join(dir, f.name);
+    const expected = sizes[f.name];
+    if (expected === undefined) return fs.existsSync(p); // legacy marker
+    try {
+      return fs.statSync(p).size === expected;
+    } catch {
+      return false; // missing or unreadable
+    }
+  });
 }
 
 /** Free a model's disk space. */
@@ -58,6 +93,9 @@ async function downloadFile(baseDir, model, file, { onBytes, signal }) {
   const dest = path.join(dir, file.name);
   const part = `${dest}.part`;
 
+  // No HTTP range/resume: a failed or cancelled transfer discards the `.part`
+  // and the next attempt re-fetches the whole file from the start. Completed
+  // files are still skipped (below), so only the in-flight file is repeated.
   const res = await fetch(file.url, { signal });
   if (!res.ok || !res.body) {
     throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
@@ -120,7 +158,17 @@ async function download(baseDir, model, { onProgress, signal } = {}) {
     });
   }
 
-  await fsp.writeFile(path.join(modelDir(baseDir, model), MARKER), "");
+  // Record each file's actual on-disk size in the marker, so a later integrity
+  // check can catch truncation without relying on the registry's approximate
+  // sizes.
+  const sizes = {};
+  for (const file of model.files) {
+    sizes[file.name] = fs.statSync(filePath(baseDir, model, file)).size;
+  }
+  await fsp.writeFile(
+    path.join(modelDir(baseDir, model), MARKER),
+    JSON.stringify({ files: sizes })
+  );
   onProgress?.({ received: total, total, fraction: 1, file: null });
 }
 

--- a/main/engines/registry.js
+++ b/main/engines/registry.js
@@ -1,0 +1,120 @@
+// Registry of the models Earheart can download and run in-process.
+//
+// Two kinds:
+//   - "stt"     speech-to-text, run by sherpa-onnx (NVIDIA Parakeet, ONNX)
+//   - "cleanup" transcript cleanup, run by node-llama-cpp (Gemma, GGUF)
+//
+// Each model is just a list of files to fetch. We download individual files
+// (rather than an archive) so there is nothing to extract: the download
+// manager streams each URL to disk and the engines load the files in place.
+//
+// `bytes` is the expected size of each file, used both for the wizard's
+// progress bar and as a cheap integrity check (a finished file whose size
+// doesn't match is treated as incomplete). `sha256` is optional; when present
+// the download manager verifies it. Sizes are approximate upstream values and
+// the source of truth if a model is re-hosted.
+
+// Sherpa-onnx hosts ready-to-run ONNX bundles of the NeMo Parakeet models on
+// Hugging Face; we pull the encoder/decoder/joiner and the token table.
+const STT_HF = "https://huggingface.co/csukuangfj";
+
+// Google publishes QAT (quantization-aware-trained) Gemma weights as q4_0
+// GGUF, which is exactly what node-llama-cpp / llama.cpp load.
+const GEMMA_HF = "https://huggingface.co/google";
+
+const MODELS = {
+  stt: {
+    "parakeet-tdt-0.6b-v3-int8": {
+      id: "parakeet-tdt-0.6b-v3-int8",
+      label: "Parakeet TDT 0.6B v3 (multilingual, int8)",
+      kind: "stt",
+      engine: "sherpa-parakeet",
+      // ~25 languages, auto-detected, faster-than-realtime on CPU.
+      note: "Runs on this computer · 25 languages · ~660 MB",
+      files: [
+        { name: "encoder.int8.onnx", bytes: 636_000_000,
+          url: `${STT_HF}/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main/encoder.int8.onnx` },
+        { name: "decoder.int8.onnx", bytes: 7_000_000,
+          url: `${STT_HF}/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main/decoder.int8.onnx` },
+        { name: "joiner.int8.onnx", bytes: 5_000_000,
+          url: `${STT_HF}/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main/joiner.int8.onnx` },
+        { name: "tokens.txt", bytes: 60_000,
+          url: `${STT_HF}/sherpa-onnx-nemo-parakeet-tdt-0.6b-v3-int8/resolve/main/tokens.txt` },
+      ],
+      // How the sherpa-onnx engine should wire the files together.
+      sherpa: {
+        encoder: "encoder.int8.onnx",
+        decoder: "decoder.int8.onnx",
+        joiner: "joiner.int8.onnx",
+        tokens: "tokens.txt",
+        modelType: "nemo_transducer",
+      },
+    },
+  },
+  cleanup: {
+    "gemma-3-1b": {
+      id: "gemma-3-1b",
+      label: "Gemma 3 1B (fast, small)",
+      kind: "cleanup",
+      engine: "llama-gguf",
+      default: true,
+      note: "Runs on this computer · ~0.7 GB · best for most laptops",
+      files: [
+        { name: "gemma-3-1b-it-q4_0.gguf", bytes: 720_000_000,
+          url: `${GEMMA_HF}/gemma-3-1b-it-qat-q4_0-gguf/resolve/main/gemma-3-1b-it-q4_0.gguf` },
+      ],
+      gguf: { file: "gemma-3-1b-it-q4_0.gguf" },
+    },
+    "gemma-3-4b": {
+      id: "gemma-3-4b",
+      label: "Gemma 3 4B (balanced)",
+      kind: "cleanup",
+      engine: "llama-gguf",
+      note: "Runs on this computer · ~2.6 GB · needs ~6 GB RAM",
+      files: [
+        { name: "gemma-3-4b-it-q4_0.gguf", bytes: 2_600_000_000,
+          url: `${GEMMA_HF}/gemma-3-4b-it-qat-q4_0-gguf/resolve/main/gemma-3-4b-it-q4_0.gguf` },
+      ],
+      gguf: { file: "gemma-3-4b-it-q4_0.gguf" },
+    },
+    "gemma-4-12b": {
+      id: "gemma-4-12b",
+      label: "Gemma 4 12B (best quality)",
+      kind: "cleanup",
+      engine: "llama-gguf",
+      note: "Runs on this computer · ~7 GB · needs ~10 GB RAM, strong machine",
+      files: [
+        { name: "gemma-4-12b-it-q4_0.gguf", bytes: 7_300_000_000,
+          url: `${GEMMA_HF}/gemma-4-12B-it-qat-q4_0-gguf/resolve/main/gemma-4-12b-it-q4_0.gguf` },
+      ],
+      gguf: { file: "gemma-4-12b-it-q4_0.gguf" },
+    },
+  },
+};
+
+const DEFAULT_STT_MODEL = "parakeet-tdt-0.6b-v3-int8";
+const DEFAULT_CLEANUP_MODEL = "gemma-3-1b";
+
+/** Look up a model by kind ("stt" | "cleanup") and id. */
+function getModel(kind, id) {
+  return (MODELS[kind] && MODELS[kind][id]) || null;
+}
+
+/** All models of a kind, as an array (for settings dropdowns). */
+function listModels(kind) {
+  return Object.values(MODELS[kind] || {});
+}
+
+/** Total download size of a model in bytes. */
+function totalBytes(model) {
+  return model.files.reduce((sum, f) => sum + (f.bytes || 0), 0);
+}
+
+module.exports = {
+  MODELS,
+  DEFAULT_STT_MODEL,
+  DEFAULT_CLEANUP_MODEL,
+  getModel,
+  listModels,
+  totalBytes,
+};

--- a/main/engines/registry.js
+++ b/main/engines/registry.js
@@ -8,11 +8,13 @@
 // (rather than an archive) so there is nothing to extract: the download
 // manager streams each URL to disk and the engines load the files in place.
 //
-// `bytes` is the expected size of each file, used both for the wizard's
-// progress bar and as a cheap integrity check (a finished file whose size
-// doesn't match is treated as incomplete). `sha256` is optional; when present
-// the download manager verifies it. Sizes are approximate upstream values and
-// the source of truth if a model is re-hosted.
+// `bytes` is the approximate size of each file, used for the wizard's progress
+// bar. `sha256` is optional but strongly recommended before release: when
+// present the download manager verifies it, which is the only real guard
+// against a corrupted, tampered, or wrong file being loaded into the native
+// runtimes. The entries below ship without checksums and should have them
+// filled in (and the URLs/sizes sanity-checked against the live repos) before
+// the built-in engines are released.
 
 // Sherpa-onnx hosts ready-to-run ONNX bundles of the NeMo Parakeet models on
 // Hugging Face; we pull the encoder/decoder/joiner and the token table.

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -111,10 +111,10 @@ function init({ applyHotkey, onSettingsChanged }) {
     try {
       await engines.download(kind, modelId, {
         signal: controller.signal,
+        // Broadcast so whichever window is open (wizard and/or Settings) tracks
+        // the same download, not just the one that started it.
         onProgress: (p) => {
-          if (!event.sender.isDestroyed()) {
-            event.sender.send("models:progress", { kind, modelId, ...p });
-          }
+          windows.broadcast("models:progress", { kind, modelId, ...p });
         },
       });
       return { ok: true };

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -7,7 +7,11 @@ const windows = require("./windows");
 const stt = require("./services/stt");
 const cleanup = require("./services/cleanup");
 const serverManager = require("./services/server-manager");
+const engines = require("./engines");
 const { encodeSilenceWav } = require("./util/wav");
+
+// In-flight model downloads, so the UI can cancel them. Keyed by kind:modelId.
+const downloads = new Map();
 
 function init({ applyHotkey, onSettingsChanged }) {
   ipcMain.handle("settings:get", () => ({
@@ -53,12 +57,13 @@ function init({ applyHotkey, onSettingsChanged }) {
     return { settings: saved };
   });
 
-  // Round-trip a short silent WAV through the configured STT service to
-  // verify URL/key/model without needing the microphone.
+  // Round-trip a short silent WAV through the configured STT service (or the
+  // in-process engine) to verify it actually works.
   ipcMain.handle("stt:test", async (event, cfg) => {
     try {
       const wav = encodeSilenceWav(0.5);
-      await stt.transcribe(wav, cfg);
+      if (cfg.engine === "builtin") await engines.transcribe(wav, cfg);
+      else await stt.transcribe(wav, cfg);
       return { ok: true };
     } catch (err) {
       return { ok: false, error: err.message };
@@ -67,11 +72,70 @@ function init({ applyHotkey, onSettingsChanged }) {
 
   ipcMain.handle("cleanup:test", async (event, cfg) => {
     try {
-      const result = await cleanup.clean(
-        "um so this is uh a test of the cleanup service",
-        cfg
-      );
+      const sample = "um so this is uh a test of the cleanup service";
+      const result =
+        cfg.engine === "builtin"
+          ? await engines.clean(sample, cfg)
+          : await cleanup.clean(sample, cfg);
       return { ok: true, sample: result.slice(0, 200) };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  });
+
+  // ---- in-process model management (wizard download step + Settings) ----
+
+  // Which built-in models are downloaded and how big they are. Used to decide
+  // whether the wizard needs to show its download step.
+  ipcMain.handle("models:status", () => {
+    const describe = (kind) =>
+      engines.registry.listModels(kind).map((m) => ({
+        id: m.id,
+        kind: m.kind,
+        label: m.label,
+        note: m.note,
+        default: !!m.default,
+        bytes: engines.registry.totalBytes(m),
+        installed: engines.isInstalled(kind, m.id),
+      }));
+    return { stt: describe("stt"), cleanup: describe("cleanup") };
+  });
+
+  // Stream a model download to disk, posting progress to the requesting window.
+  ipcMain.handle("models:download", async (event, { kind, modelId }) => {
+    const key = `${kind}:${modelId}`;
+    if (downloads.has(key)) return { ok: false, error: "Already downloading" };
+    if (engines.isInstalled(kind, modelId)) return { ok: true };
+    const controller = new AbortController();
+    downloads.set(key, controller);
+    try {
+      await engines.download(kind, modelId, {
+        signal: controller.signal,
+        onProgress: (p) => {
+          if (!event.sender.isDestroyed()) {
+            event.sender.send("models:progress", { kind, modelId, ...p });
+          }
+        },
+      });
+      return { ok: true };
+    } catch (err) {
+      const aborted = controller.signal.aborted;
+      return { ok: false, cancelled: aborted, error: err.message };
+    } finally {
+      downloads.delete(key);
+    }
+  });
+
+  ipcMain.handle("models:cancel", (event, { kind, modelId }) => {
+    const controller = downloads.get(`${kind}:${modelId}`);
+    if (controller) controller.abort();
+    return { ok: true };
+  });
+
+  ipcMain.handle("models:remove", async (event, { kind, modelId }) => {
+    try {
+      await engines.remove(kind, modelId);
+      return { ok: true };
     } catch (err) {
       return { ok: false, error: err.message };
     }

--- a/main/main.js
+++ b/main/main.js
@@ -9,6 +9,7 @@ const hotkeys = require("./hotkeys");
 const tray = require("./tray");
 const ipc = require("./ipc");
 const serverManager = require("./services/server-manager");
+const engines = require("./engines");
 
 const isSmokeTest = process.argv.includes("--smoke-test");
 const startHidden = process.argv.includes("--hidden");
@@ -93,5 +94,6 @@ function main() {
   app.on("will-quit", () => {
     hotkeys.unregisterAll();
     serverManager.stop();
+    engines.stop();
   });
 }

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -17,8 +17,22 @@ const windows = require("./windows");
 const settings = require("./settings");
 const stt = require("./services/stt");
 const cleanup = require("./services/cleanup");
+const engines = require("./engines");
 const { deliver } = require("./output/deliver");
 const history = require("./history");
+
+// Route a stage to the in-process engine or the HTTP client based on settings.
+function runTranscribe(wav, cfg, signal) {
+  return cfg.engine === "builtin"
+    ? engines.transcribe(wav, cfg)
+    : stt.transcribe(wav, cfg, signal);
+}
+
+function runCleanup(raw, cfg, signal) {
+  return cfg.engine === "builtin"
+    ? engines.clean(raw, cfg)
+    : cleanup.clean(raw, cfg, signal);
+}
 
 let state = "idle"; // idle | recording | processing
 let session = 0; // current dictation session id
@@ -109,7 +123,7 @@ async function process(sid, wavArrayBuffer) {
 
   try {
     overlayStatus("transcribing");
-    const raw = await stt.transcribe(wav, cfg.stt, signal);
+    const raw = await runTranscribe(wav, cfg.stt, signal);
     if (stale()) return;
 
     if (!raw) {
@@ -123,7 +137,7 @@ async function process(sid, wavArrayBuffer) {
     if (cfg.cleanup.enabled) {
       overlayStatus("cleaning");
       try {
-        text = await cleanup.clean(raw, cfg.cleanup, signal);
+        text = await runCleanup(raw, cfg.cleanup, signal);
         cleaned = true;
       } catch (err) {
         if (stale()) return;

--- a/main/settings.js
+++ b/main/settings.js
@@ -4,6 +4,7 @@
 const { app } = require("electron");
 const fs = require("node:fs");
 const path = require("node:path");
+const registry = require("./engines/registry");
 
 const DEFAULT_CLEANUP_PROMPT = `You clean up raw speech-to-text transcriptions.
 
@@ -27,6 +28,11 @@ const DEFAULTS = {
     pasteDelayMs: 150, // wait before simulating the paste keystroke
   },
   stt: {
+    // "builtin" = run Parakeet in-process (no setup, default for new users),
+    // "server"  = a local OpenAI-compatible server we can autostart (uvx),
+    // "remote"  = any other OpenAI-compatible transcription endpoint.
+    engine: "builtin",
+    builtin: { model: registry.DEFAULT_STT_MODEL },
     baseUrl: "http://127.0.0.1:8484/v1",
     apiKey: "",
     model: "parakeet",
@@ -34,7 +40,11 @@ const DEFAULTS = {
     timeoutMs: 120000,
   },
   cleanup: {
-    enabled: false,
+    // On by default now that cleanup can run in-process with no setup.
+    enabled: true,
+    // "builtin" = run Gemma in-process, "remote" = OpenAI-compatible chat API.
+    engine: "builtin",
+    builtin: { model: registry.DEFAULT_CLEANUP_MODEL },
     baseUrl: "http://127.0.0.1:11434/v1",
     apiKey: "",
     model: "",
@@ -75,6 +85,23 @@ function deepMerge(base, override) {
   return out;
 }
 
+// Settings files written before in-process engines existed have `stt`/`cleanup`
+// sections but no `engine` field. New defaults are "builtin", which would
+// silently switch an existing user off their configured HTTP service — so map
+// legacy configs onto the equivalent external engine instead. Idempotent: a
+// file already carrying `engine` is left untouched.
+function migrateLegacy(stored) {
+  if (stored && stored.stt && stored.stt.engine === undefined) {
+    stored.stt.engine = stored.sttServer && stored.sttServer.autoStart
+      ? "server"
+      : "remote";
+  }
+  if (stored && stored.cleanup && stored.cleanup.engine === undefined) {
+    stored.cleanup.engine = "remote";
+  }
+  return stored;
+}
+
 function load() {
   if (cached) return cached;
   let stored = {};
@@ -83,7 +110,7 @@ function load() {
   } catch {
     // First run or unreadable file: fall back to defaults.
   }
-  cached = deepMerge(DEFAULTS, stored);
+  cached = deepMerge(DEFAULTS, migrateLegacy(stored));
   return cached;
 }
 
@@ -109,6 +136,7 @@ module.exports = {
   get,
   save,
   isFirstRun,
+  migrateLegacy,
   DEFAULTS,
   DEFAULT_CLEANUP_PROMPT,
   deepMerge,

--- a/main/util/wav.js
+++ b/main/util/wav.js
@@ -38,4 +38,64 @@ function encodeSilenceWav(seconds) {
   return encodeWav(new Int16Array(Math.round(SAMPLE_RATE * seconds)));
 }
 
-module.exports = { encodeWav, encodeSilenceWav, SAMPLE_RATE };
+/**
+ * Decode a mono PCM16 WAV buffer to float32 samples in [-1, 1], the shape the
+ * in-process Parakeet engine wants. Walks the RIFF chunk list to find `fmt `
+ * (for the sample rate) and `data`, so it tolerates WAVs with extra chunks.
+ *
+ * Only the format the overlay produces is supported: PCM (format 1), 16-bit,
+ * mono. Anything else throws — callers fall back to the HTTP STT path.
+ *
+ * @param {Buffer} buf
+ * @returns {{ samples: Float32Array, sampleRate: number }}
+ */
+function wavToFloat32(buf) {
+  if (!Buffer.isBuffer(buf)) buf = Buffer.from(buf);
+  if (buf.length < 12 || buf.toString("ascii", 0, 4) !== "RIFF" ||
+      buf.toString("ascii", 8, 12) !== "WAVE") {
+    throw new Error("Not a RIFF/WAVE file");
+  }
+  let sampleRate = SAMPLE_RATE;
+  let format = 1;
+  let channels = 1;
+  let bitsPerSample = 16;
+  let dataOffset = -1;
+  let dataSize = 0;
+
+  let pos = 12;
+  while (pos + 8 <= buf.length) {
+    const id = buf.toString("ascii", pos, pos + 4);
+    const size = buf.readUInt32LE(pos + 4);
+    const body = pos + 8;
+    if (id === "fmt " && body + 16 <= buf.length) {
+      format = buf.readUInt16LE(body);
+      channels = buf.readUInt16LE(body + 2);
+      sampleRate = buf.readUInt32LE(body + 4);
+      bitsPerSample = buf.readUInt16LE(body + 14);
+    } else if (id === "data") {
+      dataOffset = body;
+      dataSize = Math.min(size, buf.length - body);
+    }
+    // Chunks are word-aligned: an odd size is followed by a pad byte.
+    pos = body + size + (size & 1);
+  }
+
+  if (dataOffset < 0) throw new Error("WAV has no data chunk");
+  if (format !== 1 || bitsPerSample !== 16) {
+    throw new Error(`Unsupported WAV format (format=${format}, bits=${bitsPerSample})`);
+  }
+
+  const frameCount = Math.floor(dataSize / 2 / channels);
+  const samples = new Float32Array(frameCount);
+  for (let i = 0; i < frameCount; i++) {
+    // Mixdown to mono by averaging channels (overlay audio is already mono).
+    let acc = 0;
+    for (let c = 0; c < channels; c++) {
+      acc += buf.readInt16LE(dataOffset + (i * channels + c) * 2);
+    }
+    samples[i] = acc / channels / 32768;
+  }
+  return { samples, sampleRate };
+}
+
+module.exports = { encodeWav, encodeSilenceWav, wavToFloat32, SAMPLE_RATE };

--- a/main/windows.js
+++ b/main/windows.js
@@ -226,6 +226,14 @@ function sendToSettings(channel, payload) {
   }
 }
 
+// Send to every live window. Used for events both the wizard and Settings care
+// about (e.g. model download progress) so whichever is open stays in sync.
+function broadcast(channel, payload) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(channel, payload);
+  }
+}
+
 module.exports = {
   createOverlay,
   getOverlay,
@@ -235,6 +243,7 @@ module.exports = {
   sendToOverlay,
   openSettings,
   sendToSettings,
+  broadcast,
   openWizard,
   closeWizard,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "earheart",
       "version": "0.5.0",
       "license": "MIT",
+      "dependencies": {
+        "node-llama-cpp": "^3.18.1",
+        "sherpa-onnx-node": "^1.13.3"
+      },
       "devDependencies": {
         "electron": "^41.2.0",
         "electron-builder": "^26.4.0"
@@ -317,11 +321,19 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.4"
@@ -329,6 +341,21 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
@@ -398,6 +425,218 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@node-llama-cpp/linux-arm64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-arm64/-/linux-arm64-3.18.1.tgz",
+      "integrity": "sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-armv7l": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-armv7l/-/linux-armv7l-3.18.1.tgz",
+      "integrity": "sha512-BrJL2cGo0pN5xd5nw+CzTn2rFMpz9MJyZZPUY81ptGkF2uIuXT2hdCVh56i9ImQrTwBfq1YcZL/l/Qe/1+HR/Q==",
+      "cpu": [
+        "arm",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64/-/linux-x64-3.18.1.tgz",
+      "integrity": "sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.18.1.tgz",
+      "integrity": "sha512-qOaYP4uwsUoBHQ/7xSOvyJIuXapS57Al+Sudgi00f96ldNZLKe1vuSGptAi5LTM2lIj66PKm6h8PlRWctwsZ2g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.18.1.tgz",
+      "integrity": "sha512-VqyKhAVHPCpFzh0f1koCBgpThL+04QOXwv0oDQ8s8YcpfMMOXQlBhTB0plgTh0HrPExoObfTS4ohkrbyGgmztQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-vulkan": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.18.1.tgz",
+      "integrity": "sha512-SIaNTK5pUPhwJD0gmiQfHa8OrRctVMmnqu+slJrz2Mzgg/XrwFndJlS9hvc+jSjTXCouwf7sYeQaaJWvQgBh/A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-arm64-metal": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-arm64-metal/-/mac-arm64-metal-3.18.1.tgz",
+      "integrity": "sha512-cyZTdsUMlvuRlGmkkoBbN3v/DT6NuruEqoQYd9CqIrPyLa1xLNBTSKIZ9SgRnw23iCOj4URfITvRP+2pu63LuQ==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/mac-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/mac-x64/-/mac-x64-3.18.1.tgz",
+      "integrity": "sha512-GfCPgdltaIpBhEnQ7WfsrRXrZO9r9pBtDUAQMXRuJwOPP5q7xKrQZUXI6J6mpc8tAG0//CTIuGn4hTKoD/8V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-arm64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-arm64/-/win-arm64-3.18.1.tgz",
+      "integrity": "sha512-S05YUzBMVSRS5KNbOS26cDYugeQHqogI3uewtTUBVC0tPbTHRSKjsdicmgWru1eNAry399LWWhzOf/3St/qsAw==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64/-/win-x64-3.18.1.tgz",
+      "integrity": "sha512-QLDVphPl+YDI+x/VYYgIV1N9g0GMXk3PqcoopOUG3cBRUtce7FO+YX903YdRJezs4oKbIp8YaO+xYBgeUSqhpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.18.1.tgz",
+      "integrity": "sha512-drgJmBhnxGQtB/SLo4sf4PPSuxRv3MdNP0FF6rKPY9TtzEOV293bRQyYEu/JYwvXfVApAIsRaJUTGvCkA9Qobw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda-ext": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.18.1.tgz",
+      "integrity": "sha512-u0FzJBQsJA355ksKERxwPJhlcWl3ZJSNkU2ZUwDEiKNOCbv3ybvSCIEyDvB63wdtkfVUuCRJWijZnpDZxrCGqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-vulkan": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.18.1.tgz",
+      "integrity": "sha512-PjmxrnPToi7y0zlP7l+hRIhvOmuEv94P6xZ11vjqICEJu8XdAJpvTfPKgDW4W0p0v4+So8ZiZYLUuwIHcsseyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@peculiar/asn1-schema": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
@@ -450,6 +689,169 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/@reflink/reflink": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink/-/reflink-0.1.19.tgz",
+      "integrity": "sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink-darwin-arm64": "0.1.19",
+        "@reflink/reflink-darwin-x64": "0.1.19",
+        "@reflink/reflink-linux-arm64-gnu": "0.1.19",
+        "@reflink/reflink-linux-arm64-musl": "0.1.19",
+        "@reflink/reflink-linux-x64-gnu": "0.1.19",
+        "@reflink/reflink-linux-x64-musl": "0.1.19",
+        "@reflink/reflink-win32-arm64-msvc": "0.1.19",
+        "@reflink/reflink-win32-x64-msvc": "0.1.19"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-arm64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-arm64/-/reflink-darwin-arm64-0.1.19.tgz",
+      "integrity": "sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-darwin-x64": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-darwin-x64/-/reflink-darwin-x64-0.1.19.tgz",
+      "integrity": "sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-gnu/-/reflink-linux-arm64-gnu-0.1.19.tgz",
+      "integrity": "sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-arm64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-arm64-musl/-/reflink-linux-arm64-musl-0.1.19.tgz",
+      "integrity": "sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-gnu": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-gnu/-/reflink-linux-x64-gnu-0.1.19.tgz",
+      "integrity": "sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-linux-x64-musl": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-linux-x64-musl/-/reflink-linux-x64-musl-0.1.19.tgz",
+      "integrity": "sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-arm64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-arm64-msvc/-/reflink-win32-arm64-msvc-0.1.19.tgz",
+      "integrity": "sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reflink/reflink-win32-x64-msvc": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@reflink/reflink-win32-x64-msvc/-/reflink-win32-x64-msvc-0.1.19.tgz",
+      "integrity": "sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -474,6 +876,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tinyhttp/content-disposition": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@tinyhttp/content-disposition/-/content-disposition-2.2.4.tgz",
+      "integrity": "sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/tinyhttp/tinyhttp?sponsor=1"
       }
     },
     "node_modules/@types/cacheable-request": {
@@ -600,11 +1015,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -614,7 +1040,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -828,6 +1253,24 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/async-retry/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -959,6 +1402,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
@@ -1029,11 +1481,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chmodrp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chmodrp/-/chmodrp-1.0.2.tgz",
+      "integrity": "sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==",
+      "license": "MIT"
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -1050,7 +1507,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1062,11 +1518,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -1090,11 +1572,71 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cmake-js": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-8.0.0.tgz",
+      "integrity": "sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "fs-extra": "^11.3.3",
+        "node-api-headers": "^1.8.0",
+        "rc": "1.2.8",
+        "semver": "^7.7.3",
+        "tar": "^7.5.6",
+        "url-join": "^4.0.1",
+        "which": "^6.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/cmake-js/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cmake-js/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1107,7 +1649,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -1170,7 +1711,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1185,14 +1725,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1208,7 +1746,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1249,6 +1786,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/defer-to-connect": {
@@ -1582,7 +2128,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -1606,6 +2151,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-var": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-7.5.0.tgz",
+      "integrity": "sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/err-code": {
@@ -1676,7 +2230,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1695,6 +2248,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -1785,6 +2344,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1838,10 +2424,21 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2032,7 +2629,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2163,6 +2759,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2182,14 +2787,221 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ipull": {
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/ipull/-/ipull-3.9.5.tgz",
+      "integrity": "sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tinyhttp/content-disposition": "^2.2.0",
+        "async-retry": "^1.3.3",
+        "chalk": "^5.3.0",
+        "ci-info": "^4.0.0",
+        "cli-spinners": "^2.9.2",
+        "commander": "^10.0.0",
+        "eventemitter3": "^5.0.1",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.1.1",
+        "is-unicode-supported": "^2.0.0",
+        "lifecycle-utils": "^2.0.1",
+        "lodash.debounce": "^4.0.8",
+        "lowdb": "^7.0.1",
+        "pretty-bytes": "^6.1.0",
+        "pretty-ms": "^8.0.0",
+        "sleep-promise": "^9.1.0",
+        "slice-ansi": "^7.1.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.1.0"
+      },
+      "bin": {
+        "ipull": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/ido-pluto/ipull?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@reflink/reflink": "^0.1.16"
+      }
+    },
+    "node_modules/ipull/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ipull/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ipull/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ipull/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/ipull/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/ipull/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/lifecycle-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-2.1.0.tgz",
+      "integrity": "sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==",
+      "license": "MIT"
+    },
+    "node_modules/ipull/node_modules/parse-ms": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-3.0.0.tgz",
+      "integrity": "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/pretty-ms": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-8.0.0.tgz",
+      "integrity": "sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipull/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ipull/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -2312,7 +3124,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -2338,12 +3149,55 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lifecycle-utils": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lifecycle-utils/-/lifecycle-utils-3.1.1.tgz",
+      "integrity": "sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==",
+      "license": "MIT"
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowdb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
+      "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
+      "license": "MIT",
+      "dependencies": {
+        "steno": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -2428,6 +3282,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -2458,7 +3324,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2468,7 +3333,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2478,7 +3342,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -2505,8 +3368,25 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
     },
     "node_modules/node-abi": {
       "version": "4.31.0",
@@ -2520,6 +3400,21 @@
       "engines": {
         "node": ">=22.12.0"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-api-headers": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/node-api-headers/-/node-api-headers-1.9.0.tgz",
+      "integrity": "sha512-2oNILP4jXwRB4ywnYKjVk1YyJ96n2D4EOVJO6S3oYZ5PtbJrw3Yt9TpAuX3nBLMuzn74rnfGQrv13pS9vC+YiA==",
+      "license": "MIT"
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
@@ -2609,6 +3504,154 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-llama-cpp": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/node-llama-cpp/-/node-llama-cpp-3.18.1.tgz",
+      "integrity": "sha512-w0zfuy/IKS2fhrbed5SylZDXJHTVz4HnkwZ4UrFPgSNwJab3QIPwIl4lyCKHHy9flLrtxsAuV5kXfH3HZ6bb8w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "async-retry": "^1.3.3",
+        "bytes": "^3.1.2",
+        "chalk": "^5.6.2",
+        "chmodrp": "^1.0.2",
+        "cmake-js": "^8.0.0",
+        "cross-spawn": "^7.0.6",
+        "env-var": "^7.5.0",
+        "filenamify": "^6.0.0",
+        "fs-extra": "^11.3.4",
+        "ignore": "^7.0.4",
+        "ipull": "^3.9.5",
+        "is-unicode-supported": "^2.1.0",
+        "lifecycle-utils": "^3.1.1",
+        "log-symbols": "^7.0.1",
+        "nanoid": "^5.1.6",
+        "node-addon-api": "^8.6.0",
+        "ora": "^9.3.0",
+        "pretty-ms": "^9.3.0",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.7.1",
+        "simple-git": "^3.33.0",
+        "slice-ansi": "^8.0.0",
+        "stdout-update": "^4.0.1",
+        "strip-ansi": "^7.2.0",
+        "validate-npm-package-name": "^7.0.2",
+        "which": "^6.0.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "nlc": "dist/cli/cli.js",
+        "node-llama-cpp": "dist/cli/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/giladgd"
+      },
+      "optionalDependencies": {
+        "@node-llama-cpp/linux-arm64": "3.18.1",
+        "@node-llama-cpp/linux-armv7l": "3.18.1",
+        "@node-llama-cpp/linux-x64": "3.18.1",
+        "@node-llama-cpp/linux-x64-cuda": "3.18.1",
+        "@node-llama-cpp/linux-x64-cuda-ext": "3.18.1",
+        "@node-llama-cpp/linux-x64-vulkan": "3.18.1",
+        "@node-llama-cpp/mac-arm64-metal": "3.18.1",
+        "@node-llama-cpp/mac-x64": "3.18.1",
+        "@node-llama-cpp/win-arm64": "3.18.1",
+        "@node-llama-cpp/win-x64": "3.18.1",
+        "@node-llama-cpp/win-x64-cuda": "3.18.1",
+        "@node-llama-cpp/win-x64-cuda-ext": "3.18.1",
+        "@node-llama-cpp/win-x64-vulkan": "3.18.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/node-llama-cpp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
@@ -2659,6 +3702,110 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -2685,6 +3832,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2699,7 +3858,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2816,6 +3974,33 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
@@ -2861,7 +4046,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -2913,6 +4097,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
@@ -2946,7 +4145,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3000,11 +4198,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -3075,7 +4300,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3113,7 +4337,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -3126,18 +4349,125 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/sherpa-onnx-darwin-arm64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-arm64/-/sherpa-onnx-darwin-arm64-1.13.3.tgz",
+      "integrity": "sha512-9x86Cbf+BDFONdtCPM3cnjvtAW0ER8tMaHK5pVfz+SHPt8GeuwRXaiR/BzcByFBUyxCgmceO09/WMZOCi44P/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sherpa-onnx-darwin-x64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-darwin-x64/-/sherpa-onnx-darwin-x64-1.13.3.tgz",
+      "integrity": "sha512-TVQ35g7JIpDPB1lUDdcog+JtI0cI45ZzOnvHXm0DtWs/dgxnJXtWMY3uLRtBbLnysV9j5ljffwZ1IX9VDHsCzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sherpa-onnx-linux-arm64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-arm64/-/sherpa-onnx-linux-arm64-1.13.3.tgz",
+      "integrity": "sha512-uDtZkkoP6QQ/3DHOscCpEZ2WpaiHUQsDpbyYaHURrJ7DbsjqGnS6G8l+R589Ro5Bf282QElzBy3okwxXbt3Kxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sherpa-onnx-linux-x64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-linux-x64/-/sherpa-onnx-linux-x64-1.13.3.tgz",
+      "integrity": "sha512-OFVK0GYwKwKNsjxbPmfcLQm/dfA0IwAoiIQJ96s+eFYcDqhlapcY06ocdb7SNluGBcM7xgU5jEW2QXBkMIOEvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sherpa-onnx-node": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-node/-/sherpa-onnx-node-1.13.3.tgz",
+      "integrity": "sha512-3XEiRvfZ73QoKDZqweAkAOb+OA2LPMKcLcRY6zngjhwZ1ymV6xagdahepYzeDRIzVq0nRjhUe8IaRdlRMYoamw==",
+      "license": "Apache-2.0",
+      "optionalDependencies": {
+        "sherpa-onnx-darwin-arm64": "^1.13.3",
+        "sherpa-onnx-darwin-x64": "^1.13.3",
+        "sherpa-onnx-linux-arm64": "^1.13.3",
+        "sherpa-onnx-linux-x64": "^1.13.3",
+        "sherpa-onnx-win-ia32": "^1.13.3",
+        "sherpa-onnx-win-x64": "^1.13.3"
+      }
+    },
+    "node_modules/sherpa-onnx-win-ia32": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-ia32/-/sherpa-onnx-win-ia32-1.13.3.tgz",
+      "integrity": "sha512-VDZh1M7Ccx/bkP3WwBCFoJzwAwq+b5nR1KRkYRz5p1w5bfhzfa3ACBGr7vpUt5AGUge4qSLe0MSKXyKtSmy1uA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sherpa-onnx-win-x64": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx-win-x64/-/sherpa-onnx-win-x64-1.13.3.tgz",
+      "integrity": "sha512-ZQzcSmFvZK4jzmtWckqxocDUuEjYnBV2MHrDD21HPTeUMfGdE9yfvuSPpesIVfdzKbQzIQY42RAcfZEGWu0FbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
@@ -3150,6 +4480,55 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sleep-promise": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/sleep-promise/-/sleep-promise-9.1.0.tgz",
+      "integrity": "sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==",
+      "license": "MIT"
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -3191,6 +4570,107 @@
         "node": ">= 6"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdout-update": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stdout-update/-/stdout-update-4.0.1.tgz",
+      "integrity": "sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^6.2.0",
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/stdout-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/stdout-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stdout-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/stdout-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdout-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/steno": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
+      "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3205,7 +4685,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -3220,13 +4699,21 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sumchecker": {
@@ -3259,7 +4746,6 @@
       "version": "7.5.16",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
       "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -3276,7 +4762,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -3418,7 +4903,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -3453,6 +4937,12 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "license": "MIT"
+    },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
@@ -3466,6 +4956,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/validate-npm-package-name": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
+      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/webcrypto-core": {
       "version": "1.9.2",
@@ -3501,7 +5000,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -3536,7 +5034,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -3553,7 +5050,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -3572,7 +5068,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -3586,6 +5081,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "devDependencies": {
     "electron": "^41.2.0",
     "electron-builder": "^26.4.0"
+  },
+  "dependencies": {
+    "node-llama-cpp": "^3.18.1",
+    "sherpa-onnx-node": "^1.13.3"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -10,6 +10,7 @@ const LISTEN = new Set([
   "history:changed",
   "overlay:show",
   "overlay:hide",
+  "models:progress",
 ]);
 
 const SEND = new Set([
@@ -31,6 +32,10 @@ const INVOKE = new Set([
   "cleanup:test",
   "history:list",
   "history:clear",
+  "models:status",
+  "models:download",
+  "models:cancel",
+  "models:remove",
 ]);
 
 contextBridge.exposeInMainWorld("earheart", {

--- a/renderer/settings.css
+++ b/renderer/settings.css
@@ -313,3 +313,38 @@ footer {
   padding: 14px 24px;
   border-top: 1px solid var(--border);
 }
+
+/* ---------- built-in model management ---------- */
+
+.model-manage {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+}
+
+.model-manage .hint {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.dl-bar {
+  height: 8px;
+  border-radius: 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+
+.dl-bar[hidden] {
+  display: none;
+}
+
+.dl-fill {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -79,74 +79,114 @@
 
       <!-- STT -->
       <section id="tab-stt" class="panel">
-        <p class="lead">
-          Any service that speaks the OpenAI audio transcription API works here:
-          the bundled local Parakeet server, OpenAI, Groq, speaches, …
-        </p>
         <div class="field">
-          <label for="stt-url">Base URL</label>
-          <input id="stt-url" placeholder="http://127.0.0.1:8484/v1" />
-          <p class="hint">The app calls <code>{base URL}/audio/transcriptions</code>.</p>
+          <label>Speech-to-text engine</label>
+          <label class="choice">
+            <input type="radio" name="stt-engine" value="builtin" />
+            On this computer, built in <span class="muted">(Parakeet — private, no setup)</span>
+          </label>
+          <label class="choice">
+            <input type="radio" name="stt-engine" value="external" />
+            An OpenAI-compatible service <span class="muted">(local server, OpenAI, Groq, …)</span>
+          </label>
         </div>
-        <div class="field">
-          <label for="stt-key">API key <span class="muted">(optional for local servers)</span></label>
-          <input id="stt-key" type="password" autocomplete="off" />
-        </div>
-        <div class="grid-2">
+
+        <div id="stt-builtin-fields">
           <div class="field">
-            <label for="stt-model">Model</label>
-            <input id="stt-model" placeholder="parakeet" />
+            <label for="stt-builtin-model">Model</label>
+            <select id="stt-builtin-model"></select>
+          </div>
+          <div id="stt-model-manage" class="model-manage"></div>
+        </div>
+
+        <div id="stt-external-fields">
+          <div class="field">
+            <label for="stt-url">Base URL</label>
+            <input id="stt-url" placeholder="http://127.0.0.1:8484/v1" />
+            <p class="hint">The app calls <code>{base URL}/audio/transcriptions</code>.</p>
           </div>
           <div class="field">
-            <label for="stt-language">Language <span class="muted">(optional, e.g. en)</span></label>
-            <input id="stt-language" placeholder="auto" />
+            <label for="stt-key">API key <span class="muted">(optional for local servers)</span></label>
+            <input id="stt-key" type="password" autocomplete="off" />
           </div>
-        </div>
-        <div class="row">
-          <button id="stt-test">Test connection</button>
-          <span id="stt-test-result" class="status"></span>
+          <div class="grid-2">
+            <div class="field">
+              <label for="stt-model">Model</label>
+              <input id="stt-model" placeholder="parakeet" />
+            </div>
+            <div class="field">
+              <label for="stt-language">Language <span class="muted">(optional, e.g. en)</span></label>
+              <input id="stt-language" placeholder="auto" />
+            </div>
+          </div>
+          <div class="row">
+            <button id="stt-test">Test connection</button>
+            <span id="stt-test-result" class="status"></span>
+          </div>
         </div>
       </section>
 
       <!-- Cleanup -->
       <section id="tab-cleanup" class="panel">
         <p class="lead">
-          After transcription, a language model can fix punctuation and remove
-          filler words. Works with any OpenAI-compatible chat API: Ollama,
-          llama.cpp, LM Studio, OpenRouter, OpenAI, …
+          After transcription, a language model fixes punctuation and removes
+          filler words and false starts.
         </p>
         <div class="field">
           <label class="choice">
             <input type="checkbox" id="cleanup-enabled" />
-            Clean up transcripts with a language model
+            Clean up transcripts automatically
           </label>
         </div>
         <div id="cleanup-fields">
           <div class="field">
-            <label for="cleanup-url">Base URL</label>
-            <input id="cleanup-url" placeholder="http://127.0.0.1:11434/v1" />
-            <p class="hint">The app calls <code>{base URL}/chat/completions</code>.</p>
+            <label>Cleanup engine</label>
+            <label class="choice">
+              <input type="radio" name="cleanup-engine" value="builtin" />
+              On this computer, built in <span class="muted">(Gemma — no setup)</span>
+            </label>
+            <label class="choice">
+              <input type="radio" name="cleanup-engine" value="external" />
+              An OpenAI-compatible service <span class="muted">(Ollama, LM Studio, OpenAI, …)</span>
+            </label>
           </div>
-          <div class="field">
-            <label for="cleanup-key">API key <span class="muted">(optional for local servers)</span></label>
-            <input id="cleanup-key" type="password" autocomplete="off" />
-          </div>
-          <div class="grid-2">
+
+          <div id="cleanup-builtin-fields">
             <div class="field">
-              <label for="cleanup-model">Model</label>
-              <input id="cleanup-model" placeholder="llama3.2" />
+              <label for="cleanup-builtin-model">Model</label>
+              <select id="cleanup-builtin-model"></select>
+            </div>
+            <div id="cleanup-model-manage" class="model-manage"></div>
+          </div>
+
+          <div id="cleanup-external-fields">
+            <div class="field">
+              <label for="cleanup-url">Base URL</label>
+              <input id="cleanup-url" placeholder="http://127.0.0.1:11434/v1" />
+              <p class="hint">The app calls <code>{base URL}/chat/completions</code>.</p>
             </div>
             <div class="field">
-              <label for="cleanup-temperature">Temperature</label>
-              <input id="cleanup-temperature" type="number" min="0" max="2" step="0.1" />
+              <label for="cleanup-key">API key <span class="muted">(optional for local servers)</span></label>
+              <input id="cleanup-key" type="password" autocomplete="off" />
+            </div>
+            <div class="grid-2">
+              <div class="field">
+                <label for="cleanup-model">Model</label>
+                <input id="cleanup-model" placeholder="llama3.2" />
+              </div>
+              <div class="field">
+                <label for="cleanup-temperature">Temperature</label>
+                <input id="cleanup-temperature" type="number" min="0" max="2" step="0.1" />
+              </div>
             </div>
           </div>
+
           <div class="field">
             <label for="cleanup-prompt">System prompt</label>
             <textarea id="cleanup-prompt" rows="9" spellcheck="false"></textarea>
             <button id="cleanup-prompt-reset" class="ghost">Reset to default</button>
           </div>
-          <div class="row">
+          <div class="row" id="cleanup-test-row">
             <button id="cleanup-test">Test connection</button>
             <span id="cleanup-test-result" class="status"></span>
           </div>

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -3,6 +3,7 @@
 let current = null; // settings object being edited
 let defaults = null;
 let platform = "linux";
+let modelStatus = null; // { stt: [...], cleanup: [...] } from the main process
 
 const $ = (id) => document.getElementById(id);
 
@@ -121,6 +122,8 @@ function populate() {
   $("stt-key").value = current.stt.apiKey;
   $("stt-model").value = current.stt.model;
   $("stt-language").value = current.stt.language;
+  selectEngine("stt", current.stt.engine);
+  $("stt-builtin-model").value = current.stt.builtin.model;
 
   $("cleanup-enabled").checked = current.cleanup.enabled;
   $("cleanup-url").value = current.cleanup.baseUrl;
@@ -128,7 +131,11 @@ function populate() {
   $("cleanup-model").value = current.cleanup.model;
   $("cleanup-temperature").value = current.cleanup.temperature;
   $("cleanup-prompt").value = current.cleanup.systemPrompt;
+  selectEngine("cleanup", current.cleanup.engine);
+  $("cleanup-builtin-model").value = current.cleanup.builtin.model;
   syncCleanupEnabled();
+  syncEngine("stt");
+  syncEngine("cleanup");
 
   $("history-enabled").checked = current.history.enabled;
   $("server-autostart").checked = current.sttServer.autoStart;
@@ -152,6 +159,8 @@ function collect() {
     },
     stt: {
       ...current.stt,
+      engine: engineValue("stt"),
+      builtin: { ...current.stt.builtin, model: $("stt-builtin-model").value },
       baseUrl: $("stt-url").value.trim(),
       apiKey: $("stt-key").value.trim(),
       model: $("stt-model").value.trim(),
@@ -160,6 +169,8 @@ function collect() {
     cleanup: {
       ...current.cleanup,
       enabled: $("cleanup-enabled").checked,
+      engine: engineValue("cleanup"),
+      builtin: { ...current.cleanup.builtin, model: $("cleanup-builtin-model").value },
       baseUrl: $("cleanup-url").value.trim(),
       apiKey: $("cleanup-key").value.trim(),
       model: $("cleanup-model").value.trim(),
@@ -186,6 +197,133 @@ function syncCleanupEnabled() {
   $("cleanup-fields").classList.toggle("disabled", !$("cleanup-enabled").checked);
 }
 $("cleanup-enabled").addEventListener("change", syncCleanupEnabled);
+
+/* ---------- built-in engines + model management ---------- */
+
+// The settings UI offers a simple Built-in / External choice; the "server"
+// engine (a local OpenAI-compatible server, configured under Advanced) is
+// equivalent to "remote" for routing, so both map to the external option.
+function engineValue(kind) {
+  const v = document.querySelector(`input[name="${kind}-engine"]:checked`).value;
+  return v === "builtin" ? "builtin" : "remote";
+}
+
+function selectEngine(kind, engine) {
+  const v = engine === "builtin" ? "builtin" : "external";
+  const radio = document.querySelector(`input[name="${kind}-engine"][value="${v}"]`);
+  if (radio) radio.checked = true;
+}
+
+function syncEngine(kind) {
+  const builtin =
+    document.querySelector(`input[name="${kind}-engine"]:checked`).value === "builtin";
+  $(`${kind}-builtin-fields`).hidden = !builtin;
+  $(`${kind}-external-fields`).hidden = builtin;
+  if (kind === "cleanup") $("cleanup-test-row").hidden = builtin;
+  renderManage(kind);
+}
+
+function populateModelSelect(kind) {
+  const select = $(`${kind}-builtin-model`);
+  select.replaceChildren();
+  for (const m of modelStatus[kind]) {
+    const option = document.createElement("option");
+    option.value = m.id;
+    option.textContent = m.label;
+    select.appendChild(option);
+  }
+}
+
+// Per-kind handles to the live progress bar / status so download progress
+// events can find their row.
+const manage = { stt: {}, cleanup: {} };
+
+function renderManage(kind) {
+  const container = $(`${kind}-model-manage`);
+  if (!container || !modelStatus) return;
+  const modelId = $(`${kind}-builtin-model`).value;
+  const info = modelStatus[kind].find((m) => m.id === modelId);
+  container.replaceChildren();
+  manage[kind] = { modelId };
+  if (!info) return;
+
+  const note = document.createElement("p");
+  note.className = "hint";
+  note.textContent = info.note;
+
+  const bar = document.createElement("div");
+  bar.className = "dl-bar";
+  bar.hidden = true;
+  const fill = document.createElement("div");
+  fill.className = "dl-fill";
+  bar.appendChild(fill);
+
+  const row = document.createElement("div");
+  row.className = "row";
+  const status = document.createElement("span");
+  status.className = "status";
+  const btn = document.createElement("button");
+  const ui = { modelId, bar, fill, status, btn };
+
+  if (info.installed) {
+    status.textContent = "Downloaded ✓";
+    status.className = "status ok";
+    btn.textContent = "Remove";
+    btn.className = "ghost danger";
+    btn.addEventListener("click", () => removeModel(kind, modelId));
+  } else {
+    status.textContent = "Not downloaded";
+    btn.textContent = "Download";
+    btn.className = "ghost";
+    btn.addEventListener("click", () => downloadModel(kind, modelId, ui));
+  }
+  row.append(btn, status);
+  container.append(note, bar, row);
+  manage[kind] = ui;
+}
+
+async function downloadModel(kind, modelId, ui) {
+  ui.btn.disabled = true;
+  ui.bar.hidden = false;
+  ui.status.textContent = "Downloading…";
+  ui.status.className = "status";
+  const res = await earheart.invoke("models:download", { kind, modelId });
+  if (res.ok) {
+    await refreshModels();
+  } else {
+    ui.btn.disabled = false;
+    ui.bar.hidden = true;
+    ui.status.textContent = res.cancelled ? "Cancelled" : res.error || "Download failed";
+    ui.status.className = res.cancelled ? "status" : "status err";
+  }
+}
+
+async function removeModel(kind, modelId) {
+  await earheart.invoke("models:remove", { kind, modelId });
+  await refreshModels();
+}
+
+async function refreshModels() {
+  modelStatus = await earheart.invoke("models:status");
+  renderManage("stt");
+  renderManage("cleanup");
+}
+
+earheart.on("models:progress", ({ kind, modelId, fraction }) => {
+  const m = manage[kind];
+  if (m && m.modelId === modelId && m.fill) {
+    m.fill.style.width = `${Math.round(fraction * 100)}%`;
+  }
+});
+
+document
+  .querySelectorAll('input[name="stt-engine"]')
+  .forEach((r) => r.addEventListener("change", () => syncEngine("stt")));
+document
+  .querySelectorAll('input[name="cleanup-engine"]')
+  .forEach((r) => r.addEventListener("change", () => syncEngine("cleanup")));
+$("stt-builtin-model").addEventListener("change", () => renderManage("stt"));
+$("cleanup-builtin-model").addEventListener("change", () => renderManage("cleanup"));
 
 $("cleanup-prompt-reset").addEventListener("click", () => {
   $("cleanup-prompt").value = defaults.cleanup.systemPrompt;
@@ -312,6 +450,9 @@ $("wizard-banner-dismiss").addEventListener("click", () => {
   defaults = data.defaults;
   platform = data.platform;
   $("version").textContent = `v${data.version}`;
+  modelStatus = await earheart.invoke("models:status");
+  populateModelSelect("stt");
+  populateModelSelect("cleanup");
   populate();
   loadMicrophones();
 })();

--- a/renderer/wizard.css
+++ b/renderer/wizard.css
@@ -219,3 +219,68 @@ kbd {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ---------- value cards (built-in engine selling points) ---------- */
+
+.value-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-top: 12px;
+}
+
+.value-card .lead {
+  margin-top: 0;
+}
+
+.value-list {
+  list-style: none;
+  margin: 10px 0 4px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12.5px;
+}
+
+/* ---------- model download progress (final step) ---------- */
+
+.dl-item {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 12px;
+}
+
+.dl-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.dl-bar {
+  height: 8px;
+  border-radius: 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.dl-fill {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+
+.dl-item .hint {
+  margin-top: 8px;
+}
+
+.dl-item button {
+  margin-top: 10px;
+}

--- a/renderer/wizard.html
+++ b/renderer/wizard.html
@@ -109,8 +109,13 @@
         <h2>Where should speech become text?</h2>
         <div class="field">
           <label class="choice">
-            <input type="radio" name="stt-mode" value="local" checked />
-            On this computer <span class="muted">(recommended — private and free)</span>
+            <input type="radio" name="stt-mode" value="builtin" checked />
+            On this computer, built in
+            <span class="muted">(recommended — no setup)</span>
+          </label>
+          <label class="choice">
+            <input type="radio" name="stt-mode" value="server" />
+            A local STT server <span class="muted">(advanced — <code>uvx earheart-stt</code>)</span>
           </label>
           <label class="choice">
             <input type="radio" name="stt-mode" value="remote" />
@@ -118,10 +123,28 @@
           </label>
         </div>
 
-        <div id="stt-local-fields">
+        <div id="stt-builtin-fields">
+          <div class="value-card">
+            <p class="lead">
+              Earheart runs NVIDIA's <strong>Parakeet</strong> model right inside
+              the app — nothing to install, no separate program.
+            </p>
+            <ul class="value-list">
+              <li>🔒 Your voice never leaves this computer</li>
+              <li>⚡ Faster than real time, even without a graphics card</li>
+              <li>🌍 Understands 25 languages automatically</li>
+            </ul>
+            <p class="hint">
+              The model (~660&nbsp;MB) downloads in the next step, with a
+              progress bar.
+            </p>
+          </div>
+        </div>
+
+        <div id="stt-local-fields" hidden>
           <p class="lead">
-            Earheart ships a local server using NVIDIA's Parakeet model. Audio
-            never leaves your machine.
+            Run the Parakeet server as a separate process. Audio never leaves
+            your machine.
           </p>
           <div class="field">
             <label class="choice">
@@ -133,9 +156,8 @@
               <input id="server-command" placeholder="uvx earheart-stt" />
               <p class="hint">
                 Needs <code>uv</code> installed. The first start downloads the
-                Parakeet model (~2.4&nbsp;GB), so the very first transcription
-                takes a while. See the <code>stt-server</code> README for
-                details.
+                Parakeet model (~2.4&nbsp;GB). See the <code>stt-server</code>
+                README for details.
               </p>
             </div>
           </div>
@@ -161,54 +183,78 @@
           </div>
         </div>
 
-        <div class="row">
+        <div class="row" id="stt-test-row" hidden>
           <button id="stt-test">Test connection</button>
           <span id="stt-test-result" class="status"></span>
         </div>
-        <p class="hint">
-          Optional — if the local server isn't installed yet, the test will
-          fail and that's okay. You can test again from Settings later.
-        </p>
       </section>
 
       <!-- 5. Cleanup -->
       <section class="step" id="step-cleanup">
-        <h2>Tidy up transcripts? <span class="muted">(optional)</span></h2>
+        <h2>Polish your transcripts automatically?</h2>
         <p class="lead">
-          A language model can fix punctuation and strip filler words ("um",
-          "uh") after transcription. Works with any OpenAI-compatible chat API:
-          Ollama, LM Studio, OpenAI, … Most people start without it.
+          After transcription, a small language model can fix punctuation and
+          capitalization and remove filler words and false starts — so what
+          lands is clean, not a raw stream of speech.
         </p>
         <div class="field">
           <label class="choice">
-            <input type="checkbox" id="cleanup-enabled" />
-            Clean up transcripts with a language model
+            <input type="checkbox" id="cleanup-enabled" checked />
+            Clean up transcripts automatically <span class="muted">(recommended)</span>
           </label>
         </div>
+
         <div id="cleanup-fields">
           <div class="field">
-            <label for="cleanup-url">Base URL</label>
-            <input id="cleanup-url" placeholder="http://127.0.0.1:11434/v1" />
+            <label class="choice">
+              <input type="radio" name="cleanup-mode" value="builtin" checked />
+              On this computer, built in <span class="muted">(no setup)</span>
+            </label>
+            <label class="choice">
+              <input type="radio" name="cleanup-mode" value="external" />
+              An OpenAI-compatible service <span class="muted">(Ollama, LM Studio, OpenAI, …)</span>
+            </label>
           </div>
-          <div class="grid-2">
-            <div class="field">
-              <label for="cleanup-key">API key <span class="muted">(optional for local servers)</span></label>
-              <input id="cleanup-key" type="password" autocomplete="off" />
-            </div>
-            <div class="field">
-              <label for="cleanup-model">Model</label>
-              <input id="cleanup-model" placeholder="llama3.2" />
+
+          <div id="cleanup-builtin-fields">
+            <div class="value-card">
+              <p class="lead">
+                Runs Google's <strong>Gemma</strong> model inside the app — like
+                an editor that tidies every dictation for you, fully offline.
+              </p>
+              <div class="field">
+                <label for="cleanup-builtin-model">Quality</label>
+                <select id="cleanup-builtin-model"></select>
+                <p class="hint" id="cleanup-builtin-note"></p>
+              </div>
             </div>
           </div>
-          <div class="row">
-            <button id="cleanup-test">Test connection</button>
-            <span id="cleanup-test-result" class="status"></span>
+
+          <div id="cleanup-external-fields" hidden>
+            <div class="field">
+              <label for="cleanup-url">Base URL</label>
+              <input id="cleanup-url" placeholder="http://127.0.0.1:11434/v1" />
+            </div>
+            <div class="grid-2">
+              <div class="field">
+                <label for="cleanup-key">API key <span class="muted">(optional for local servers)</span></label>
+                <input id="cleanup-key" type="password" autocomplete="off" />
+              </div>
+              <div class="field">
+                <label for="cleanup-model">Model</label>
+                <input id="cleanup-model" placeholder="llama3.2" />
+              </div>
+            </div>
+            <div class="row">
+              <button id="cleanup-test">Test connection</button>
+              <span id="cleanup-test-result" class="status"></span>
+            </div>
           </div>
         </div>
       </section>
 
       <!-- 6. Output + summary -->
-      <section class="step" id="step-finish">
+      <section class="step" id="step-output">
         <h2>Where should the text go?</h2>
         <div class="field">
           <label class="choice">
@@ -228,12 +274,28 @@
         <div class="field">
           <label>Your setup</label>
           <dl id="summary"></dl>
-          <p class="hint">
-            Finishing opens the settings screen with these choices pre-filled —
-            review them there, or just save them as they are.
-          </p>
-          <p id="finish-status" class="status"></p>
         </div>
+      </section>
+
+      <!-- 7. Download the on-device models -->
+      <section class="step" id="step-finish">
+        <h2 id="download-title">Setting up the models that run on your computer</h2>
+        <p class="lead" id="download-intro">
+          These run entirely on your machine, so your dictation stays private
+          and works offline. This is a one-time download.
+        </p>
+
+        <div id="download-list"></div>
+
+        <p class="hint" id="download-none" hidden>
+          Nothing to download — you're using remote services. You're all set!
+        </p>
+
+        <div class="row" id="download-later-row" hidden>
+          <button id="download-later" class="ghost">Download later (from Settings)</button>
+        </div>
+
+        <p id="finish-status" class="status"></p>
       </section>
     </main>
 

--- a/renderer/wizard.js
+++ b/renderer/wizard.js
@@ -1,11 +1,13 @@
 // First-run setup wizard renderer. Walks through hotkey, microphone,
-// speech-to-text, cleanup and output, then saves and hands over to the
-// settings window with everything pre-filled.
+// speech-to-text, cleanup and output; the last step downloads any models that
+// run on this computer (with progress) before saving and handing over to the
+// settings window.
 
 let current = null; // settings object being edited
 let defaults = null;
 let platform = "linux";
 let micLoaded = false;
+let modelStatus = null; // { stt: [...], cleanup: [...] } from the main process
 
 const $ = (id) => document.getElementById(id);
 
@@ -34,11 +36,13 @@ function showStep(index) {
       : stepIndex === steps.length - 1
         ? "Finish setup"
         : "Next";
+  $("next").disabled = false;
   if (steps[stepIndex].id === "step-mic" && !micLoaded) {
     micLoaded = true;
     loadMicrophones();
   }
-  if (steps[stepIndex].id === "step-finish") renderSummary();
+  if (steps[stepIndex].id === "step-output") renderSummary();
+  if (steps[stepIndex].id === "step-finish") enterDownloadStep();
 }
 
 $("back").addEventListener("click", () => showStep(stepIndex - 1));
@@ -129,9 +133,12 @@ function sttMode() {
 }
 
 function syncSttMode() {
-  const local = sttMode() === "local";
-  $("stt-local-fields").hidden = !local;
-  $("stt-remote-fields").hidden = local;
+  const mode = sttMode();
+  $("stt-builtin-fields").hidden = mode !== "builtin";
+  $("stt-local-fields").hidden = mode !== "server";
+  $("stt-remote-fields").hidden = mode !== "remote";
+  // The connection test only makes sense for an external endpoint.
+  $("stt-test-row").hidden = mode !== "remote";
 }
 
 document
@@ -140,42 +147,92 @@ document
 
 /* ---------- cleanup ---------- */
 
+function cleanupMode() {
+  return document.querySelector('input[name="cleanup-mode"]:checked').value;
+}
+
 function syncCleanupEnabled() {
   $("cleanup-fields").classList.toggle("disabled", !$("cleanup-enabled").checked);
 }
+
+function syncCleanupMode() {
+  const builtin = cleanupMode() === "builtin";
+  $("cleanup-builtin-fields").hidden = !builtin;
+  $("cleanup-external-fields").hidden = builtin;
+}
+
 $("cleanup-enabled").addEventListener("change", syncCleanupEnabled);
+document
+  .querySelectorAll('input[name="cleanup-mode"]')
+  .forEach((radio) => radio.addEventListener("change", syncCleanupMode));
+
+function populateCleanupModels() {
+  const select = $("cleanup-builtin-model");
+  select.replaceChildren();
+  for (const m of modelStatus.cleanup) {
+    const option = document.createElement("option");
+    option.value = m.id;
+    option.textContent = m.label;
+    select.appendChild(option);
+  }
+  select.value = current.cleanup.builtin.model;
+  syncCleanupNote();
+}
+
+function syncCleanupNote() {
+  const id = $("cleanup-builtin-model").value;
+  const m = modelStatus.cleanup.find((x) => x.id === id);
+  $("cleanup-builtin-note").textContent = m
+    ? m.installed ? `${m.note} · already downloaded` : m.note
+    : "";
+}
+// Bound after the select exists.
 
 /* ---------- collect wizard choices into a settings object ---------- */
 
 function collect() {
-  const local = sttMode() === "local";
+  const mode = sttMode();
+  const cMode = cleanupMode();
   return {
     ...current,
     output: {
       ...current.output,
       mode: document.querySelector('input[name="output-mode"]:checked').value,
     },
-    stt: local
-      ? { ...defaults.stt }
-      : {
-          ...current.stt,
-          baseUrl: $("stt-url").value.trim() || defaults.stt.baseUrl,
-          apiKey: $("stt-key").value.trim(),
-          model: $("stt-model").value.trim() || defaults.stt.model,
-        },
+    stt: {
+      ...current.stt,
+      engine: mode,
+      builtin: { ...current.stt.builtin },
+      ...(mode === "remote"
+        ? {
+            baseUrl: $("stt-url").value.trim() || defaults.stt.baseUrl,
+            apiKey: $("stt-key").value.trim(),
+            model: $("stt-model").value.trim() || defaults.stt.model,
+          }
+        : {}),
+    },
     cleanup: {
       ...current.cleanup,
       enabled: $("cleanup-enabled").checked,
-      baseUrl: $("cleanup-url").value.trim() || defaults.cleanup.baseUrl,
-      apiKey: $("cleanup-key").value.trim(),
-      model: $("cleanup-model").value.trim(),
+      engine: cMode === "external" ? "remote" : "builtin",
+      builtin: {
+        ...current.cleanup.builtin,
+        model: $("cleanup-builtin-model").value,
+      },
+      ...(cMode === "external"
+        ? {
+            baseUrl: $("cleanup-url").value.trim() || defaults.cleanup.baseUrl,
+            apiKey: $("cleanup-key").value.trim(),
+            model: $("cleanup-model").value.trim(),
+          }
+        : {}),
     },
     audio: {
       ...current.audio,
       deviceId: $("mic-device").value,
     },
     sttServer: {
-      autoStart: local && $("server-autostart").checked,
+      autoStart: mode === "server" && $("server-autostart").checked,
       command: $("server-command").value.trim() || defaults.sttServer.command,
     },
   };
@@ -207,28 +264,38 @@ bindTest("cleanup-test", "cleanup-test-result", "cleanup:test", () => ({
 
 /* ---------- summary ---------- */
 
+const STT_LABELS = {
+  builtin: "Built-in Parakeet (on this computer)",
+  server: "Local Parakeet server",
+  remote: null, // shown as the base URL
+};
+
 function renderSummary() {
   const next = collect();
-  const local = sttMode() === "local";
   const mic = $("mic-device");
   const rows = [
     ["Hotkey", next.hotkey],
     ["Microphone", mic.selectedOptions[0]?.textContent || "System default"],
     [
       "Speech-to-text",
-      local ? "Local Parakeet server" : next.stt.baseUrl,
+      STT_LABELS[next.stt.engine] || next.stt.baseUrl,
     ],
   ];
-  if (local) {
-    rows.push(["Start STT server with app", next.sttServer.autoStart ? "Yes" : "No"]);
+  if (!next.cleanup.enabled) {
+    rows.push(["Cleanup", "Off"]);
+  } else if (next.cleanup.engine === "builtin") {
+    const m = modelStatus.cleanup.find((x) => x.id === next.cleanup.builtin.model);
+    rows.push(["Cleanup", `Built-in ${m ? m.label : ""} (on this computer)`]);
+  } else {
+    rows.push(["Cleanup", next.cleanup.model || "external service"]);
   }
   rows.push([
-    "Cleanup",
-    next.cleanup.enabled ? next.cleanup.model || "enabled" : "Off",
-  ]);
-  rows.push([
     "Output",
-    next.output.mode === "paste" ? "Paste into active app" : "Clipboard only",
+    next.output.mode === "clipboard"
+      ? "Clipboard only"
+      : next.output.mode === "paste-copy"
+        ? "Paste and keep on clipboard"
+        : "Paste into active app",
   ]);
 
   const summary = $("summary");
@@ -247,6 +314,169 @@ function renderSummary() {
 document
   .querySelectorAll('input[name="output-mode"]')
   .forEach((radio) => radio.addEventListener("change", renderSummary));
+
+/* ---------- download step ---------- */
+
+// Models the user's choices require to run on this computer.
+function neededModels(cfg) {
+  const list = [];
+  if (cfg.stt.engine === "builtin") {
+    list.push({ kind: "stt", modelId: cfg.stt.builtin.model });
+  }
+  if (cfg.cleanup.enabled && cfg.cleanup.engine === "builtin") {
+    list.push({ kind: "cleanup", modelId: cfg.cleanup.builtin.model });
+  }
+  return list;
+}
+
+const dlRows = new Map(); // "kind:id" -> { fill, status, retry, done }
+let downloadStarted = false;
+
+function infoFor(kind, modelId) {
+  return modelStatus[kind].find((m) => m.id === modelId);
+}
+
+function setFill(row, fraction) {
+  row.fill.style.width = `${Math.round(fraction * 100)}%`;
+}
+
+function checkAllDone() {
+  const allDone = [...dlRows.values()].every((r) => r.done);
+  $("next").disabled = !allDone;
+  $("next").textContent = allDone ? "Finish setup" : "Downloading…";
+}
+
+async function runDownload(kind, modelId) {
+  const key = `${kind}:${modelId}`;
+  const row = dlRows.get(key);
+  row.done = false;
+  row.retry.hidden = true;
+  row.status.textContent = "Downloading…";
+  row.status.className = "status";
+  checkAllDone();
+
+  const res = await earheart.invoke("models:download", { kind, modelId });
+  if (res.ok) {
+    setFill(row, 1);
+    row.status.textContent = "Ready ✓";
+    row.status.className = "status ok";
+    row.done = true;
+  } else if (res.cancelled) {
+    row.status.textContent = "Cancelled";
+    row.status.className = "status";
+  } else {
+    row.status.textContent = res.error || "Download failed";
+    row.status.className = "status err";
+    row.retry.hidden = false;
+  }
+  checkAllDone();
+}
+
+function buildRow(kind, modelId) {
+  const info = infoFor(kind, modelId);
+  const wrap = document.createElement("div");
+  wrap.className = "dl-item";
+
+  const head = document.createElement("div");
+  head.className = "dl-head";
+  const name = document.createElement("strong");
+  name.textContent = info ? info.label : modelId;
+  const status = document.createElement("span");
+  status.className = "status";
+  head.append(name, status);
+
+  const bar = document.createElement("div");
+  bar.className = "dl-bar";
+  const fill = document.createElement("div");
+  fill.className = "dl-fill";
+  bar.appendChild(fill);
+
+  const note = document.createElement("p");
+  note.className = "hint";
+  note.textContent = info ? info.note : "";
+
+  const retry = document.createElement("button");
+  retry.className = "ghost";
+  retry.textContent = "Retry";
+  retry.hidden = true;
+  retry.addEventListener("click", () => runDownload(kind, modelId));
+
+  wrap.append(head, bar, note, retry);
+  dlRows.set(`${kind}:${modelId}`, { fill, status, retry, done: false });
+  return wrap;
+}
+
+async function enterDownloadStep() {
+  const cfg = collect();
+  const needed = neededModels(cfg);
+
+  // Rebuild only when the set of needed models changes (revisiting the step
+  // after going back shouldn't restart finished downloads).
+  const signature = needed.map((n) => `${n.kind}:${n.modelId}`).sort().join(",");
+  if (downloadStarted && signature === enterDownloadStep.signature) {
+    checkAllDone();
+    return;
+  }
+  enterDownloadStep.signature = signature;
+
+  // Cancel anything in flight from a previous selection.
+  for (const [key] of dlRows) {
+    const [kind, modelId] = key.split(":");
+    earheart.invoke("models:cancel", { kind, modelId });
+  }
+  dlRows.clear();
+  const listEl = $("download-list");
+  listEl.replaceChildren();
+
+  const toDownload = needed.filter((n) => {
+    const info = infoFor(n.kind, n.modelId);
+    return info && !info.installed;
+  });
+
+  $("download-none").hidden = needed.length > 0;
+  $("download-later-row").hidden = toDownload.length === 0;
+  $("download-title").textContent = toDownload.length
+    ? "Setting up the models that run on your computer"
+    : "You're all set";
+  $("download-intro").hidden = toDownload.length === 0;
+
+  // Show every needed model; already-installed ones render as Ready.
+  for (const n of needed) {
+    listEl.appendChild(buildRow(n.kind, n.modelId));
+    const row = dlRows.get(`${n.kind}:${n.modelId}`);
+    const info = infoFor(n.kind, n.modelId);
+    if (info && info.installed) {
+      setFill(row, 1);
+      row.status.textContent = "Ready ✓";
+      row.status.className = "status ok";
+      row.done = true;
+    }
+  }
+
+  downloadStarted = true;
+  checkAllDone();
+  // Kick off the downloads that are actually missing.
+  for (const n of toDownload) runDownload(n.kind, n.modelId);
+}
+
+earheart.on("models:progress", ({ kind, modelId, fraction }) => {
+  const row = dlRows.get(`${kind}:${modelId}`);
+  if (row && !row.done) setFill(row, fraction);
+});
+
+$("download-later").addEventListener("click", () => {
+  // Stop in-flight downloads and let the user finish; models can be fetched
+  // later from Settings. The pipeline shows a clear error until they exist.
+  for (const [key, row] of dlRows) {
+    if (row.done) continue;
+    const [kind, modelId] = key.split(":");
+    earheart.invoke("models:cancel", { kind, modelId });
+    row.done = true;
+    row.status.textContent = "Skipped — download later in Settings";
+    row.status.className = "status";
+  }
+  checkAllDone();
+});
 
 /* ---------- finish ---------- */
 
@@ -281,6 +511,7 @@ async function finish() {
   current = data.settings;
   defaults = data.defaults;
   platform = data.platform;
+  modelStatus = await earheart.invoke("models:status");
 
   hotkeyInput.value = current.hotkey;
   $("server-command").value = current.sttServer.command;
@@ -288,10 +519,24 @@ async function finish() {
   $("cleanup-model").value = current.cleanup.model;
   $("cleanup-enabled").checked = current.cleanup.enabled;
   document.querySelector(
+    `input[name="stt-mode"][value="${current.stt.engine}"]`
+  ).checked = true;
+  document.querySelector(
+    `input[name="cleanup-mode"][value="${current.cleanup.engine === "builtin" ? "builtin" : "external"}"]`
+  ).checked = true;
+  document.querySelector(
     `input[name="output-mode"][value="${current.output.mode}"]`
   ).checked = true;
+
+  populateCleanupModels();
+  $("cleanup-builtin-model").addEventListener("change", () => {
+    current.cleanup.builtin.model = $("cleanup-builtin-model").value;
+    syncCleanupNote();
+  });
+
   syncSttMode();
   syncCleanupEnabled();
+  syncCleanupMode();
 
   if (platform === "darwin") $("demo-mod").textContent = "⌘";
   if (platform !== "linux") $("wayland-note").style.display = "none";

--- a/scripts/engine-smoke.js
+++ b/scripts/engine-smoke.js
@@ -1,0 +1,27 @@
+// Boots the engine utilityProcess worker and round-trips a `ping`, proving the
+// worker forks and the parent<->worker IPC works. It does not download a model
+// or load the native runtimes (the `ping` handler touches neither), so it is a
+// fast, deterministic guard against the worker failing to start or the message
+// plumbing regressing. Run under Electron:
+//
+//   xvfb-run -a npx electron scripts/engine-smoke.js --no-sandbox   # Linux
+//   npx electron scripts/engine-smoke.js                            # macOS/Win
+
+const { app } = require("electron");
+const host = require("../main/engines/host");
+
+app.whenReady().then(async () => {
+  try {
+    const res = await host.request("ping", {}, [], 30000);
+    if (!res || res.pong !== true) {
+      throw new Error(`unexpected ping reply: ${JSON.stringify(res)}`);
+    }
+    console.log("[engine-smoke] worker ping ok");
+    host.stop();
+    app.exit(0);
+  } catch (err) {
+    console.error("[engine-smoke] failed:", (err && err.message) || err);
+    host.stop();
+    app.exit(1);
+  }
+});

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -1,0 +1,177 @@
+// Tests for the in-process engine support modules that don't need Electron or
+// the native runtimes: the model registry and the download manager.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const http = require("node:http");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const registry = require("../main/engines/registry");
+const manager = require("../main/engines/model-manager");
+
+/* ---------------- registry ---------------- */
+
+test("registry exposes default models that resolve", () => {
+  const stt = registry.getModel("stt", registry.DEFAULT_STT_MODEL);
+  const cleanup = registry.getModel("cleanup", registry.DEFAULT_CLEANUP_MODEL);
+  assert.ok(stt && stt.files.length > 0);
+  assert.ok(cleanup && cleanup.files.length > 0);
+  assert.strictEqual(registry.getModel("stt", "nope"), null);
+});
+
+test("registry totalBytes sums the file sizes", () => {
+  const model = { files: [{ bytes: 10 }, { bytes: 5 }, {}] };
+  assert.strictEqual(registry.totalBytes(model), 15);
+});
+
+test("exactly one cleanup model is marked default", () => {
+  const defaults = registry.listModels("cleanup").filter((m) => m.default);
+  assert.strictEqual(defaults.length, 1);
+  assert.strictEqual(defaults[0].id, registry.DEFAULT_CLEANUP_MODEL);
+});
+
+/* ---------------- download manager ---------------- */
+
+// A tiny static file server backing a fake model, so the download manager runs
+// end to end (stream -> .part -> rename -> marker) without the network.
+function serveFiles(fileMap) {
+  const server = http.createServer((req, res) => {
+    const body = fileMap[req.url];
+    if (!body) {
+      res.statusCode = 404;
+      res.end("nope");
+      return;
+    }
+    res.setHeader("content-length", body.length);
+    res.end(body);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({ server, base: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function withTmp(fn) {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "earheart-models-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("download streams files, reports progress, and marks complete", async () => {
+  const a = Buffer.from("encoder-bytes-".repeat(100));
+  const b = Buffer.from("tokens");
+  const { server, base } = await serveFiles({ "/a.onnx": a, "/b.txt": b });
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt",
+        id: "fake",
+        files: [
+          { name: "a.onnx", bytes: a.length, url: `${base}/a.onnx` },
+          { name: "b.txt", bytes: b.length, url: `${base}/b.txt` },
+        ],
+      };
+      assert.strictEqual(manager.isInstalled(dir, model), false);
+
+      const fractions = [];
+      await manager.download(dir, model, {
+        onProgress: (p) => fractions.push(p.fraction),
+      });
+
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+      assert.deepStrictEqual(
+        fs.readFileSync(manager.filePath(dir, model, model.files[0])),
+        a
+      );
+      // Progress is monotonic and finishes at exactly 1.
+      assert.strictEqual(fractions.at(-1), 1);
+      for (let i = 1; i < fractions.length; i++) {
+        assert.ok(fractions[i] >= fractions[i - 1]);
+      }
+      // No leftover temp files.
+      assert.ok(!fs.existsSync(manager.filePath(dir, model, model.files[0]) + ".part"));
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("download verifies sha256 and rejects a mismatch", async () => {
+  const good = Buffer.from("trustworthy bytes");
+  const sha = crypto.createHash("sha256").update(good).digest("hex");
+  const { server, base } = await serveFiles({ "/m.gguf": good });
+  try {
+    await withTmp(async (dir) => {
+      const ok = {
+        kind: "cleanup", id: "ok",
+        files: [{ name: "m.gguf", bytes: good.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      await manager.download(dir, ok); // matching checksum: resolves
+      assert.strictEqual(manager.isInstalled(dir, ok), true);
+
+      const bad = {
+        kind: "cleanup", id: "bad",
+        files: [{ name: "m.gguf", bytes: good.length, url: `${base}/m.gguf`, sha256: "deadbeef" }],
+      };
+      await assert.rejects(() => manager.download(dir, bad), /Checksum mismatch/);
+      assert.strictEqual(manager.isInstalled(dir, bad), false);
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("download skips files already on disk and remove frees them", async () => {
+  const a = Buffer.from("already here");
+  let hits = 0;
+  const server = http.createServer((req, res) => {
+    hits++;
+    res.end(a);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "skip",
+        files: [{ name: "a.bin", bytes: a.length, url: `${base}/a.bin` }],
+      };
+      // Pre-place the file as if a previous run had fetched it.
+      await fsp.mkdir(manager.modelDir(dir, model), { recursive: true });
+      await fsp.writeFile(manager.filePath(dir, model, model.files[0]), a);
+
+      await manager.download(dir, model);
+      assert.strictEqual(hits, 0); // never hit the network
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+
+      await manager.remove(dir, model);
+      assert.strictEqual(manager.isInstalled(dir, model), false);
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("download surfaces HTTP errors", async () => {
+  const { server, base } = await serveFiles({}); // serves 404 for everything
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "missing",
+        files: [{ name: "x", bytes: 1, url: `${base}/x` }],
+      };
+      await assert.rejects(() => manager.download(dir, model), /Download failed/);
+    });
+  } finally {
+    server.close();
+  }
+});

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -161,6 +161,28 @@ test("download skips files already on disk and remove frees them", async () => {
   }
 });
 
+test("isInstalled rejects a model whose file was truncated after download", async () => {
+  const a = Buffer.from("the-whole-file-".repeat(20));
+  const { server, base } = await serveFiles({ "/a.bin": a });
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "trunc",
+        files: [{ name: "a.bin", bytes: a.length, url: `${base}/a.bin` }],
+      };
+      await manager.download(dir, model);
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+
+      // Simulate corruption/truncation of an already-installed file: the marker
+      // recorded the original size, so the shorter file no longer matches.
+      await fsp.writeFile(manager.filePath(dir, model, model.files[0]), "tiny");
+      assert.strictEqual(manager.isInstalled(dir, model), false);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("download surfaces HTTP errors", async () => {
   const { server, base } = await serveFiles({}); // serves 404 for everything
   try {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -4,9 +4,9 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
 
-const { encodeWav, encodeSilenceWav } = require("../main/util/wav");
+const { encodeWav, encodeSilenceWav, wavToFloat32 } = require("../main/util/wav");
 const { stripThinking } = require("../main/services/cleanup");
-const { deepMerge } = require("../main/settings");
+const { deepMerge, migrateLegacy, DEFAULTS } = require("../main/settings");
 
 test("encodeWav produces a valid RIFF header", () => {
   const samples = new Int16Array([0, 1000, -1000, 32767, -32768]);
@@ -50,4 +50,49 @@ test("deepMerge keeps defaults for missing keys and overrides present ones", () 
 
 test("deepMerge ignores null/undefined overrides", () => {
   assert.deepStrictEqual(deepMerge({ a: 1 }, undefined), { a: 1 });
+});
+
+test("wavToFloat32 round-trips PCM16 samples to [-1, 1]", () => {
+  const wav = encodeWav(new Int16Array([0, 16384, -16384, 32767, -32768]));
+  const { samples, sampleRate } = wavToFloat32(wav);
+  assert.strictEqual(sampleRate, 16000);
+  assert.strictEqual(samples.length, 5);
+  assert.strictEqual(samples[0], 0);
+  assert.ok(Math.abs(samples[1] - 0.5) < 1e-4);
+  assert.ok(Math.abs(samples[2] + 0.5) < 1e-4);
+  assert.ok(samples[3] <= 1 && samples[3] > 0.99);
+  assert.strictEqual(samples[4], -1);
+});
+
+test("wavToFloat32 rejects non-WAV input", () => {
+  assert.throws(() => wavToFloat32(Buffer.from("not a wav at all!!")));
+});
+
+test("migrateLegacy maps pre-engine settings onto external engines", () => {
+  // Local autostart server -> "server".
+  const autostart = migrateLegacy({
+    stt: { baseUrl: "http://x" },
+    cleanup: { enabled: true },
+    sttServer: { autoStart: true },
+  });
+  assert.strictEqual(autostart.stt.engine, "server");
+  assert.strictEqual(autostart.cleanup.engine, "remote");
+
+  // No autostart -> "remote".
+  const remote = migrateLegacy({ stt: {}, cleanup: {}, sttServer: {} });
+  assert.strictEqual(remote.stt.engine, "remote");
+});
+
+test("migrateLegacy leaves fresh and already-migrated configs untouched", () => {
+  assert.deepStrictEqual(migrateLegacy({}), {}); // fresh install
+  const modern = { stt: { engine: "builtin" }, cleanup: { engine: "builtin" } };
+  assert.deepStrictEqual(migrateLegacy(modern), modern);
+});
+
+test("new installs default to in-process engines", () => {
+  assert.strictEqual(DEFAULTS.stt.engine, "builtin");
+  assert.strictEqual(DEFAULTS.cleanup.engine, "builtin");
+  assert.strictEqual(DEFAULTS.cleanup.enabled, true);
+  assert.ok(DEFAULTS.stt.builtin.model);
+  assert.ok(DEFAULTS.cleanup.builtin.model);
 });


### PR DESCRIPTION
Add the backend for running Parakeet (speech-to-text) and Gemma (transcript
cleanup) directly inside the app, with no separate executable or Python:

- main/engines/registry.js   downloadable model catalogue (Parakeet + Gemma)
- main/engines/model-manager.js  streaming, atomic, checksum-verified downloads
- main/engines/engine-worker.js  utilityProcess hosting sherpa-onnx + llama.cpp
- main/engines/host.js / index.js  parent-side facade and worker lifecycle

The native runtimes are required lazily, so the app still boots and the
existing HTTP services keep working if a model isn't downloaded. Settings now
default new installs to the built-in engines and migrate existing configs onto
the equivalent external engine. Pipeline and IPC route each stage to the
built-in engine or the HTTP client based on the chosen engine.

Covered by unit tests: WAV decode, settings migration, registry, and the
download manager (progress, checksum, skip-existing, errors).