### PR TITLE
Clearer install section + native macOS Intel build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,10 @@ jobs:
       # One platform failing must not cancel the other platforms' uploads.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macos-latest is Apple Silicon (arm64); macos-13 is Intel (x64). Each
+        # builds for its own arch so the per-arch native addons npm installed on
+        # that host are the ones that ship — see electron-builder.yml.
+        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/README.md
+++ b/README.md
@@ -60,30 +60,54 @@ OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
 
 ## Install
 
-### Download a release
+### 1. Download the right file for your OS
 
-Grab the latest installer for your platform from the
-[releases page](https://github.com/cleanunicorn/earheart/releases/latest):
+Open the **[latest release page](https://github.com/cleanunicorn/earheart/releases/latest)**
+and, under **Assets**, download the file that matches your system. `<version>`
+is just the version number (e.g. `0.6.1`).
 
-| Platform | File | Install |
-| --- | --- | --- |
-| Windows | `Earheart Setup <version>.exe` | Run the installer (a portable `Earheart <version>.exe` is also available) |
-| macOS | `Earheart-<version>.dmg` | Open and drag Earheart to Applications |
-| Linux (any distro) | `Earheart-<version>.AppImage` | `chmod +x` the file, then run it |
-| Debian / Ubuntu | `earheart_<version>_amd64.deb` | `sudo apt install ./earheart_<version>_amd64.deb` |
+**🪟 Windows**
 
-> **macOS note:** builds are not yet signed or notarized, so Gatekeeper blocks
-> the first launch. If you see **"Earheart is damaged and can't be opened"**,
-> the app isn't actually broken — macOS quarantines unsigned downloads. After
-> dragging Earheart to Applications, clear the quarantine flag once:
+- **Most people:** `Earheart-Setup-<version>.exe` — the installer.
+- Don't want to install? `Earheart-<version>.exe` — a portable build you can
+  run directly.
+
+**🍎 macOS**
+
+- **Apple Silicon (M1/M2/M3/M4):** `Earheart-<version>-arm64.dmg`
+- **Intel Macs:** `Earheart-<version>.dmg`
+- Not sure which Mac you have? Click  → **About This Mac** and look at
+  "Chip" / "Processor".
+
+**🐧 Linux**
+
+- **Any distro:** `Earheart-<version>.AppImage` — works everywhere.
+- **Debian / Ubuntu:** `earheart_<version>_amd64.deb` — installs as a normal
+  package.
+
+### 2. Install it
+
+| Your download | What to do |
+| --- | --- |
+| `Earheart-Setup-<version>.exe` | Double-click and follow the installer. |
+| `Earheart-<version>.exe` (portable) | Just double-click to run — no install. |
+| `Earheart-<version>*.dmg` | Open it, then drag **Earheart** into **Applications**. (See the macOS note below — the first launch needs one extra step.) |
+| `Earheart-<version>.AppImage` | In a terminal: `chmod +x Earheart-*.AppImage`, then double-click or run it. |
+| `earheart_<version>_amd64.deb` | `sudo apt install ./earheart_<version>_amd64.deb` |
+
+> **⚠️ macOS first launch: "Earheart is damaged and can't be opened"**
+>
+> This does **not** mean the app is broken. Earheart isn't signed/notarized
+> yet, so macOS quarantines it. After dragging Earheart to Applications, run
+> this once in Terminal:
 >
 > ```bash
 > xattr -dr com.apple.quarantine /Applications/Earheart.app
 > ```
 >
-> Then open it normally. (The "right-click → Open" trick only clears the
-> milder "unidentified developer" warning, not the "damaged" one.) See
-> [macOS](#macos) below for details.
+> Then open Earheart normally. (The "right-click → Open" trick only clears the
+> milder "unidentified developer" warning, not the "damaged" one.) More detail
+> in [macOS notes](#macos) below.
 
 That's it — the built-in engines need nothing else installed. The first-run
 wizard downloads the speech and cleanup models for you.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,6 +42,11 @@ linux:
     entry:
       StartupWMClass: earheart
 
+# The release matrix builds macOS on two runners — arm64 on macos-latest and
+# x64 on the Intel macos-13 runner — so the per-arch native addons
+# (sherpa-onnx-darwin-* and @node-llama-cpp/mac-*) are the ones npm actually
+# installed on that host. Each run defaults to the host arch; cross-compiling
+# both from one runner would bundle the wrong-arch native binaries.
 mac:
   target:
     - dmg


### PR DESCRIPTION
## Summary

Two related changes to make Earheart easier to install and to cover Intel Macs:

- **README install section reworked** into two scannable steps — *pick the right file for your OS*, then *install it* — with filenames corrected to match what's actually published (`Earheart-Setup-<version>.exe`, per-arch dmgs, etc.).
- **Native macOS Intel (x64) build added.** Previously the release only built arm64, so Intel Mac users had no binary. The release matrix now builds macOS on both `macos-latest` (Apple Silicon / arm64) and `macos-13` (Intel / x64).

## Why a second runner instead of cross-compiling

Both native deps (`sherpa-onnx-node`, `node-llama-cpp`) ship as per-arch optional packages, and npm only installs the variant matching the build host. Cross-compiling x64 from the arm64 runner would bundle arm64 native binaries into an Intel app and crash on launch. Each arch builds on its own native runner so the correct binaries ship.

## Resulting assets

- `Earheart-<version>-arm64.dmg` (Apple Silicon)
- `Earheart-<version>.dmg` (Intel)

## Notes

- No auto-updater is wired up, so both mac jobs writing `latest-mac.yml` is harmless; the dmg/zip names are per-arch and don't collide.
- The x64 dmg's correctness will be confirmed by the first tagged release that runs this workflow (couldn't run a macOS build locally).
- `macos-13` is an older Intel image GitHub will eventually retire; the matrix entry will need updating (or dropping Intel) when that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)