### PR TITLE
feat: live transcript preview while recording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,18 +117,24 @@ main/                    Electron main process
   engines/               in-process STT + cleanup (no separate executable)
     registry.js          downloadable model catalogue
     model-manager.js     streaming, atomic, checksum-verified downloads
-    engine-worker.js     utilityProcess: sherpa-onnx (STT) + node-llama-cpp
-    host.js / index.js   parent-side worker lifecycle + facade
+    engine-worker.js     utilityProcess: sherpa-onnx (STT) + node-llama-cpp;
+                         forked once per engine (two workers)
+    host.js              createHost() factory: one worker process per host
+    index.js             facade routing STT → sttHost, cleanup → cleanupHost
   output/deliver.js      clipboard + per-OS paste keystroke injection
-renderer/                overlay (mic capture → 16 kHz WAV), settings UI,
-                         first-run wizard (incl. model download step)
+renderer/                overlay (mic capture → 16 kHz WAV, live transcript
+                         preview), settings UI, first-run wizard
+  transcript.js          pure two-layer (raw/cleaned) reconcile helper
 stt-server/              Python: FastAPI + onnx-asr Parakeet server (optional)
 ```
 
 The pipeline routes each stage to the in-process engine or the HTTP client
 based on `stt.engine` / `cleanup.engine` ("builtin" | "remote").
-The native runtimes are loaded lazily inside the worker, so the app boots and
-the HTTP paths keep working even if a model isn't downloaded.
+STT and cleanup each run in their **own** `utilityProcess` worker, so they
+parallelize (used by the live-transcript preview) and a native crash in one
+engine can't take down the other. The native runtimes are loaded lazily inside
+each worker, so the app boots and the HTTP paths keep working even if a model
+isn't downloaded.
 
 Design constraints worth keeping:
 
@@ -139,7 +145,9 @@ Design constraints worth keeping:
   from the asar (`asarUnpack` in `electron-builder.yml`). Models are downloaded
   at first run, not bundled.
 - **The overlay window owns the microphone.** The main process never touches
-  audio; it receives a finished WAV from the renderer.
+  raw audio; it receives finished WAVs from the renderer — the final one on stop,
+  plus periodic partial WAVs while recording for the live preview (re-transcribed
+  best-effort; see [docs/live-transcription-plan.md](docs/live-transcription-plan.md)).
 - **Never lose the user's words.** If cleanup fails, deliver the raw
   transcript; if paste fails, fall back to the clipboard; history keeps the
   text either way.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
   Runtime, faster than realtime on CPU and with no network hop. Or point
   Earheart at any OpenAI-compatible transcription API, or run the optional
   [`earheart-stt`](stt-server/) server yourself.
+- **Live transcript while you speak (on by default)** — with the built-in
+  engine the overlay fills in the text as you talk, with a cleaned-up version
+  settling in behind the raw words on pauses. The final transcript on stop is
+  unchanged. Toggle it under Settings → Speech-to-text.
 - **LLM cleanup (on by default)** — punctuation, filler-word removal, false
   starts. By default a small Gemma model runs **in-process**; or point cleanup
   at any OpenAI-compatible chat API. The prompt is fully editable. If cleanup

--- a/docs/live-transcription-plan.md
+++ b/docs/live-transcription-plan.md
@@ -55,15 +55,24 @@ hotkey ─▶ pipeline.toggle()                         (main/pipeline.js:95)
 
 ---
 
-## Phase 1 — Live preview (rolling re-transcribe)
+## Phase 1 — Live preview (chunked, append-only)
 
-Keep Parakeet offline. While recording, the overlay periodically re-encodes the
-audio buffered *so far* and the main process re-runs the whole buffer through
-the offline recognizer, pushing the partial **raw** transcript back to the
-overlay. Separately, on speech pauses, the main process also runs the **cleanup**
-model over the full raw transcript and pushes a partial **cleaned** transcript.
-The overlay shows both as two layers (see below). On stop, the existing final
-pass (+ cleanup + deliver) runs unchanged.
+> **Superseded note:** this section originally described re-decoding the *whole*
+> buffer every tick. That shipped, but measurement showed it's O(n²): decode time
+> grew with total length (1.7s at 30s, 6.3s at 73s), crossed the tick interval at
+> ~21s, and crashed the app after ~30s. It was replaced with **append-only
+> chunking** — the overlay ships audio in ~5s chunks, each transcribed once and
+> accumulated; only the in-progress chunk is re-decoded, so cost stays flat (~370ms
+> per chunk regardless of dictation length). Cleanup is likewise incremental (only
+> newly committed text). The two-layer display and lifecycle below are unchanged.
+
+Keep Parakeet offline. While recording, the overlay ships the audio of the
+current in-progress chunk; the main process transcribes it and accumulates a
+committed transcript, pushing the partial **raw** transcript back to the overlay.
+On speech pauses after a chunk commits, the main process cleans **only the newly
+committed text** and appends it to the partial **cleaned** transcript. The overlay
+shows both as two layers (see below). On stop, the existing final pass (+ cleanup
++ deliver) runs unchanged over the whole authoritative audio.
 
 No new model, no new dependency, fully private, reuses the whole pipeline.
 

--- a/docs/live-transcription-plan.md
+++ b/docs/live-transcription-plan.md
@@ -1,0 +1,341 @@
+# Live transcription plan
+
+Adding real-time ("type as you talk") transcription to earheart.
+
+Today the flow is batch-only: you press the hotkey, speak, stop, and only then
+does any text appear. This plan adds a live transcript that fills in *while you
+speak*, in two phases — first a preview in the overlay, later keystrokes into
+the focused app.
+
+## Why this isn't a flag
+
+The current pipeline is whole-file by design:
+
+- The overlay buffers all audio in a `chunks[]` array and only encodes a WAV +
+  ships it on stop (`renderer/overlay.js:148`, `audio:captured`).
+- Both STT backends are whole-file. The builtin engine uses sherpa-onnx's
+  `OfflineRecognizer` with Parakeet-TDT (`main/engines/engine-worker.js:57`),
+  decoded in one shot. The HTTP path POSTs a complete WAV to
+  `/audio/transcriptions` (`main/services/stt.js:29`). Parakeet-TDT is an
+  *offline* model — it has no native streaming decoder.
+
+So "stream as I talk" requires either re-transcribing a growing buffer
+(Phase 1) or a genuinely streaming-capable recognizer (Phase 2).
+
+## Scope decisions (already made)
+
+- **Target UX:** live preview now, in-app keystrokes later.
+- **Engine path:** builtin (in-process, private) Parakeet only. The HTTP /
+  server path and a server-streaming endpoint are explicitly out of scope.
+
+## Architecture recap
+
+```
+hotkey ─▶ pipeline.toggle()                         (main/pipeline.js:95)
+            │
+   overlay records mic, buffers chunks[]            (renderer/overlay.js:113)
+            │  on stop: encodeWav() ─▶ audio:captured
+            ▼
+   pipeline.process(): transcribe ─▶ cleanup ─▶ deliver   (main/pipeline.js:144)
+            │
+   builtin engine, utilityProcess worker            (main/engines/engine-worker.js)
+```
+
+- **Main process** orchestrates the pipeline and owns engine state.
+- **Overlay renderer** owns the microphone and the UI pill.
+- **Engine workers** (`utilityProcess`) run sherpa-onnx STT and Gemma cleanup off
+  the main thread. *Today this is a single shared worker* (`engine-worker.js`
+  hosts both engines, `host.js` routes to one child); Phase 1 splits this into
+  two workers — one for STT, one for cleanup — so they run in parallel (see the
+  "Split the engine worker" change below).
+- IPC channels are whitelisted in `preload.js:5-42` — any new channel must be
+  added there or it is silently dropped.
+- Every dictation has a session id (`session`, `main/pipeline.js:38`) echoed in
+  overlay messages; events from a stale session are ignored.
+
+---
+
+## Phase 1 — Live preview (rolling re-transcribe)
+
+Keep Parakeet offline. While recording, the overlay periodically re-encodes the
+audio buffered *so far* and the main process re-runs the whole buffer through
+the offline recognizer, pushing the partial **raw** transcript back to the
+overlay. Separately, on speech pauses, the main process also runs the **cleanup**
+model over the full raw transcript and pushes a partial **cleaned** transcript.
+The overlay shows both as two layers (see below). On stop, the existing final
+pass (+ cleanup + deliver) runs unchanged.
+
+No new model, no new dependency, fully private, reuses the whole pipeline.
+
+### Two-layer live display
+
+The overlay shows two stacked layers so the fast-but-jittery raw text and the
+slower-but-calm cleaned text don't fight each other:
+
+```
+The quick brown fox jumps              ← cleaned (main line, settled)
+                          over the lazy umm dog   ← raw tail (faint, still streaming)
+```
+
+- **Cleaned line (main, prominent):** the latest cleaned transcript. Updates
+  only when a cleanup pass completes, so it changes in calm chunks.
+- **Raw tail (faint, trailing):** the portion of the raw transcript *past* the
+  end of the cleaned text — i.e. what's been heard but not yet cleaned. Updates
+  every raw tick, keeping pace with the voice. As cleanup catches up, the tail
+  shrinks and the cleaned line grows.
+
+The two layers are reconciled by prefix: the raw tail is `raw` with the
+already-cleaned span removed. Because cleanup runs over the *full* raw text each
+time (not per-segment), the cleaned line is internally coherent and re-cleaning a
+stable prefix yields stable output, which keeps the main line from flickering.
+
+### Changes
+
+1. **`renderer/overlay.html`** — add a live-transcript element under the meter
+   with two layers: a prominent **cleaned** line and a faint **raw tail** that
+   follows it inline. Empty until the first partial arrives.
+
+2. **`renderer/overlay.js`**
+   - Alongside the existing meter rAF loop, add a partial timer (~1.2 s) that,
+     while `recording` is set, calls `encodeWav(recording.chunks)`
+     (`overlay.js:81`) and sends `audio:partial { sid, wav }`.
+   - Stop and clear the timer in `teardown()` (`overlay.js:185`) so it never
+     outlives a session.
+   - Handle `pipeline:partial { kind, text }` where `kind` is `"raw"` or
+     `"cleaned"`: update the raw tail or the cleaned line respectively, then
+     re-derive the tail as `raw` minus the cleaned prefix so the two layers stay
+     reconciled. Clear both on `record:start` and on the final `done` status
+     (the delivered transcript supersedes the preview).
+   - Gate the whole thing on a `livePreview` flag passed in `record:start`
+     (see settings below) so it's off-path when disabled.
+
+3. **`preload.js`** — whitelist `audio:partial` (send, overlay → main) and
+   `pipeline:partial` (listen, main → overlay) in the channel lists
+   (`preload.js:5-42`).
+
+4. **`main/pipeline.js`**
+   - Add an `ipcMain.on("audio:partial", …)` handler in `init()`
+     (`pipeline.js:209`). It must:
+     - **Session-guard:** ignore if `sid !== session` or `state !== "recording"`.
+     - **Drop-if-busy (STT):** keep a `partialInFlight` flag; if a previous
+       partial decode hasn't returned, skip this one entirely (no queue — we only
+       care about the latest audio, and queueing would lag further behind real
+       time).
+     - Run `runTranscribe(wav, cfg.stt, partialSignal)` on a **separate abort
+       scope** from `process()`'s `abortController`, so a partial decode never
+       collides with or cancels the final transcription.
+     - On success, store the latest `raw` partial and, if still the same session
+       and still recording, send `pipeline:partial { kind: "raw", text }` to the
+       overlay via `windows.sendToOverlay`.
+     - Swallow errors silently (a dropped partial is cosmetic; never surface it
+       as a pipeline error).
+   - **Partial cleanup (pause-triggered, full-text).** Track the latest raw
+     partial and whether it grew since the last tick. When the raw text has been
+     **stable for ~1 s** (a speech pause), and cleanup is enabled and not already
+     in flight, run `runCleanup(latestRaw, cfg.cleanup, …)` over the **full** raw
+     transcript (not a segment) on its own abort scope, and send
+     `pipeline:partial { kind: "cleaned", text }`. Cleaning the whole text each
+     time keeps punctuation coherent across pauses and is idempotent on stable
+     prefixes, so the cleaned line stays calm. Same drop-if-busy discipline as
+     STT; a cleanup in flight blocks a new one.
+   - Pass the `livePreview` flag into the `record:start` payload in
+     `startRecording()` (`pipeline.js:113`).
+   - In `process()` (`pipeline.js:144`), cancel/ignore any in-flight partial
+     **decode and cleanup** before the final transcribe + cleanup so they don't
+     overlap on the single-instance engine worker.
+
+5. **Split the engine worker into two (`host.js`, `index.js`).** Today a single
+   `utilityProcess` hosts both engines and serializes every request, so partial
+   STT and partial cleanup would block each other. Run them in **two separate
+   workers** so the raw tail (STT) and the cleaned line (cleanup) decode in
+   parallel.
+   - **`engine-worker.js`** — no change. It already handles both engine types via
+     its `HANDLERS` map; we just fork it twice and only ever send STT requests to
+     one instance and cleanup requests to the other.
+   - **`main/engines/host.js`** — convert the module-level singleton (`child`,
+     `nextId`, `pending`, `exitListeners`) into a `createHost({ serviceName })`
+     factory returning an instance with the same `{ request, stop, onExit }`
+     surface. Each instance owns its own child and lazily forks on first
+     `request` (the existing `spawn()` behavior, unchanged).
+   - **`main/engines/index.js`** — hold two host instances, `sttHost` and
+     `cleanupHost`; route `load-stt`/`transcribe`/`unload-stt` to the first and
+     `load-cleanup`/`clean`/`unload-cleanup` to the second. Split `forgetLoaded`,
+     `unloadIdle`, `stop`, and the `onExit` hook so each worker's lifecycle is
+     independent (e.g. unload the heavy LLM while keeping the STT recognizer
+     warm). **Lazy spawn:** because each host forks on first request, a
+     batch-only user who never triggers cleanup never spawns the 2nd worker;
+     streaming users get full parallelism.
+   - Within each worker, requests are still serialized, so the drop-if-busy rule
+     still applies *per stage* (don't pile up STT partials; don't pile up cleanup
+     passes) — but STT and cleanup no longer block each other, and a crash in one
+     worker no longer takes down the other.
+
+6. **`main/settings.js`** — add `stt.livePreview` (default decided below). Surface
+   it in Settings (`renderer/settings.*`) as a toggle.
+
+### Guardrails
+
+- **Cost grows with utterance length.** The offline recognizer re-decodes the
+  *entire* buffer each tick, so a 60 s dictation re-decodes ~60 s of audio every
+  1.2 s near the end. Cap it: stop issuing partials past a threshold
+  (e.g. 30 s) and leave the last partial on screen with a "still listening…"
+  hint, or scale the interval up as the buffer grows. Decide the threshold
+  before coding.
+- **Two workers, serialized within each.** STT and cleanup now run in separate
+  workers, so they no longer block each other — the raw tail and the cleaned line
+  decode in parallel. *Within* each worker requests are still serial, so the
+  drop-if-busy rule still applies per stage (don't queue STT partials; don't
+  queue cleanup passes). Before the final pass, cancel/ignore the in-flight
+  partials in *both* workers so they don't overlap the authoritative final
+  transcribe + cleanup. Verify a partial in flight at stop doesn't delay the
+  final result.
+- **Pause-triggered, full-text cleanup.** Cleanup runs over the *entire* raw
+  transcript on each pause, not per-segment — a long pause is not a sentence end,
+  so segmenting would corrupt punctuation. The pause trigger doubles as the
+  throttle: it keeps full-text cleanup from running every tick, which is what
+  makes repeatedly cleaning a growing transcript affordable. Tune the
+  stability window (~1 s) so normal mid-sentence pauses don't fire it constantly
+  on long dictations.
+- **Default off vs. on.** Live preview adds steady CPU load while recording.
+  Lean toward defaulting it **on** for short dictations but make the toggle
+  prominent; revisit after measuring decode latency on the default model.
+
+### Done when
+
+- Speaking shows a faint raw tail in the overlay within ~1–2 s that keeps pace
+  with your voice.
+- On pauses, the cleaned main line fills in behind the raw tail and the tail
+  shrinks, without the main line flickering.
+- Stopping still produces the same final, cleaned, delivered text as today — the
+  preview is purely additive and the batch path is untouched on the happy path.
+  The final delivered text should closely match the last cleaned preview (a
+  nice-to-have signal that streaming cleanup is faithful).
+- Toggling `stt.livePreview` off restores exactly the current behavior (no
+  `audio:partial` traffic, no partial cleanup).
+- Cancelling mid-dictation tears down the partial timer and drops any in-flight
+  partial decode and cleanup.
+
+---
+
+## Phase 2 — Keystrokes into the focused app (later)
+
+The real "type as you talk" experience: words appear directly in whatever app
+has focus as you speak. This is a larger change and is deliberately deferred;
+Phase 1's `pipeline:partial` IPC and the overlay live-text element carry over as
+scaffolding.
+
+### Sketch
+
+- **Streaming recognizer.** Add sherpa-onnx `OnlineRecognizer` with a
+  streaming-capable model (e.g. a streaming Zipformer) in
+  `engine-worker.js`, alongside the existing offline recognizer. The overlay
+  feeds PCM frames continuously (the worklet already produces frame chunks,
+  `overlay.js:148`) instead of re-encoding whole WAVs; the worker runs the
+  `acceptWaveform` → `isReady` → `decode` → `getResult` loop with endpoint
+  detection.
+- **Keep Parakeet for the final pass.** Streaming models are generally less
+  accurate than offline Parakeet-TDT. Use the streaming model for the live
+  preview/keystrokes and still run Parakeet once on stop for the authoritative
+  transcript (then reconcile). This means two models resident — account for the
+  memory and the idle-unload logic (`pipeline.js:55`).
+- **Incremental injection.** Extend `main/output/deliver.js` with a mode that
+  types committed words into the focused app as they stabilize and reconciles
+  when a partial is revised (backspace/replace). This is the fiddly part —
+  cursor races, undo stacks, and the interaction with the final cleanup pass
+  (which rewrites text the user already saw typed) all need handling.
+
+Decide Phase 2's exact shape after Phase 1 ships and the live-preview UX is
+validated.
+
+---
+
+## SWOT analysis
+
+A structured read on this plan (Phase 1 first, Phase 2 deferred).
+
+### Strengths
+
+- **Zero new dependencies or models in Phase 1.** Rolling re-transcribe reuses
+  the existing offline Parakeet engine and the whole pipeline — small, reviewable
+  diff, nothing to download.
+- **Stays private and offline.** No server, no network — preserves earheart's
+  core "no audio leaves your machine" promise.
+- **Purely additive on the happy path.** The batch record → transcribe → clean →
+  deliver flow is untouched; live preview is layered on top and gated behind a
+  toggle, so the failure mode degrades to today's behavior.
+- **Stateless partials.** `transcribe` already creates a fresh stream per call
+  (`engine-worker.js:80`), so repeated whole-buffer decodes need no engine
+  change and carry no cross-call state to corrupt.
+- **Reusable scaffolding.** The `pipeline:partial` IPC and overlay live-text
+  element built in Phase 1 carry straight into Phase 2.
+- **Worker split is a standalone win.** Separating STT and cleanup into two
+  workers buys true parallelism *and* crash isolation (a native crash in one
+  engine no longer kills the other) and independent idle-unload — improvements
+  that hold even apart from streaming.
+
+### Weaknesses
+
+- **Not true streaming.** Phase 1 re-decodes the *entire* buffer each tick, so
+  cost grows with utterance length and latency is the decode time of the whole
+  clip — fine for ~15–30 s, sluggish for minutes.
+- **Engine layer refactor.** Splitting the single worker into two (host factory,
+  two instances, per-worker lifecycle) touches the whole engine facade
+  (`host.js`, `index.js`). Modest and well-contained, but it's net-new plumbing
+  that the batch-only path didn't need.
+- **Higher *peak* resource use under streaming.** Two workers, and during
+  streaming both models now work *simultaneously* rather than time-slicing one
+  CPU. Parallelism trades latency for peak CPU + RAM pressure — material on
+  laptops, the primary platform. (Lazy spawn keeps batch-only users unaffected.)
+- **Cleaned preview can still revise.** Streaming cleanup makes the preview match
+  the final closely, but the cleaned line still updates in chunks as cleanup
+  catches up, so earlier cleaned text can change when later context arrives. The
+  two-layer display contains this (it's expected on the main line) but it isn't
+  zero-jitter.
+
+### Opportunities
+
+- **Validate the UX cheaply.** Phase 1 answers "does seeing partials actually
+  feel good?" before committing to the much larger Phase 2 work.
+- **Natural path to keystroke injection.** If the preview lands well, Phase 2
+  (streaming recognizer + in-app typing) is the marquee feature competitors
+  (Wispr Flow, etc.) charge for.
+- **Settings surface for tuning.** The `stt.livePreview` toggle + interval/length
+  caps become knobs users can tune to their hardware.
+- **Informs a future streaming model choice.** Real-world partial-latency data
+  from Phase 1 guides which streaming model to pick in Phase 2.
+
+### Threats
+
+- **Decode latency may be too high to feel "live."** If a whole-buffer decode on
+  the default int8 model takes >1–2 s on typical hardware, the raw tail lags
+  enough to feel broken rather than real-time — the core risk to Phase 1.
+- **Cleanup may not keep up.** Gemma 1B cleaning a growing full transcript on
+  every pause may fall far behind on long dictations, leaving a large faint raw
+  tail and a stale cleaned line. Mitigated by the pause trigger and by cleanup
+  being allowed to lag, but worth measuring alongside decode latency.
+- **Phase 2 accuracy regression.** Streaming models are less accurate than
+  offline Parakeet-TDT; the two-model reconcile (live stream vs. final Parakeet)
+  is complex and can surface visible corrections.
+- **Incremental injection is genuinely hard.** Cursor races, undo stacks, and the
+  final cleanup rewriting already-typed text are real, fiddly failure modes in
+  Phase 2.
+- **Memory pressure in Phase 2.** Keeping a streaming model *and* Parakeet
+  resident competes with the existing idle-unload logic (`pipeline.js:55`) and
+  raises the app's footprint.
+
+### Takeaway
+
+Phase 1 is low-risk, high-information, and cheap to build — the right first move,
+with the single make-or-break unknown being **decode latency on the default
+model**. Measure that early (a quick timing harness on a representative clip)
+before investing in the overlay UI; if it's too slow, raise the partial interval,
+cap by length, or jump straight to evaluating a Phase 2 streaming model. Phase 2
+carries the real engineering risk and should only start once Phase 1 proves the
+UX is worth it.
+
+## Out of scope
+
+- **Server-streaming endpoint** (a WebSocket on `stt-server`). Only benefits the
+  HTTP path; the builtin in-process engine — earheart's private default — would
+  gain nothing, so it's excluded per the engine-path decision above.
+- **Streaming the HTTP `/audio/transcriptions` client.** Same reason.

--- a/main/engines/host.js
+++ b/main/engines/host.js
@@ -1,7 +1,13 @@
-// Parent side of the engine worker. Lazily forks the utilityProcess, routes
-// request/reply messages by id, and restarts the worker if it dies. All of the
-// Electron-specific plumbing lives here so the rest of the app talks to plain
-// async functions.
+// Parent side of an engine worker. Each host owns one utilityProcess, lazily
+// forks it, routes request/reply messages by id, and restarts the worker if it
+// dies. All of the Electron-specific plumbing lives here so the rest of the app
+// talks to plain async functions.
+//
+// `createHost({ serviceName })` returns an independent host instance. The app
+// runs two of them — one for STT, one for cleanup — so a long inference or a
+// native crash in one engine never blocks or takes down the other. They share
+// the same engine-worker.js code; each instance is only ever sent the request
+// types for its engine.
 
 const path = require("node:path");
 
@@ -9,89 +15,93 @@ const path = require("node:path");
 // while, but a wedged worker should never hang a caller forever.
 const DEFAULT_REQUEST_TIMEOUT_MS = 180000;
 
-let child = null;
-let nextId = 1;
-const pending = new Map();
-// Notified whenever the worker process goes away, so callers can drop any
-// state they were caching about what the (now gone) worker had loaded.
-const exitListeners = new Set();
+function createHost({ serviceName = "earheart-engines" } = {}) {
+  let child = null;
+  let nextId = 1;
+  const pending = new Map();
+  // Notified whenever the worker process goes away, so callers can drop any
+  // state they were caching about what the (now gone) worker had loaded.
+  const exitListeners = new Set();
 
-function onExit(fn) {
-  exitListeners.add(fn);
-  return fn;
-}
-
-function spawn() {
-  if (child) return child;
-  // Required lazily so this module can be loaded in non-Electron unit tests.
-  const { utilityProcess } = require("electron");
-  child = utilityProcess.fork(path.join(__dirname, "engine-worker.js"), [], {
-    serviceName: "earheart-engines",
-    stdio: "inherit",
-  });
-  child.on("message", (msg) => {
-    const entry = msg && pending.get(msg.id);
-    if (!entry) return;
-    pending.delete(msg.id);
-    if (msg.ok) entry.resolve(msg.result);
-    else entry.reject(new Error(msg.error || "engine error"));
-  });
-  child.on("exit", () => {
-    child = null;
-    // Fail anything still in flight so callers fall back instead of hanging.
-    for (const entry of pending.values()) {
-      entry.reject(new Error("engine process exited"));
-    }
-    pending.clear();
-    // A fresh worker has nothing loaded; let callers reset their caches so the
-    // next request re-loads the model instead of assuming it is still resident.
-    for (const fn of exitListeners) fn();
-  });
-  return child;
-}
-
-/**
- * Send a request to the worker and await its reply. Message payloads are
- * structured-cloned across the process boundary; Electron's utilityProcess
- * has no transfer list for plain buffers (only MessagePortMain), so callers
- * pass any binary data as ordinary fields.
- * @param {string} type
- * @param {object} [args]
- * @param {number} [timeoutMs]
- */
-function request(type, args = {}, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
-  const proc = spawn();
-  const id = nextId++;
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      if (pending.has(id)) {
-        pending.delete(id);
-        reject(new Error(`engine request '${type}' timed out`));
-      }
-    }, timeoutMs);
-    pending.set(id, {
-      resolve: (v) => {
-        clearTimeout(timer);
-        resolve(v);
-      },
-      reject: (e) => {
-        clearTimeout(timer);
-        reject(e);
-      },
-    });
-    proc.postMessage({ id, type, ...args });
-  });
-}
-
-function stop() {
-  if (child) {
-    try {
-      child.kill();
-    } catch {
-      // already gone
-    }
-    child = null;
+  function onExit(fn) {
+    exitListeners.add(fn);
+    return fn;
   }
+
+  function spawn() {
+    if (child) return child;
+    // Required lazily so this module can be loaded in non-Electron unit tests.
+    const { utilityProcess } = require("electron");
+    child = utilityProcess.fork(path.join(__dirname, "engine-worker.js"), [], {
+      serviceName,
+      stdio: "inherit",
+    });
+    child.on("message", (msg) => {
+      const entry = msg && pending.get(msg.id);
+      if (!entry) return;
+      pending.delete(msg.id);
+      if (msg.ok) entry.resolve(msg.result);
+      else entry.reject(new Error(msg.error || "engine error"));
+    });
+    child.on("exit", () => {
+      child = null;
+      // Fail anything still in flight so callers fall back instead of hanging.
+      for (const entry of pending.values()) {
+        entry.reject(new Error("engine process exited"));
+      }
+      pending.clear();
+      // A fresh worker has nothing loaded; let callers reset their caches so the
+      // next request re-loads the model instead of assuming it is still resident.
+      for (const fn of exitListeners) fn();
+    });
+    return child;
+  }
+
+  /**
+   * Send a request to the worker and await its reply. Message payloads are
+   * structured-cloned across the process boundary; Electron's utilityProcess
+   * has no transfer list for plain buffers (only MessagePortMain), so callers
+   * pass any binary data as ordinary fields.
+   * @param {string} type
+   * @param {object} [args]
+   * @param {number} [timeoutMs]
+   */
+  function request(type, args = {}, timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS) {
+    const proc = spawn();
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (pending.has(id)) {
+          pending.delete(id);
+          reject(new Error(`engine request '${type}' timed out`));
+        }
+      }, timeoutMs);
+      pending.set(id, {
+        resolve: (v) => {
+          clearTimeout(timer);
+          resolve(v);
+        },
+        reject: (e) => {
+          clearTimeout(timer);
+          reject(e);
+        },
+      });
+      proc.postMessage({ id, type, ...args });
+    });
+  }
+
+  function stop() {
+    if (child) {
+      try {
+        child.kill();
+      } catch {
+        // already gone
+      }
+      child = null;
+    }
+  }
+
+  return { request, stop, onExit };
 }
 
-module.exports = { request, stop, onExit };
+module.exports = { createHost };

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -7,7 +7,16 @@ const { app } = require("electron");
 
 const registry = require("./registry");
 const manager = require("./model-manager");
-const host = require("./host");
+const hostModule = require("./host");
+
+// STT and cleanup each get their own worker process so they run in parallel and
+// a crash in one engine can't take down the other. Each host lazily forks its
+// worker on the first request, so a user who only ever transcribes (no cleanup)
+// never spawns the cleanup worker, and vice versa. Unit tests stub `./host` with
+// a `createHost`-shaped fake (see test/engines.test.js), so there's a single
+// host-construction path here.
+const sttHost = hostModule.createHost({ serviceName: "earheart-stt" });
+const cleanupHost = hostModule.createHost({ serviceName: "earheart-cleanup" });
 
 function modelsDir() {
   return path.join(app.getPath("userData"), "models");
@@ -45,7 +54,7 @@ async function ensureStt(modelId) {
     throw new Error(`STT model "${modelId}" is not downloaded yet`);
   }
   if (loadedStt !== modelId) {
-    await host.request("load-stt", {
+    await sttHost.request("load-stt", {
       dir: manager.modelDir(modelsDir(), model),
       sherpa: model.sherpa,
       modelId,
@@ -69,7 +78,7 @@ async function transcribe(wav, cfg, signal) {
   // is structured-cloned across. A few seconds of PCM16 is small enough that
   // the one extra copy is negligible.
   const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
-  const text = await host.request("transcribe", {
+  const text = await sttHost.request("transcribe", {
     wav: ab,
     language: cfg.language || "",
   });
@@ -88,7 +97,7 @@ async function ensureCleanup(modelId) {
     throw new Error(`Cleanup model "${modelId}" is not downloaded yet`);
   }
   if (loadedCleanup !== modelId) {
-    await host.request("load-cleanup", {
+    await cleanupHost.request("load-cleanup", {
       modelPath: path.join(manager.modelDir(modelsDir(), model), model.gguf.file),
     });
     loadedCleanup = modelId;
@@ -99,7 +108,7 @@ async function ensureCleanup(modelId) {
 async function clean(transcript, cfg, signal) {
   if (signal?.aborted) throw new Error("aborted");
   await ensureCleanup(cfg.builtin.model);
-  const cleaned = await host.request("clean", {
+  const cleaned = await cleanupHost.request("clean", {
     transcript,
     systemPrompt: cfg.systemPrompt,
     temperature: cfg.temperature,
@@ -108,40 +117,52 @@ async function clean(transcript, cfg, signal) {
   return cleaned && cleaned.trim().length > 0 ? cleaned : transcript;
 }
 
-// Forget which models the worker had resident, so the next call re-runs
+// Forget which models a worker had resident, so the next call re-runs
 // ensureStt/ensureCleanup instead of assuming a model is still loaded.
-function forgetLoaded() {
+function forgetStt() {
   loadedStt = null;
+}
+
+function forgetCleanup() {
   loadedCleanup = null;
 }
 
 function stop() {
-  forgetLoaded();
-  host.stop();
+  forgetStt();
+  forgetCleanup();
+  sttHost.stop();
+  cleanupHost.stop();
 }
 
-// Release the loaded models without killing the worker, leaving it ready for a
-// fast re-load; the next transcribe/clean call re-runs ensureStt/ensureCleanup.
+// Release the loaded models without killing the workers, leaving them ready for
+// a fast re-load; the next transcribe/clean call re-runs ensureStt/ensureCleanup.
 // The cleanup engine frees its memory promptly via dispose(); the STT engine
 // has no explicit free, so its memory is reclaimed by GC rather than at once.
-// No-op if the worker has already exited (nothing is loaded).
+// Each worker is unloaded independently and only if it had a model resident.
 async function unloadIdle() {
-  if (loadedStt === null && loadedCleanup === null) return;
-  forgetLoaded();
+  const jobs = [];
+  if (loadedStt !== null) {
+    forgetStt();
+    jobs.push(sttHost.request("unload-stt"));
+  }
+  if (loadedCleanup !== null) {
+    forgetCleanup();
+    jobs.push(cleanupHost.request("unload-cleanup"));
+  }
+  if (jobs.length === 0) return;
   try {
-    await Promise.all([
-      host.request("unload-stt"),
-      host.request("unload-cleanup"),
-    ]);
+    await Promise.all(jobs);
   } catch {
-    // Worker may have exited; the flags are already cleared either way.
+    // A worker may have exited; the flags are already cleared either way.
   }
 }
 
-// If the worker dies (native crash, or our own stop()), it comes back empty.
+// If a worker dies (native crash, or our own stop()), it comes back empty.
 // Forget what we thought it had loaded so the next call re-loads the model
-// instead of sending inference to a worker that has no model resident.
-host.onExit(forgetLoaded);
+// instead of sending inference to a worker that has no model resident. Each
+// host's exit only affects its own engine's loaded-state.
+sttHost.onExit(forgetStt);
+cleanupHost.onExit(forgetCleanup);
 
 module.exports = {
   modelsDir,

--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -1,0 +1,132 @@
+// Live preview: while recording, transcribe the audio captured so far and push
+// the partial transcript to the overlay, with cleanup running over the *full*
+// raw text on speech pauses. This is the second, side-channel state machine of a
+// dictation — separate from the pipeline's authoritative record→transcribe→clean
+// →deliver flow — so it lives in its own module and the pipeline just wires it.
+//
+// STT and cleanup live in separate engine workers, so partial STT and partial
+// cleanup run in parallel with each other. Within each worker, requests are
+// serialized (one model, one inference at a time), so we use a drop-if-busy flag
+// per stage to keep partials from queueing up behind real time.
+//
+// One thing the worker split does NOT buy us: partial STT and the pipeline's
+// *final* transcribe share the same STT worker, and a worker request already
+// dispatched isn't cancellable mid-inference. So if the user stops while a
+// partial decode is in flight, the final transcribe waits for that partial to
+// finish (a brief delay, bounded by one partial decode). cancel() prevents *new*
+// partial work from starting but can't reclaim a decode already running.
+//
+// All of this is best-effort and silent: a dropped or failed partial is cosmetic
+// and must never disturb the dictation.
+//
+// Dependencies are injected so the module stays free of the pipeline's private
+// session/state and is unit-testable:
+//   runTranscribe(wav, cfg.stt, signal) -> Promise<string>
+//   runCleanup(raw, cfg.cleanup, signal) -> Promise<string>
+//   sendToOverlay(channel, payload)
+//   getSettings() -> settings object
+//   isCurrent(sid) -> true iff sid is the active, still-recording session
+function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettings, isCurrent }) {
+  let sttBusy = false;
+  let cleanupBusy = false;
+  let abort = null; // aborts in-flight partial work when recording ends
+  let lastRaw = ""; // most recent raw transcript shown
+  let lastCleanedRaw = ""; // raw text the last cleanup pass ran on
+  let pauseTimer = null; // fires a cleanup pass once the raw text goes quiet
+
+  function cancel() {
+    if (abort) {
+      abort.abort();
+      abort = null;
+    }
+    if (pauseTimer) {
+      clearTimeout(pauseTimer);
+      pauseTimer = null;
+    }
+    sttBusy = false;
+    cleanupBusy = false;
+    lastRaw = "";
+    lastCleanedRaw = "";
+  }
+
+  // A partial is stale the moment its session ends, recording stops, or its work
+  // is aborted — any of which means the result must be dropped, not shown.
+  function stale(sid, signal) {
+    return !isCurrent(sid) || signal.aborted;
+  }
+
+  async function handleAudio(sid, wavArrayBuffer) {
+    // Only the active recording session may produce partials, and only when the
+    // STT engine is in-process — re-checked here (not just at record:start)
+    // because settings are live: switching to the HTTP engine mid-dictation must
+    // not start POSTing partial WAVs to a remote endpoint.
+    if (!isCurrent(sid)) return;
+    if (sttBusy) return; // drop-if-busy: keep up with the latest audio only
+    const cfg = getSettings();
+    if (cfg.stt.engine !== "builtin") return;
+    if (!abort) abort = new AbortController();
+    const { signal } = abort;
+    sttBusy = true;
+    try {
+      const wav = Buffer.from(wavArrayBuffer);
+      const raw = await runTranscribe(wav, cfg.stt, signal);
+      // The session may have ended (stop/cancel) while we were decoding.
+      if (stale(sid, signal)) return;
+      const text = (raw || "").trim();
+      if (!text || text === lastRaw) return;
+      lastRaw = text;
+      sendToOverlay("pipeline:partial", { kind: "raw", text });
+      scheduleCleanup(sid, cfg, signal);
+    } catch {
+      // Cosmetic: ignore failed partials entirely.
+    } finally {
+      sttBusy = false;
+    }
+  }
+
+  // Run cleanup once the raw text has been stable for the configured pause. We
+  // clean the *whole* raw transcript (not the new segment): a long pause is not a
+  // sentence boundary, so segmenting would corrupt punctuation across pauses, and
+  // re-cleaning a stable prefix is idempotent enough to keep the cleaned line calm.
+  function scheduleCleanup(sid, cfg, signal) {
+    // Only clean live when both cleanup is on and it runs in-process: a remote
+    // cleanup endpoint shouldn't be hit repeatedly mid-dictation. The final pass
+    // still cleans on stop regardless of engine.
+    if (!cfg.cleanup.enabled || cfg.cleanup.engine !== "builtin") return;
+    if (pauseTimer) clearTimeout(pauseTimer);
+    const pauseMs = cfg.stt.livePreview?.cleanupPauseMs || 1000;
+    pauseTimer = setTimeout(() => {
+      pauseTimer = null;
+      runCleanupPass(sid, cfg, signal);
+    }, pauseMs);
+  }
+
+  async function runCleanupPass(sid, cfg, signal) {
+    if (stale(sid, signal)) return;
+    if (cleanupBusy) return; // drop-if-busy
+    const raw = lastRaw;
+    if (!raw || raw === lastCleanedRaw) return; // nothing new to clean
+    cleanupBusy = true;
+    lastCleanedRaw = raw;
+    try {
+      const cleaned = await runCleanup(raw, cfg.cleanup, signal);
+      if (stale(sid, signal)) return;
+      const text = (cleaned || "").trim();
+      if (text) sendToOverlay("pipeline:partial", { kind: "cleaned", text });
+    } catch {
+      // Cosmetic: a failed partial cleanup just leaves the raw tail showing.
+    } finally {
+      cleanupBusy = false;
+      // The raw text may have grown while we were cleaning; if so, clean again
+      // after the next pause. Bail if the work was aborted (cancel ran during the
+      // await) so a cancelled cleanup can't re-arm pauseTimer.
+      if (!signal.aborted && lastRaw !== lastCleanedRaw && isCurrent(sid)) {
+        scheduleCleanup(sid, cfg, signal);
+      }
+    }
+  }
+
+  return { handleAudio, cancel };
+}
+
+module.exports = { createLivePreview };

--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -1,20 +1,30 @@
-// Live preview: while recording, transcribe the audio captured so far and push
-// the partial transcript to the overlay, with cleanup running over the *full*
-// raw text on speech pauses. This is the second, side-channel state machine of a
+// Live preview: while recording, transcribe the audio and push a partial
+// transcript to the overlay. This is the second, side-channel state machine of a
 // dictation — separate from the pipeline's authoritative record→transcribe→clean
 // →deliver flow — so it lives in its own module and the pipeline just wires it.
 //
+// Append-only chunking (the key to flat cost): the overlay ships audio in
+// chunks. Each tick it sends the CURRENT in-progress chunk (the audio recorded
+// since the last committed boundary); when that chunk reaches its length it's
+// sent once more marked `final`. We re-decode only the in-progress chunk, so
+// decode cost is bounded by the chunk length (~5s) no matter how long the
+// dictation runs — instead of re-decoding the whole growing buffer every tick
+// (which was O(n²) and ground the app to a halt after ~30s). On `final` we append
+// the chunk's text to the committed transcript and never touch that audio again.
+//
+// Raw shown = committedRaw + the live (in-progress) chunk's text.
+// Cleanup is likewise incremental: when a chunk commits, only its new text is
+// cleaned and appended to the committed cleaned line — never the whole transcript.
+//
 // STT and cleanup live in separate engine workers, so partial STT and partial
-// cleanup run in parallel with each other. Within each worker, requests are
-// serialized (one model, one inference at a time), so we use a drop-if-busy flag
-// per stage to keep partials from queueing up behind real time.
+// cleanup run in parallel. Within each worker requests are serialized, so a
+// drop-if-busy flag per stage keeps partials from queueing up behind real time.
 //
 // One thing the worker split does NOT buy us: partial STT and the pipeline's
-// *final* transcribe share the same STT worker, and a worker request already
-// dispatched isn't cancellable mid-inference. So if the user stops while a
-// partial decode is in flight, the final transcribe waits for that partial to
-// finish (a brief delay, bounded by one partial decode). cancel() prevents *new*
-// partial work from starting but can't reclaim a decode already running.
+// *final* transcribe share the same STT worker, and a dispatched worker request
+// isn't cancellable mid-inference. So if the user stops while a partial decode is
+// in flight, the final transcribe waits for it to finish (bounded by one chunk's
+// decode — now small). cancel() prevents *new* partial work from starting.
 //
 // All of this is best-effort and silent: a dropped or failed partial is cosmetic
 // and must never disturb the dictation.
@@ -26,13 +36,32 @@
 //   sendToOverlay(channel, payload)
 //   getSettings() -> settings object
 //   isCurrent(sid) -> true iff sid is the active, still-recording session
+function joinText(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  return `${a} ${b}`;
+}
+
 function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettings, isCurrent }) {
   let sttBusy = false;
   let cleanupBusy = false;
   let abort = null; // aborts in-flight partial work when recording ends
-  let lastRaw = ""; // most recent raw transcript shown
-  let lastCleanedRaw = ""; // raw text the last cleanup pass ran on
-  let pauseTimer = null; // fires a cleanup pass once the raw text goes quiet
+
+  // Append-only accumulators.
+  let committedRaw = ""; // text from finalized chunks (never re-decoded)
+  let committedClean = ""; // cleaned text from finalized chunks
+  let liveRaw = ""; // decode of the current in-progress chunk (replaced each tick)
+  let pendingClean = ""; // committed raw not yet reflected in committedClean
+  let lastSeq = -1; // highest chunk seq we've committed
+  let pauseTimer = null; // fires a cleanup pass once a chunk has committed + settled
+
+  function reset() {
+    committedRaw = "";
+    committedClean = "";
+    liveRaw = "";
+    pendingClean = "";
+    lastSeq = -1;
+  }
 
   function cancel() {
     if (abort) {
@@ -45,8 +74,7 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
     }
     sttBusy = false;
     cleanupBusy = false;
-    lastRaw = "";
-    lastCleanedRaw = "";
+    reset();
   }
 
   // A partial is stale the moment its session ends, recording stops, or its work
@@ -55,11 +83,14 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
     return !isCurrent(sid) || signal.aborted;
   }
 
-  async function handleAudio(sid, wavArrayBuffer) {
-    // Only the active recording session may produce partials, and only when the
-    // STT engine is in-process — re-checked here (not just at record:start)
-    // because settings are live: switching to the HTTP engine mid-dictation must
-    // not start POSTing partial WAVs to a remote endpoint.
+  function pushRaw() {
+    sendToOverlay("pipeline:partial", { kind: "raw", text: joinText(committedRaw, liveRaw) });
+  }
+
+  // Handle one chunk's audio. `seq` identifies the chunk; `final` means this is
+  // the last send of that chunk (commit it). A growing in-progress chunk arrives
+  // as repeated non-final sends with the same seq.
+  async function handleAudio(sid, { seq, final, wav: wavArrayBuffer } = {}) {
     if (!isCurrent(sid)) return;
     if (sttBusy) return; // drop-if-busy: keep up with the latest audio only
     const cfg = getSettings();
@@ -70,28 +101,37 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
     try {
       const wav = Buffer.from(wavArrayBuffer);
       const raw = await runTranscribe(wav, cfg.stt, signal);
-      // The session may have ended (stop/cancel) while we were decoding.
       if (stale(sid, signal)) return;
       const text = (raw || "").trim();
-      if (!text || text === lastRaw) return;
-      lastRaw = text;
-      sendToOverlay("pipeline:partial", { kind: "raw", text });
-      scheduleCleanup(sid, cfg, signal);
+
+      if (final && seq > lastSeq) {
+        // Freeze this chunk into the committed transcript and start fresh.
+        lastSeq = seq;
+        committedRaw = joinText(committedRaw, text);
+        liveRaw = "";
+        pendingClean = joinText(pendingClean, text);
+        pushRaw();
+        scheduleCleanup(sid, cfg, signal);
+      } else {
+        // In-progress chunk: replace the live tail.
+        if (text === liveRaw) return;
+        liveRaw = text;
+        pushRaw();
+      }
     } catch {
-      // Cosmetic: ignore failed partials entirely.
+      // Cosmetic: ignore failed partials entirely; the final pass is authoritative.
     } finally {
       sttBusy = false;
     }
   }
 
-  // Run cleanup once the raw text has been stable for the configured pause. We
-  // clean the *whole* raw transcript (not the new segment): a long pause is not a
-  // sentence boundary, so segmenting would corrupt punctuation across pauses, and
-  // re-cleaning a stable prefix is idempotent enough to keep the cleaned line calm.
+  // After a chunk commits and the dictation settles for the pause window, clean
+  // ONLY the newly committed text (pendingClean) and append it to the cleaned
+  // line. Flat cost — we never re-clean the whole transcript.
   function scheduleCleanup(sid, cfg, signal) {
-    // Only clean live when both cleanup is on and it runs in-process: a remote
-    // cleanup endpoint shouldn't be hit repeatedly mid-dictation. The final pass
-    // still cleans on stop regardless of engine.
+    // Only clean live when cleanup is on and runs in-process: a remote cleanup
+    // endpoint shouldn't be hit repeatedly mid-dictation. The final pass on stop
+    // still cleans the whole authoritative transcript regardless of engine.
     if (!cfg.cleanup.enabled || cfg.cleanup.engine !== "builtin") return;
     if (pauseTimer) clearTimeout(pauseTimer);
     const pauseMs = cfg.stt.livePreview?.cleanupPauseMs || 1000;
@@ -104,23 +144,31 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
   async function runCleanupPass(sid, cfg, signal) {
     if (stale(sid, signal)) return;
     if (cleanupBusy) return; // drop-if-busy
-    const raw = lastRaw;
-    if (!raw || raw === lastCleanedRaw) return; // nothing new to clean
+    const toClean = pendingClean.trim();
+    if (!toClean) return; // nothing new committed to clean
     cleanupBusy = true;
-    lastCleanedRaw = raw;
+    pendingClean = "";
     try {
-      const cleaned = await runCleanup(raw, cfg.cleanup, signal);
-      if (stale(sid, signal)) return;
+      const cleaned = await runCleanup(toClean, cfg.cleanup, signal);
+      if (stale(sid, signal)) {
+        // Put the text back so a later (non-stale) pass still cleans it.
+        pendingClean = joinText(toClean, pendingClean);
+        return;
+      }
       const text = (cleaned || "").trim();
-      if (text) sendToOverlay("pipeline:partial", { kind: "cleaned", text });
+      if (text) {
+        committedClean = joinText(committedClean, text);
+        sendToOverlay("pipeline:partial", { kind: "cleaned", text: committedClean });
+      }
     } catch {
       // Cosmetic: a failed partial cleanup just leaves the raw tail showing.
+      // Restore the pending text so the next pass retries it.
+      pendingClean = joinText(toClean, pendingClean);
     } finally {
       cleanupBusy = false;
-      // The raw text may have grown while we were cleaning; if so, clean again
-      // after the next pause. Bail if the work was aborted (cancel ran during the
-      // await) so a cancelled cleanup can't re-arm pauseTimer.
-      if (!signal.aborted && lastRaw !== lastCleanedRaw && isCurrent(sid)) {
+      // More may have committed while we were cleaning; if so, clean it after the
+      // next pause. Bail if aborted so a cancelled cleanup can't re-arm pauseTimer.
+      if (!signal.aborted && pendingClean.trim() && isCurrent(sid)) {
         scheduleCleanup(sid, cfg, signal);
       }
     }

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -40,6 +40,19 @@ let session = 0; // current dictation session id
 let abortController = null;
 const stateListeners = new Set();
 
+// Live preview (the streaming partial transcript shown while recording) lives in
+// its own module; the pipeline just feeds it audio and cancels it at the right
+// lifecycle points. Dependencies are injected so it stays free of our private
+// session/state — `isCurrent(sid)` is the single source of truth for "this sid
+// is still the active recording".
+const livePreview = createLivePreview({
+  runTranscribe,
+  runCleanup,
+  sendToOverlay: windows.sendToOverlay,
+  getSettings: settings.get,
+  isCurrent: (sid) => sid === session && state === "recording",
+});
+
 // Idle eviction: after a dictation finishes, wait the configured idle window
 // and then unload the built-in models to reclaim memory. Any new dictation
 // cancels the pending timer (and re-arms it when done), so the models stay
@@ -149,19 +162,6 @@ function cancel() {
   setState("idle");
   windows.hideOverlay();
 }
-
-// Live preview (the streaming partial transcript shown while recording) lives in
-// its own module; the pipeline just feeds it audio and cancels it at the right
-// lifecycle points. Dependencies are injected so it stays free of our private
-// session/state — `isCurrent(sid)` is the single source of truth for "this sid
-// is still the active recording".
-const livePreview = createLivePreview({
-  runTranscribe,
-  runCleanup,
-  sendToOverlay: windows.sendToOverlay,
-  getSettings: settings.get,
-  isCurrent: (sid) => sid === session && state === "recording",
-});
 
 async function process(sid, wavArrayBuffer) {
   // The final pass is authoritative; stop any partial work so it doesn't

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -238,8 +238,8 @@ function init() {
     process(sid, wav);
   });
 
-  ipcMain.on("audio:partial", (event, { sid, wav } = {}) => {
-    livePreview.handleAudio(sid, wav);
+  ipcMain.on("audio:partial", (event, { sid, seq, final, wav } = {}) => {
+    livePreview.handleAudio(sid, { seq, final, wav });
   });
 
   ipcMain.on("record:cancelled", (event, { sid } = {}) => {

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -20,6 +20,7 @@ const cleanup = require("./services/cleanup");
 const engines = require("./engines");
 const { deliver } = require("./output/deliver");
 const history = require("./history");
+const { createLivePreview } = require("./live-preview");
 
 // Route a stage to the in-process engine or the HTTP client based on settings.
 // Both backends take the same (payload, cfg, signal) shape, so the only
@@ -114,6 +115,13 @@ function startRecording() {
       sid,
       deviceId: cfg.audio.deviceId,
       maxSeconds: cfg.audio.maxRecordingSeconds,
+      // Live preview only runs on the builtin engine (the HTTP path would be
+      // hammered with repeated full-file uploads). The overlay gates on
+      // `enabled`; we also gate on the engine here.
+      livePreview:
+        cfg.stt.engine === "builtin" && cfg.stt.livePreview?.enabled
+          ? cfg.stt.livePreview
+          : { enabled: false },
     });
   };
   // The overlay may still be loading right after launch (or after a renderer
@@ -132,6 +140,7 @@ function stopRecording() {
 
 function cancel() {
   session++; // invalidate in-flight session events
+  livePreview.cancel();
   if (state === "recording") {
     windows.sendToOverlay("record:cancel");
   } else if (state === "processing" && abortController) {
@@ -141,7 +150,24 @@ function cancel() {
   windows.hideOverlay();
 }
 
+// Live preview (the streaming partial transcript shown while recording) lives in
+// its own module; the pipeline just feeds it audio and cancels it at the right
+// lifecycle points. Dependencies are injected so it stays free of our private
+// session/state — `isCurrent(sid)` is the single source of truth for "this sid
+// is still the active recording".
+const livePreview = createLivePreview({
+  runTranscribe,
+  runCleanup,
+  sendToOverlay: windows.sendToOverlay,
+  getSettings: settings.get,
+  isCurrent: (sid) => sid === session && state === "recording",
+});
+
 async function process(sid, wavArrayBuffer) {
+  // The final pass is authoritative; stop any partial work so it doesn't
+  // contend with the real transcribe/clean on the engine workers.
+  livePreview.cancel();
+
   const cfg = settings.get();
   setState("processing");
   const controller = new AbortController();
@@ -212,14 +238,20 @@ function init() {
     process(sid, wav);
   });
 
+  ipcMain.on("audio:partial", (event, { sid, wav } = {}) => {
+    livePreview.handleAudio(sid, wav);
+  });
+
   ipcMain.on("record:cancelled", (event, { sid } = {}) => {
     if (sid !== session) return;
+    livePreview.cancel();
     if (state === "recording") setState("idle");
     windows.hideOverlay();
   });
 
   ipcMain.on("record:error", (event, { sid, message } = {}) => {
     if (sid !== session) return;
+    livePreview.cancel();
     if (state === "recording") setState("idle");
     overlayStatus("error", { message });
     hideOverlaySoon(sid, 5000);

--- a/main/settings.js
+++ b/main/settings.js
@@ -53,17 +53,18 @@ const DEFAULTS = {
     // recording, so it is exposed as a toggle.
     livePreview: {
       enabled: true,
-      // How often (ms) the overlay re-encodes the buffer and asks for a fresh
+      // How often (ms) the overlay ships the in-progress audio chunk for a fresh
       // partial transcript. Lower = snappier, but more CPU.
       intervalMs: 1200,
-      // Stop issuing partials once the recording passes this many seconds: the
-      // offline recognizer re-decodes the whole buffer each tick, so cost grows
-      // with length. 0 = no cap.
-      maxSeconds: 30,
-      // After the raw partial has been stable (unchanged) for this long, run a
-      // cleanup pass over the full raw transcript and show the cleaned line. A
-      // pause, not a sentence boundary — see the pipeline for why it cleans the
-      // whole text rather than per-segment.
+      // Transcription is append-only and chunked: every `chunkSeconds` of audio
+      // is frozen into a committed chunk, transcribed once, and accumulated. Only
+      // the current in-progress chunk is re-decoded each tick, so decode cost
+      // stays flat (~this many seconds of audio) no matter how long you talk,
+      // instead of growing with the whole buffer.
+      chunkSeconds: 5,
+      // After the in-progress chunk has been stable (unchanged) for this long,
+      // clean the newly committed text and append it to the cleaned line. Only
+      // the new text is cleaned, so cleanup cost is flat too.
       cleanupPauseMs: 1000,
     },
   },

--- a/main/settings.js
+++ b/main/settings.js
@@ -46,6 +46,26 @@ const DEFAULTS = {
     model: "parakeet",
     language: "",
     timeoutMs: 120000,
+    // Live preview: while recording, re-transcribe the audio captured so far on
+    // a short interval and show the provisional text in the overlay (with a
+    // cleaned line filling in behind it on pauses). Purely additive — the final
+    // transcribe/clean/deliver on stop is unchanged. Adds steady CPU load while
+    // recording, so it is exposed as a toggle.
+    livePreview: {
+      enabled: true,
+      // How often (ms) the overlay re-encodes the buffer and asks for a fresh
+      // partial transcript. Lower = snappier, but more CPU.
+      intervalMs: 1200,
+      // Stop issuing partials once the recording passes this many seconds: the
+      // offline recognizer re-decodes the whole buffer each tick, so cost grows
+      // with length. 0 = no cap.
+      maxSeconds: 30,
+      // After the raw partial has been stable (unchanged) for this long, run a
+      // cleanup pass over the full raw transcript and show the cleaned line. A
+      // pause, not a sentence boundary — see the pipeline for why it cleans the
+      // whole text rather than per-segment.
+      cleanupPauseMs: 1000,
+    },
   },
   cleanup: {
     // On by default now that cleanup can run in-process with no setup.

--- a/main/windows.js
+++ b/main/windows.js
@@ -86,9 +86,12 @@ ipcMain.on("overlay:resize", (event, { height } = {}) => {
   const [w, h] = win.getSize();
   if (target === h) return;
   const [winX, winY] = win.getPosition();
-  // Keep the bottom edge fixed: the top moves up as the window grows.
+  // Keep the bottom edge fixed: the top moves up as the window grows. If that
+  // pushes the top above the work area (a tall transcript near the top of the
+  // screen), floor it at the work-area top so the transcript isn't clipped.
   const bottom = winY + h;
-  const nextY = bottom - target;
+  const { workArea } = screen.getDisplayNearestPoint({ x: winX, y: winY });
+  const nextY = Math.max(workArea.y, bottom - target);
   win.setBounds({ x: winX, y: nextY, width: w, height: target });
 });
 

--- a/main/windows.js
+++ b/main/windows.js
@@ -8,11 +8,8 @@ const PRELOAD = path.join(__dirname, "..", "preload.js");
 const RENDERER = path.join(__dirname, "..", "renderer");
 
 const OVERLAY_WIDTH = 360;
-const OVERLAY_HEIGHT = 80;
-// Ceiling the live transcript can grow the overlay to (the CSS also caps the
-// transcript panel at max-height 132px; this is the hard window bound).
-const OVERLAY_MAX_HEIGHT = 600;
-// Matches the pill's fade-out transition in overlay.css.
+const OVERLAY_HEIGHT = 80; // base card: 56px control row + 12px margin top/bottom
+// Matches the card's fade-out transition in overlay.css.
 const OVERLAY_FADE_MS = 200;
 
 let overlayWindow = null;
@@ -82,15 +79,18 @@ ipcMain.on("overlay:drag", (event, { x, y } = {}) => {
 ipcMain.on("overlay:resize", (event, { height } = {}) => {
   const win = getOverlay();
   if (!win || typeof height !== "number") return;
-  const target = Math.max(OVERLAY_HEIGHT, Math.min(Math.round(height), OVERLAY_MAX_HEIGHT));
   const [w, h] = win.getSize();
-  if (target === h) return;
   const [winX, winY] = win.getPosition();
+  const { workArea } = screen.getDisplayNearestPoint({ x: winX, y: winY });
+  // Grow freely, but never taller than the work area leaves room for (with a
+  // small bottom gap) — a runaway transcript shouldn't fill the whole screen.
+  const cap = Math.max(OVERLAY_HEIGHT, workArea.height - 48);
+  const target = Math.max(OVERLAY_HEIGHT, Math.min(Math.round(height), cap));
+  if (target === h) return;
   // Keep the bottom edge fixed: the top moves up as the window grows. If that
   // pushes the top above the work area (a tall transcript near the top of the
   // screen), floor it at the work-area top so the transcript isn't clipped.
   const bottom = winY + h;
-  const { workArea } = screen.getDisplayNearestPoint({ x: winX, y: winY });
   const nextY = Math.max(workArea.y, bottom - target);
   win.setBounds({ x: winX, y: nextY, width: w, height: target });
 });
@@ -106,7 +106,10 @@ function createOverlay() {
     show: false,
     frame: false,
     transparent: true,
-    resizable: false,
+    // Must be resizable so the live transcript can grow the window via setBounds:
+    // macOS ignores programmatic height changes on a non-resizable window. The
+    // window is frameless, so there are no user-facing resize handles anyway.
+    resizable: true,
     movable: false,
     minimizable: false,
     maximizable: false,

--- a/main/windows.js
+++ b/main/windows.js
@@ -9,6 +9,9 @@ const RENDERER = path.join(__dirname, "..", "renderer");
 
 const OVERLAY_WIDTH = 360;
 const OVERLAY_HEIGHT = 80;
+// Ceiling the live transcript can grow the overlay to (the CSS also caps the
+// transcript panel at max-height 132px; this is the hard window bound).
+const OVERLAY_MAX_HEIGHT = 600;
 // Matches the pill's fade-out transition in overlay.css.
 const OVERLAY_FADE_MS = 200;
 
@@ -19,11 +22,15 @@ let overlayCustomPosition = null; // set when the user drags the pill
 let overlayDragOrigin = null; // { winX, winY, pointerX, pointerY }
 let overlayHideTimer = null;
 
-function clampToWorkArea(x, y) {
+// Clamp a top-left position so the window stays on-screen. The height matters
+// for the bottom bound: a transcript-grown overlay is taller than OVERLAY_HEIGHT,
+// so pass its actual height (defaulting to the base pill height) or the window's
+// bottom edge can be dragged off the work area.
+function clampToWorkArea(x, y, height = OVERLAY_HEIGHT) {
   const { workArea } = screen.getDisplayNearestPoint({ x, y });
   return {
     x: Math.min(Math.max(x, workArea.x), workArea.x + workArea.width - OVERLAY_WIDTH),
-    y: Math.min(Math.max(y, workArea.y), workArea.y + workArea.height - OVERLAY_HEIGHT),
+    y: Math.min(Math.max(y, workArea.y), workArea.y + workArea.height - height),
   };
 }
 
@@ -53,12 +60,36 @@ ipcMain.on("overlay:drag", (event, { x, y } = {}) => {
   const win = getOverlay();
   if (!win || !overlayDragOrigin) return;
   if (typeof x !== "number" || typeof y !== "number") return;
+  const [, h] = win.getSize();
   const next = clampToWorkArea(
     Math.round(overlayDragOrigin.winX + x - overlayDragOrigin.pointerX),
-    Math.round(overlayDragOrigin.winY + y - overlayDragOrigin.pointerY)
+    Math.round(overlayDragOrigin.winY + y - overlayDragOrigin.pointerY),
+    h // a transcript-grown overlay is taller than the base pill height
   );
   win.setPosition(next.x, next.y);
-  overlayCustomPosition = next;
+  // Store the pill's *bottom-anchored* top-left (where a base-height window would
+  // sit), so the next show — which resets to base height — places it correctly
+  // instead of inheriting the grown top.
+  overlayCustomPosition = { x: next.x, y: next.y + h - OVERLAY_HEIGHT };
+});
+
+// The live transcript grows the overlay's content upward (the pill stays pinned
+// to the bottom edge so it doesn't jump). The renderer reports the height its
+// content needs; we resize the window and shift its top up by the delta, then
+// re-clamp so a tall transcript near the top of the screen isn't pushed off.
+// We deliberately do NOT touch overlayCustomPosition here — it tracks the pill's
+// resting (base-height) spot, which the grow-upward must not overwrite.
+ipcMain.on("overlay:resize", (event, { height } = {}) => {
+  const win = getOverlay();
+  if (!win || typeof height !== "number") return;
+  const target = Math.max(OVERLAY_HEIGHT, Math.min(Math.round(height), OVERLAY_MAX_HEIGHT));
+  const [w, h] = win.getSize();
+  if (target === h) return;
+  const [winX, winY] = win.getPosition();
+  // Keep the bottom edge fixed: the top moves up as the window grows.
+  const bottom = winY + h;
+  const nextY = bottom - target;
+  win.setBounds({ x: winX, y: nextY, width: w, height: target });
 });
 
 function createOverlay() {
@@ -127,8 +158,11 @@ function showOverlay() {
     clearTimeout(overlayHideTimer);
     overlayHideTimer = null;
   }
+  // Reset to the base pill size before showing: a previous dictation may have
+  // grown the window for its transcript, and overlayPosition() assumes the base
+  // height. The renderer re-reports its height as the new transcript fills in.
   const { x, y } = overlayPosition();
-  win.setPosition(x, y);
+  win.setBounds({ x, y, width: OVERLAY_WIDTH, height: OVERLAY_HEIGHT });
   win.showInactive();
   win.webContents.send("overlay:show");
 }

--- a/main/windows.js
+++ b/main/windows.js
@@ -8,7 +8,8 @@ const PRELOAD = path.join(__dirname, "..", "preload.js");
 const RENDERER = path.join(__dirname, "..", "renderer");
 
 const OVERLAY_WIDTH = 360;
-const OVERLAY_HEIGHT = 80; // base card: 56px control row + 12px margin top/bottom
+// Base card: grip (~11px) + 56px control row + 12px margin top/bottom.
+const OVERLAY_HEIGHT = 92;
 // Matches the card's fade-out transition in overlay.css.
 const OVERLAY_FADE_MS = 200;
 

--- a/preload.js
+++ b/preload.js
@@ -7,6 +7,7 @@ const LISTEN = new Set([
   "record:stop",
   "record:cancel",
   "pipeline:status",
+  "pipeline:partial",
   "history:changed",
   "overlay:show",
   "overlay:hide",
@@ -15,11 +16,13 @@ const LISTEN = new Set([
 
 const SEND = new Set([
   "audio:captured",
+  "audio:partial",
   "record:cancelled",
   "record:error",
   "pipeline:cancel",
   "overlay:drag-start",
   "overlay:drag",
+  "overlay:resize",
 ]);
 
 const INVOKE = new Set([

--- a/renderer/overlay.css
+++ b/renderer/overlay.css
@@ -17,6 +17,61 @@ body {
   -webkit-app-region: no-drag;
 }
 
+/* The window can grow upward to fit a live transcript above the pill; the pill
+   stays pinned to the bottom so it doesn't jump as the transcript fills in. */
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  height: 100vh;
+}
+
+/* Live transcript panel, above the pill. Two layers on one wrapping line:
+   the cleaned text (prominent) and the still-streaming raw tail (faint). */
+#transcript {
+  margin: 0 12px;
+  padding: 10px 16px;
+  max-height: 132px;
+  overflow: hidden;
+  border-radius: 18px;
+  /* Solid (not translucent) so the faint raw tail's contrast doesn't depend on
+     whatever app shows through behind the overlay. */
+  background: rgb(22, 20, 28);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: #f3f1f7;
+  font-size: 13px;
+  line-height: 1.45;
+  /* Bottom-align the text and clip the top, so the newest words stay visible
+     when the transcript outgrows max-height. */
+  display: flex;
+  align-items: flex-end;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+#transcript > div {
+  width: 100%;
+  max-height: 100%;
+  overflow: hidden;
+  /* When the transcript outgrows max-height the oldest line clips at the top;
+     fade it out instead of guillotining glyphs mid-row. */
+  mask-image: linear-gradient(to bottom, transparent, black 16px);
+  -webkit-mask-image: linear-gradient(to bottom, transparent, black 16px);
+}
+
+#transcript.visible {
+  opacity: 1;
+}
+
+#transcript-clean {
+  font-weight: 500;
+}
+
+#transcript-raw {
+  /* Subordinate to the cleaned line but still readable on the solid panel. */
+  color: rgba(243, 241, 247, 0.65);
+}
+
 #pill {
   display: flex;
   align-items: center;
@@ -55,6 +110,11 @@ body {
   #pill {
     transition: opacity 0.2s ease;
     transform: none;
+  }
+  /* The transcript appears/disappears instantly; the window still grows, but in
+     calm whole-line steps (quantized in overlay.js) rather than easing. */
+  #transcript {
+    transition: none;
   }
 }
 

--- a/renderer/overlay.css
+++ b/renderer/overlay.css
@@ -44,9 +44,13 @@ body {
   /* Hidden until overlay:show, so the window can fade in instead of popping. */
   opacity: 0;
   transform: translateY(8px) scale(0.98);
+  /* The window resizes instantly (native setBounds can't ease); the card eases
+     its own height from old to new inside it, so the transcript slides into the
+     new space rather than popping. overlay.js sets an explicit pixel height. */
   transition:
     opacity 0.2s ease,
-    transform 0.2s ease;
+    transform 0.2s ease,
+    height 0.18s ease;
 }
 
 #card.visible {
@@ -58,14 +62,32 @@ body {
   transition: opacity 0.2s ease; /* no transform easing while dragging */
 }
 
+/* Grip handle: a short centered bar that signifies the card is draggable. The
+   card carries the actual drag, so this is purely a visual affordance. */
+#grip {
+  flex-shrink: 0;
+  width: 32px;
+  height: 4px;
+  margin: 7px auto 0;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.18);
+  transition: background 0.15s ease;
+}
+
+#card:hover #grip {
+  background: rgba(255, 255, 255, 0.3);
+}
+
 /* Live transcript: fills the top of the card and grows freely (no clip, no
    scroll, no mask). Two layers inline: the cleaned text (prominent) and the
    still-streaming raw tail (faint). */
 #transcript {
-  padding: 16px 20px 10px;
-  font-size: 14px;
+  /* Left/right inset matches the control row below so the text column and the
+     controls share one left edge. Smaller top pad because the grip handle above
+     already adds spacing; bottom frames the divider. */
+  padding: 8px 16px 12px;
+  font-size: 15px;
   line-height: 1.5;
-  letter-spacing: 0.1px;
   /* Wrap long words instead of overflowing the card width. */
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -92,7 +114,7 @@ body {
   align-items: center;
   gap: 10px;
   height: 56px;
-  padding: 0 14px 0 18px;
+  padding: 0 16px;
   flex-shrink: 0;
 }
 
@@ -195,6 +217,7 @@ body {
 }
 
 button {
+  position: relative;
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -211,6 +234,15 @@ button {
     transform 0.12s ease;
 }
 
+/* Enlarge the clickable area to ~40px without changing the painted 32px circle,
+   so the tightly-packed controls are easier to hit (and harder to mis-hit). */
+button::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+}
+
 button svg {
   display: block;
 }
@@ -219,9 +251,19 @@ button:active {
   transform: scale(0.92);
 }
 
+/* Keyboard focus ring. The overlay is focusable:false so focus normally never
+   lands here, but this is cheap insurance for AT or a future focusable context. */
+button:focus-visible {
+  outline: 2px solid #f6f4fb;
+  outline-offset: 2px;
+}
+
 #stop {
   background: #ff5470;
   color: #fff;
+  /* An emphasis ring, not elevation — the only box-shadow in the UI. The card
+     deliberately has no drop shadow (soft shadows band/halo on transparent
+     windows), so don't "fix" that by adding one. */
   box-shadow: 0 0 0 3px rgba(255, 84, 112, 0.25);
 }
 
@@ -231,6 +273,9 @@ button:active {
 }
 
 #cancel {
+  /* Extra gap before the destructive cancel (discards the dictation) so it isn't
+     hit by reflex right next to stop. */
+  margin-left: 4px;
   background: rgba(255, 255, 255, 0.08);
   color: #d6d2e0;
 }

--- a/renderer/overlay.css
+++ b/renderer/overlay.css
@@ -17,8 +17,8 @@ body {
   -webkit-app-region: no-drag;
 }
 
-/* The window can grow upward to fit a live transcript above the pill; the pill
-   stays pinned to the bottom so it doesn't jump as the transcript fills in. */
+/* The card is pinned to the bottom of the window; the transcript above the
+   controls grows the card upward so the control row never jumps. */
 body {
   display: flex;
   flex-direction: column;
@@ -26,112 +26,87 @@ body {
   height: 100vh;
 }
 
-/* Live transcript panel, above the pill. Two layers on one wrapping line:
-   the cleaned text (prominent) and the still-streaming raw tail (faint). */
-#transcript {
-  margin: 0 12px;
-  padding: 10px 16px;
-  max-height: 132px;
-  overflow: hidden;
-  border-radius: 18px;
-  /* Solid (not translucent) so the faint raw tail's contrast doesn't depend on
-     whatever app shows through behind the overlay. */
-  background: rgb(22, 20, 28);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  color: #f3f1f7;
-  font-size: 13px;
-  line-height: 1.45;
-  /* Bottom-align the text and clip the top, so the newest words stay visible
-     when the transcript outgrows max-height. */
+/* One unified card holding the transcript (top) and controls (bottom). */
+#card {
   display: flex;
-  align-items: flex-end;
-  opacity: 0;
-  transition: opacity 0.2s ease;
-}
-
-#transcript > div {
-  width: 100%;
-  max-height: 100%;
-  overflow: hidden;
-  /* When the transcript outgrows max-height the oldest line clips at the top;
-     fade it out instead of guillotining glyphs mid-row. */
-  mask-image: linear-gradient(to bottom, transparent, black 16px);
-  -webkit-mask-image: linear-gradient(to bottom, transparent, black 16px);
-}
-
-#transcript.visible {
-  opacity: 1;
-}
-
-#transcript-clean {
-  font-weight: 500;
-}
-
-#transcript-raw {
-  /* Subordinate to the cleaned line but still readable on the solid panel. */
-  color: rgba(243, 241, 247, 0.65);
-}
-
-#pill {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  height: 56px;
+  flex-direction: column;
   margin: 12px;
-  padding: 0 14px 0 16px;
-  border-radius: 28px;
-  background: rgba(22, 20, 28, 0.88);
-  /* No drop shadow: soft shadows band/halo badly on transparent windows.
-     The border alone separates the pill from whatever is behind it. */
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 22px;
+  /* Solid (not translucent) so the faint raw tail's contrast doesn't depend on
+     whatever app shows through behind the overlay, and so text never sits over a
+     see-through edge. */
+  background: rgb(24, 22, 30);
+  border: 1px solid rgba(255, 255, 255, 0.16);
   color: #f3f1f7;
-  /* The pill body is the drag handle; a move cursor signals it can be dragged.
-     Buttons reset this to a pointer below so they don't read as draggable. */
+  /* The card body is the drag handle; buttons reset this to a pointer below. */
   cursor: move;
-  /* Hidden until the main process sends overlay:show, so the window can
-     fade in instead of popping. */
+  overflow: hidden; /* keep children inside the rounded corners */
+  /* Hidden until overlay:show, so the window can fade in instead of popping. */
   opacity: 0;
-  transform: translateY(8px) scale(0.97);
+  transform: translateY(8px) scale(0.98);
   transition:
     opacity 0.2s ease,
     transform 0.2s ease;
 }
 
-#pill.visible {
+#card.visible {
   opacity: 1;
   transform: none;
 }
 
-#pill.dragging {
+#card.dragging {
   transition: opacity 0.2s ease; /* no transform easing while dragging */
 }
 
+/* Live transcript: fills the top of the card and grows freely (no clip, no
+   scroll, no mask). Two layers inline: the cleaned text (prominent) and the
+   still-streaming raw tail (faint). */
+#transcript {
+  padding: 16px 20px 10px;
+  font-size: 14px;
+  line-height: 1.5;
+  letter-spacing: 0.1px;
+  /* Wrap long words instead of overflowing the card width. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+#transcript[hidden] {
+  display: none;
+}
+
+#transcript-clean {
+  font-weight: 500;
+  color: #f6f4fb;
+}
+
+#transcript-raw {
+  /* Subordinate to the cleaned line but still readable on the solid card. */
+  color: rgba(243, 241, 247, 0.62);
+}
+
+/* Control row: meter, status, timer, buttons. The pill's old chrome, now the
+   bottom strip of the card. */
+#controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: 56px;
+  padding: 0 14px 0 18px;
+  flex-shrink: 0;
+}
+
+/* A subtle top divider only when the transcript is showing above the controls;
+   when the card is controls-only there's nothing to divide from. */
+#card[data-transcript] #controls {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
 @media (prefers-reduced-motion: reduce) {
-  #pill {
+  #card {
     transition: opacity 0.2s ease;
     transform: none;
   }
-  /* The transcript appears/disappears instantly; the window still grows, but in
-     calm whole-line steps (quantized in overlay.js) rather than easing. */
-  #transcript {
-    transition: none;
-  }
-}
-
-/* Visible drag affordance: the OS often ignores the CSS cursor on a
-   focusable:false overlay, so the grip dots make it clear the pill can be
-   dragged. It's part of the pill body, which is the drag surface. */
-#grip {
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-  margin-left: -4px;
-  color: rgba(255, 255, 255, 0.35);
-  transition: color 0.15s ease;
-}
-
-#pill:hover #grip {
-  color: rgba(255, 255, 255, 0.6);
 }
 
 #indicator {
@@ -180,9 +155,9 @@ body {
   flex-shrink: 0;
 }
 
-#pill:not([data-status="recording"]) #meter,
-#pill:not([data-status="recording"]) #timer,
-#pill:not([data-status="recording"]) #stop {
+#card:not([data-status="recording"]) #meter,
+#card:not([data-status="recording"]) #timer,
+#card:not([data-status="recording"]) #stop {
   display: none;
 }
 
@@ -193,7 +168,7 @@ body {
   flex: 1;
 }
 
-#pill:not([data-status="recording"]) #message {
+#card:not([data-status="recording"]) #message {
   display: flex;
 }
 

--- a/renderer/overlay.html
+++ b/renderer/overlay.html
@@ -9,51 +9,44 @@
     <link rel="stylesheet" href="overlay.css" />
   </head>
   <body>
-    <div id="pill" data-status="recording">
-      <div id="grip" title="Drag to move" aria-hidden="true">
-        <svg viewBox="0 0 6 16" width="6" height="16">
-          <circle cx="1.5" cy="3" r="1.1" fill="currentColor" />
-          <circle cx="4.5" cy="3" r="1.1" fill="currentColor" />
-          <circle cx="1.5" cy="8" r="1.1" fill="currentColor" />
-          <circle cx="4.5" cy="8" r="1.1" fill="currentColor" />
-          <circle cx="1.5" cy="13" r="1.1" fill="currentColor" />
-          <circle cx="4.5" cy="13" r="1.1" fill="currentColor" />
-        </svg>
-      </div>
-      <div id="indicator"></div>
-      <canvas id="meter" width="120" height="36"></canvas>
-      <div id="message">
-        <span id="status-text">Listening…</span>
-        <span id="detail-text"></span>
-      </div>
-      <span id="timer">0:00</span>
-      <button id="stop" title="Stop and transcribe" aria-label="Stop and transcribe">
-        <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
-          <rect x="3" y="3" width="10" height="10" rx="2.5" fill="currentColor" />
-        </svg>
-      </button>
-      <button id="cancel" title="Cancel" aria-label="Cancel">
-        <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
-          <path
-            d="M4 4l8 8M12 4l-8 8"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-          />
-        </svg>
-      </button>
-    </div>
-    <!-- Live transcript: shown while recording when live preview is on. The
-         cleaned text is the prominent line; the still-streaming raw tail trails
-         it, faint, so the fast-but-jittery raw text and the calm cleaned text
-         don't fight. Hidden (and empty) when there's nothing to show. -->
-    <div id="transcript" hidden>
-      <div>
+    <!-- One unified card: the live transcript fills the top and grows freely;
+         a slim control row sits along the bottom. The whole card is the drag
+         surface and carries the data-status state. -->
+    <div id="card" data-status="recording">
+      <!-- Live transcript: shown while recording when live preview is on. The
+           cleaned text is the prominent line; the still-streaming raw tail trails
+           it, faint, so the fast-but-jittery raw text and the calm cleaned text
+           don't fight. Hidden (and empty) when there's nothing to show. -->
+      <div id="transcript" hidden>
         <!-- Only the cleaned line is a polite live region: it settles in calm
              chunks on pauses, a natural announce cadence. The raw tail updates
              every ~1.2s and would be far too chatty for a screen reader. -->
         <span id="transcript-clean" aria-live="polite"></span
         ><span id="transcript-raw" aria-hidden="true"></span>
+      </div>
+      <div id="controls">
+        <div id="indicator"></div>
+        <canvas id="meter" width="120" height="36"></canvas>
+        <div id="message">
+          <span id="status-text">Listening…</span>
+          <span id="detail-text"></span>
+        </div>
+        <span id="timer">0:00</span>
+        <button id="stop" title="Stop and transcribe" aria-label="Stop and transcribe">
+          <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+            <rect x="3" y="3" width="10" height="10" rx="2.5" fill="currentColor" />
+          </svg>
+        </button>
+        <button id="cancel" title="Cancel" aria-label="Cancel">
+          <svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+            />
+          </svg>
+        </button>
       </div>
     </div>
     <script src="transcript.js"></script>

--- a/renderer/overlay.html
+++ b/renderer/overlay.html
@@ -43,6 +43,20 @@
         </svg>
       </button>
     </div>
+    <!-- Live transcript: shown while recording when live preview is on. The
+         cleaned text is the prominent line; the still-streaming raw tail trails
+         it, faint, so the fast-but-jittery raw text and the calm cleaned text
+         don't fight. Hidden (and empty) when there's nothing to show. -->
+    <div id="transcript" hidden>
+      <div>
+        <!-- Only the cleaned line is a polite live region: it settles in calm
+             chunks on pauses, a natural announce cadence. The raw tail updates
+             every ~1.2s and would be far too chatty for a screen reader. -->
+        <span id="transcript-clean" aria-live="polite"></span
+        ><span id="transcript-raw" aria-hidden="true"></span>
+      </div>
+    </div>
+    <script src="transcript.js"></script>
     <script src="overlay.js"></script>
   </body>
 </html>

--- a/renderer/overlay.html
+++ b/renderer/overlay.html
@@ -13,6 +13,10 @@
          a slim control row sits along the bottom. The whole card is the drag
          surface and carries the data-status state. -->
     <div id="card" data-status="recording">
+      <!-- Grip handle: signifies the card is draggable (the OS ignores the CSS
+           move-cursor on a focusable:false overlay, so a visible cue is needed).
+           Decorative — the card itself handles the drag. -->
+      <div id="grip" aria-hidden="true"></div>
       <!-- Live transcript: shown while recording when live preview is on. The
            cleaned text is the prominent line; the still-streaming raw tail trails
            it, faint, so the fast-but-jittery raw text and the calm cleaned text
@@ -27,7 +31,10 @@
       <div id="controls">
         <div id="indicator"></div>
         <canvas id="meter" width="120" height="36"></canvas>
-        <div id="message">
+        <!-- Polite live region so a screen reader hears the post-recording
+             status (Transcribing… / Pasted / Failed) — the feedback that tells
+             the user whether their dictation landed. -->
+        <div id="message" aria-live="polite">
           <span id="status-text">Listening…</span>
           <span id="detail-text"></span>
         </div>

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -70,7 +70,9 @@ function setStatus(status, title, detail) {
 function drawMeter() {
   meterCtx.clearRect(0, 0, meter.width, meter.height);
   const barWidth = meter.width / displayLevels.length;
-  meterCtx.fillStyle = "#ff5470";
+  // A muted rose, not the full #ff5470 accent: the saturated red is reserved for
+  // the primary (stop) button so it stays the one thing the eye lands on.
+  meterCtx.fillStyle = "rgba(255, 120, 140, 0.5)";
   displayLevels.forEach((level, i) => {
     const h = Math.max(2, Math.min(1, level * 6) * meter.height);
     meterCtx.fillRect(
@@ -207,15 +209,19 @@ function clearTranscript() {
 // document.body, whose `height:100vh` pins it to the window). The card has
 // `overflow:hidden` for its rounded corners, so its content can exceed the
 // window; scrollHeight reports that true desired height. Plus the 12px card
-// margins. Quantized to whole lines (~21px) so a single non-wrapping word doesn't
-// nudge the window every partial; it grows in calm, full-line steps and collapses
-// cleanly when the transcript hides. lastReportedHeight resets on overlay:show.
+// margins. The window jump is un-eased, but the card's own height eases via CSS
+// (see #card transition), so content slides into the new space smoothly.
 const CARD_MARGIN = 12; // matches #card margin in overlay.css
-const LINE_STEP = 21; // line-height 1.5 × 14px, one transcript line
 let lastReportedHeight = 0;
 function syncOverlayHeight() {
-  const raw = card.scrollHeight + CARD_MARGIN * 2;
-  const height = Math.ceil(raw / LINE_STEP) * LINE_STEP;
+  // Measure the card's NATURAL content height: clear any pinned height first so a
+  // shrink (e.g. transcript cleared) is measured, not clamped by the old value.
+  card.style.height = "";
+  const content = card.scrollHeight;
+  // Pin it so the CSS height transition has a concrete from/to to ease between
+  // (it can't animate `height: auto`); the window resizes instantly around it.
+  card.style.height = `${content}px`;
+  const height = content + CARD_MARGIN * 2;
   if (height !== lastReportedHeight) {
     lastReportedHeight = height;
     earheart.send("overlay:resize", { height });

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -9,12 +9,22 @@ const detailText = document.getElementById("detail-text");
 const timerEl = document.getElementById("timer");
 const meter = document.getElementById("meter");
 const meterCtx = meter.getContext("2d");
+const transcriptEl = document.getElementById("transcript");
+const transcriptCleanEl = document.getElementById("transcript-clean");
+const transcriptRawEl = document.getElementById("transcript-raw");
 
-let recording = null; // { stream, context, chunks, startedAt, timerId, maxTimerId }
+let recording = null; // { stream, context, chunks, startedAt, timerId, maxTimerId, partialTimerId }
 let generation = 0; // bumped on every start/teardown to invalidate stale awaits
 let currentSid = null; // session id from the main process
 let stopWhenReady = false; // stop arrived while getUserMedia was still pending
 let levels = new Array(24).fill(0);
+
+// Live preview state: the latest raw and cleaned partial transcripts. The
+// cleaned line is the prominent text; the raw tail is the part of the raw
+// transcript past the cleaned prefix (what's been heard but not yet cleaned).
+let livePreview = null; // { intervalMs, maxSeconds } when enabled this session
+let partialRaw = "";
+let partialClean = "";
 
 // The audio worklet posts levels far faster than the screen refreshes, so we
 // don't redraw the meter per message. Instead each frame eases the displayed
@@ -110,13 +120,83 @@ function encodeWav(chunks) {
   return buffer;
 }
 
-async function startRecording({ sid, deviceId, maxSeconds }) {
+// Live preview: re-encode the audio captured so far and ship it for a fresh
+// partial transcript. Skipped once the recording passes the configured cap
+// (the offline recognizer re-decodes the whole buffer each tick, so cost grows
+// with length) and when there's nothing recorded yet.
+function sendPartial() {
+  if (!recording || !livePreview) return;
+  const cap = livePreview.maxSeconds || 0;
+  if (cap > 0 && (Date.now() - recording.startedAt) / 1000 > cap) return;
+  if (recording.chunks.length === 0) return;
+  const wav = encodeWav(recording.chunks);
+  earheart.send("audio:partial", { sid: recording.sid, wav });
+}
+
+// Paint the two layers. The prefix-reconcile logic lives in transcript.js so it
+// can be unit-tested; here we just apply the result to the DOM. The panel fades
+// in and out via the `.visible` opacity transition; `hidden` (which removes it
+// from layout, collapsing the window height) is applied only *after* the
+// fade-out so the exit animation matches the entrance instead of popping.
+let hideTranscriptTimer = null;
+function renderTranscript() {
+  const { clean, tail, hasText } = reconcileTranscript(partialRaw, partialClean);
+  transcriptCleanEl.textContent = clean;
+  transcriptRawEl.textContent = tail;
+  if (hasText) {
+    if (hideTranscriptTimer) {
+      clearTimeout(hideTranscriptTimer);
+      hideTranscriptTimer = null;
+    }
+    transcriptEl.hidden = false;
+    transcriptEl.classList.add("visible");
+    syncOverlayHeight();
+  } else if (!transcriptEl.hidden && !hideTranscriptTimer) {
+    // Fade out, then collapse the layout once the opacity transition is done.
+    transcriptEl.classList.remove("visible");
+    hideTranscriptTimer = setTimeout(() => {
+      hideTranscriptTimer = null;
+      transcriptEl.hidden = true;
+      syncOverlayHeight();
+    }, 200); // matches the #transcript opacity transition
+  }
+}
+
+function clearTranscript() {
+  partialRaw = "";
+  partialClean = "";
+  renderTranscript();
+}
+
+// Ask the main process to size the window to the rendered content. The overlay
+// is frameless and bottom-anchored, so the main process grows it upward.
+//
+// The height is quantized to whole transcript lines (line-height 1.45 × 13px ≈
+// 19px) so a single word that doesn't wrap the line doesn't nudge the window a
+// few pixels every partial — it grows in calm, full-line steps. lastReportedHeight
+// is reset on overlay:show because the main process resets the window to the base
+// pill height there; without the reset a later session whose transcript happens to
+// match a previous height would report no change and stay clipped.
+const LINE_STEP = 19;
+let lastReportedHeight = 0;
+function syncOverlayHeight() {
+  const raw = document.body.scrollHeight;
+  const height = Math.ceil(raw / LINE_STEP) * LINE_STEP;
+  if (height !== lastReportedHeight) {
+    lastReportedHeight = height;
+    earheart.send("overlay:resize", { height });
+  }
+}
+
+async function startRecording({ sid, deviceId, maxSeconds, livePreview: live }) {
   // A new session always supersedes whatever was running.
   await teardown();
   const myGeneration = ++generation;
   currentSid = sid;
   stopWhenReady = false;
+  livePreview = live && live.enabled ? live : null;
   setStatus("recording", "Listening…");
+  clearTranscript();
   levels.fill(0);
   displayLevels.fill(0);
   drawMeter(); // clear to a flat baseline; the rAF loop starts once mic is live
@@ -164,6 +244,9 @@ async function startRecording({ sid, deviceId, maxSeconds }) {
         () => stopRecording(),
         (maxSeconds || 300) * 1000
       ),
+      partialTimerId: livePreview
+        ? setInterval(sendPartial, livePreview.intervalMs || 1200)
+        : null,
     };
     startMeter(); // rAF loop runs for the whole session (recording is now set)
     if (stopWhenReady) {
@@ -191,6 +274,7 @@ async function teardown() {
   recording = null;
   clearInterval(rec.timerId);
   clearTimeout(rec.maxTimerId);
+  if (rec.partialTimerId) clearInterval(rec.partialTimerId);
   rec.stream.getTracks().forEach((track) => track.stop());
   await rec.context.close().catch(() => {});
   return rec;
@@ -220,9 +304,25 @@ async function cancelRecording() {
 
 earheart.on("record:start", startRecording);
 earheart.on("record:stop", stopRecording);
-earheart.on("record:cancel", () => teardown());
+earheart.on("record:cancel", () => {
+  teardown();
+  clearTranscript();
+});
+
+// Live partial transcript: `raw` keeps pace with the voice, `cleaned` fills in
+// behind it on pauses. The pipeline only sends these while recording; once it
+// moves on to the final pass we clear the panel (the pill takes over).
+earheart.on("pipeline:partial", ({ kind, text }) => {
+  if (kind === "raw") partialRaw = text || "";
+  else if (kind === "cleaned") partialClean = text || "";
+  renderTranscript();
+});
 
 earheart.on("pipeline:status", ({ status, detail }) => {
+  // The live preview belongs to the recording phase; the moment the pipeline
+  // reports a post-recording status, retire the panel so it doesn't linger
+  // alongside the pill's own status/preview.
+  clearTranscript();
   switch (status) {
     case "transcribing":
       setStatus("transcribing", "Transcribing…");
@@ -255,7 +355,12 @@ earheart.on("pipeline:status", ({ status, detail }) => {
   }
 });
 
-earheart.on("overlay:show", () => pill.classList.add("visible"));
+earheart.on("overlay:show", () => {
+  // The main process resets the window to the base pill height on show; mirror
+  // that here so the next syncOverlayHeight() always re-reports against it.
+  lastReportedHeight = 0;
+  pill.classList.add("visible");
+});
 earheart.on("overlay:hide", () => pill.classList.remove("visible"));
 
 document.getElementById("stop").addEventListener("click", stopRecording);

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -3,7 +3,7 @@
 
 const SAMPLE_RATE = 16000;
 
-const pill = document.getElementById("pill");
+const card = document.getElementById("card");
 const statusText = document.getElementById("status-text");
 const detailText = document.getElementById("detail-text");
 const timerEl = document.getElementById("timer");
@@ -62,7 +62,7 @@ function stopMeter() {
 }
 
 function setStatus(status, title, detail) {
-  pill.dataset.status = status;
+  card.dataset.status = status;
   statusText.textContent = title;
   detailText.textContent = detail || "";
 }
@@ -179,32 +179,18 @@ function sendPartial() {
 }
 
 // Paint the two layers. The prefix-reconcile logic lives in transcript.js so it
-// can be unit-tested; here we just apply the result to the DOM. The panel fades
-// in and out via the `.visible` opacity transition; `hidden` (which removes it
-// from layout, collapsing the window height) is applied only *after* the
-// fade-out so the exit animation matches the entrance instead of popping.
-let hideTranscriptTimer = null;
+// can be unit-tested; here we just apply the result to the DOM. Showing/hiding
+// the transcript toggles `hidden` (in/out of layout) and the card's
+// `data-transcript` flag (which adds the divider above the controls), then resizes
+// the window to fit. The whole card fades via its own opacity transition.
 function renderTranscript() {
   const { clean, tail, hasText } = reconcileTranscript(partialRaw, partialClean);
   transcriptCleanEl.textContent = clean;
   transcriptRawEl.textContent = tail;
-  if (hasText) {
-    if (hideTranscriptTimer) {
-      clearTimeout(hideTranscriptTimer);
-      hideTranscriptTimer = null;
-    }
-    transcriptEl.hidden = false;
-    transcriptEl.classList.add("visible");
-    syncOverlayHeight();
-  } else if (!transcriptEl.hidden && !hideTranscriptTimer) {
-    // Fade out, then collapse the layout once the opacity transition is done.
-    transcriptEl.classList.remove("visible");
-    hideTranscriptTimer = setTimeout(() => {
-      hideTranscriptTimer = null;
-      transcriptEl.hidden = true;
-      syncOverlayHeight();
-    }, 200); // matches the #transcript opacity transition
-  }
+  transcriptEl.hidden = !hasText;
+  if (hasText) card.setAttribute("data-transcript", "");
+  else card.removeAttribute("data-transcript");
+  syncOverlayHeight();
 }
 
 function clearTranscript() {
@@ -216,27 +202,20 @@ function clearTranscript() {
 // Ask the main process to size the window to the rendered content. The overlay
 // is frameless and bottom-anchored, so the main process grows it upward.
 //
-// We report BASE_HEIGHT (the pill) plus the transcript panel's own height when
-// it's showing. Measuring the transcript element — not document.body — is
-// deliberate: the body is `height:100vh`, so its scrollHeight tracks the current
-// window height and could only ever grow, never letting the window shrink back
-// when the transcript shrinks or hides. The transcript's growth above the base
-// is quantized to whole lines (~19px) so a single non-wrapping word doesn't nudge
-// the window every partial; the base itself is reported exactly so the window
-// returns to the pill size when the transcript clears. lastReportedHeight resets
-// on overlay:show because the main process resets the window to BASE_HEIGHT there.
-const BASE_HEIGHT = 80; // pill (56px) + 12px margin top/bottom; matches windows.js
-const LINE_STEP = 19; // line-height 1.45 × 13px, one transcript line
+// We measure the card's CONTENT via scrollHeight (not offsetHeight, which the
+// viewport clamps to the current window height before it has grown, and not
+// document.body, whose `height:100vh` pins it to the window). The card has
+// `overflow:hidden` for its rounded corners, so its content can exceed the
+// window; scrollHeight reports that true desired height. Plus the 12px card
+// margins. Quantized to whole lines (~21px) so a single non-wrapping word doesn't
+// nudge the window every partial; it grows in calm, full-line steps and collapses
+// cleanly when the transcript hides. lastReportedHeight resets on overlay:show.
+const CARD_MARGIN = 12; // matches #card margin in overlay.css
+const LINE_STEP = 21; // line-height 1.5 × 14px, one transcript line
 let lastReportedHeight = 0;
 function syncOverlayHeight() {
-  let height = BASE_HEIGHT;
-  if (!transcriptEl.hidden) {
-    // Outer height of the transcript panel including its top/bottom margin.
-    const style = getComputedStyle(transcriptEl);
-    const margin = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
-    const panel = transcriptEl.offsetHeight + margin;
-    height = BASE_HEIGHT + Math.ceil(panel / LINE_STEP) * LINE_STEP;
-  }
+  const raw = card.scrollHeight + CARD_MARGIN * 2;
+  const height = Math.ceil(raw / LINE_STEP) * LINE_STEP;
   if (height !== lastReportedHeight) {
     lastReportedHeight = height;
     earheart.send("overlay:resize", { height });
@@ -373,7 +352,8 @@ earheart.on("record:cancel", () => {
 
 // Live partial transcript: `raw` keeps pace with the voice, `cleaned` fills in
 // behind it on pauses. The pipeline only sends these while recording; once it
-// moves on to the final pass we clear the panel (the pill takes over).
+// moves on to the final pass we clear the transcript (the control row's status
+// takes over).
 earheart.on("pipeline:partial", ({ kind, text }) => {
   if (kind === "raw") partialRaw = text || "";
   else if (kind === "cleaned") partialClean = text || "";
@@ -382,8 +362,8 @@ earheart.on("pipeline:partial", ({ kind, text }) => {
 
 earheart.on("pipeline:status", ({ status, detail }) => {
   // The live preview belongs to the recording phase; the moment the pipeline
-  // reports a post-recording status, retire the panel so it doesn't linger
-  // alongside the pill's own status/preview.
+  // reports a post-recording status, retire the transcript so it doesn't linger
+  // alongside the control row's own status/preview.
   clearTranscript();
   switch (status) {
     case "transcribing":
@@ -418,38 +398,38 @@ earheart.on("pipeline:status", ({ status, detail }) => {
 });
 
 earheart.on("overlay:show", () => {
-  // The main process resets the window to the base pill height on show; mirror
+  // The main process resets the window to the base card height on show; mirror
   // that here so the next syncOverlayHeight() always re-reports against it.
   lastReportedHeight = 0;
-  pill.classList.add("visible");
+  card.classList.add("visible");
 });
-earheart.on("overlay:hide", () => pill.classList.remove("visible"));
+earheart.on("overlay:hide", () => card.classList.remove("visible"));
 
 document.getElementById("stop").addEventListener("click", stopRecording);
 document.getElementById("cancel").addEventListener("click", cancelRecording);
 
-// Click-and-drag anywhere on the pill (except the buttons) moves the overlay.
+// Click-and-drag anywhere on the card (except the buttons) moves the overlay.
 // The window itself is moved by the main process from the streamed screen
 // coordinates, since a focusable:false frameless window can't be dragged
 // natively.
 let dragging = false;
-pill.addEventListener("pointerdown", (event) => {
+card.addEventListener("pointerdown", (event) => {
   if (event.button !== 0 || event.target.closest("button")) return;
   dragging = true;
-  pill.classList.add("dragging");
-  pill.setPointerCapture(event.pointerId);
+  card.classList.add("dragging");
+  card.setPointerCapture(event.pointerId);
   earheart.send("overlay:drag-start", { x: event.screenX, y: event.screenY });
 });
 
-pill.addEventListener("pointermove", (event) => {
+card.addEventListener("pointermove", (event) => {
   if (!dragging) return;
   earheart.send("overlay:drag", { x: event.screenX, y: event.screenY });
 });
 
 function endDrag() {
   dragging = false;
-  pill.classList.remove("dragging");
+  card.classList.remove("dragging");
 }
 
-pill.addEventListener("pointerup", endDrag);
-pill.addEventListener("pointercancel", endDrag);
+card.addEventListener("pointerup", endDrag);
+card.addEventListener("pointercancel", endDrag);

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -171,17 +171,27 @@ function clearTranscript() {
 // Ask the main process to size the window to the rendered content. The overlay
 // is frameless and bottom-anchored, so the main process grows it upward.
 //
-// The height is quantized to whole transcript lines (line-height 1.45 × 13px ≈
-// 19px) so a single word that doesn't wrap the line doesn't nudge the window a
-// few pixels every partial — it grows in calm, full-line steps. lastReportedHeight
-// is reset on overlay:show because the main process resets the window to the base
-// pill height there; without the reset a later session whose transcript happens to
-// match a previous height would report no change and stay clipped.
-const LINE_STEP = 19;
+// We report BASE_HEIGHT (the pill) plus the transcript panel's own height when
+// it's showing. Measuring the transcript element — not document.body — is
+// deliberate: the body is `height:100vh`, so its scrollHeight tracks the current
+// window height and could only ever grow, never letting the window shrink back
+// when the transcript shrinks or hides. The transcript's growth above the base
+// is quantized to whole lines (~19px) so a single non-wrapping word doesn't nudge
+// the window every partial; the base itself is reported exactly so the window
+// returns to the pill size when the transcript clears. lastReportedHeight resets
+// on overlay:show because the main process resets the window to BASE_HEIGHT there.
+const BASE_HEIGHT = 80; // pill (56px) + 12px margin top/bottom; matches windows.js
+const LINE_STEP = 19; // line-height 1.45 × 13px, one transcript line
 let lastReportedHeight = 0;
 function syncOverlayHeight() {
-  const raw = document.body.scrollHeight;
-  const height = Math.ceil(raw / LINE_STEP) * LINE_STEP;
+  let height = BASE_HEIGHT;
+  if (!transcriptEl.hidden) {
+    // Outer height of the transcript panel including its top/bottom margin.
+    const style = getComputedStyle(transcriptEl);
+    const margin = parseFloat(style.marginTop) + parseFloat(style.marginBottom);
+    const panel = transcriptEl.offsetHeight + margin;
+    height = BASE_HEIGHT + Math.ceil(panel / LINE_STEP) * LINE_STEP;
+  }
   if (height !== lastReportedHeight) {
     lastReportedHeight = height;
     earheart.send("overlay:resize", { height });

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -120,17 +120,62 @@ function encodeWav(chunks) {
   return buffer;
 }
 
-// Live preview: re-encode the audio captured so far and ship it for a fresh
-// partial transcript. Skipped once the recording passes the configured cap
-// (the offline recognizer re-decodes the whole buffer each tick, so cost grows
-// with length) and when there's nothing recorded yet.
+// Total samples recorded so far across all worklet chunks.
+function totalSamples(chunks) {
+  let n = 0;
+  for (const c of chunks) n += c.length;
+  return n;
+}
+
+// Encode the recorded samples in [from, to) into a WAV. Walks the chunk list,
+// skipping samples before `from` and stopping at `to`, so we only ever encode
+// the slice the live preview needs — not the whole growing buffer.
+function encodeWavRange(chunks, from, to) {
+  const flat = new Float32Array(to - from);
+  let pos = 0; // absolute sample index at the start of the current chunk
+  let out = 0;
+  for (const chunk of chunks) {
+    const start = Math.max(from, pos);
+    const end = Math.min(to, pos + chunk.length);
+    if (end > start) {
+      flat.set(chunk.subarray(start - pos, end - pos), out);
+      out += end - start;
+    }
+    pos += chunk.length;
+    if (pos >= to) break;
+  }
+  return encodeWav([flat]);
+}
+
+// Live preview, append-only and chunked: each tick we ship only the audio of the
+// CURRENT in-progress chunk (the samples since the last committed boundary), so
+// decode cost stays flat regardless of how long the dictation runs. Once that
+// chunk reaches `chunkSeconds`, we send it one last time marked `final` and
+// advance the boundary, freezing it into the committed transcript on the main
+// side and starting a fresh chunk.
 function sendPartial() {
   if (!recording || !livePreview) return;
-  const cap = livePreview.maxSeconds || 0;
-  if (cap > 0 && (Date.now() - recording.startedAt) / 1000 > cap) return;
-  if (recording.chunks.length === 0) return;
-  const wav = encodeWav(recording.chunks);
-  earheart.send("audio:partial", { sid: recording.sid, wav });
+  const total = totalSamples(recording.chunks);
+  const from = recording.committedSamples;
+  if (total <= from) return; // nothing new recorded since the last commit
+
+  const chunkSamples = (livePreview.chunkSeconds || 5) * SAMPLE_RATE;
+  const liveSamples = total - from;
+  const final = liveSamples >= chunkSamples;
+
+  const wav = encodeWavRange(recording.chunks, from, total);
+  earheart.send("audio:partial", {
+    sid: recording.sid,
+    seq: recording.seq,
+    final,
+    wav,
+  });
+
+  if (final) {
+    // Freeze this chunk: future ticks send only audio recorded after it.
+    recording.committedSamples = total;
+    recording.seq += 1;
+  }
 }
 
 // Paint the two layers. The prefix-reconcile logic lives in transcript.js so it
@@ -249,6 +294,13 @@ async function startRecording({ sid, deviceId, maxSeconds, livePreview: live }) 
       context,
       chunks,
       startedAt: Date.now(),
+      // Append-only live preview: `committedSamples` is the sample offset where
+      // the current in-progress chunk starts; everything before it has been
+      // frozen into committed chunks and need never be re-sent. `seq` counts
+      // committed chunks so the main process can tell a growing in-progress chunk
+      // from the start of a new one.
+      committedSamples: 0,
+      seq: 0,
       timerId: setInterval(updateTimer, 250),
       maxTimerId: setTimeout(
         () => stopRecording(),

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -129,6 +129,17 @@
             <span id="stt-test-result" class="status"></span>
           </div>
         </div>
+        <div class="field">
+          <label class="choice">
+            <input type="checkbox" id="stt-live-preview" />
+            Show a live transcript while you speak
+          </label>
+          <p class="hint">
+            Transcribes as you talk and shows the text in the overlay, with a
+            cleaned version filling in on pauses. The final transcript on stop is
+            unchanged. Adds some CPU load while recording.
+          </p>
+        </div>
       </section>
 
       <!-- Cleanup -->

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -124,6 +124,7 @@ function populate() {
   $("stt-language").value = current.stt.language;
   selectEngine("stt", current.stt.engine);
   $("stt-builtin-model").value = current.stt.builtin.model;
+  $("stt-live-preview").checked = current.stt.livePreview?.enabled ?? true;
 
   $("cleanup-enabled").checked = current.cleanup.enabled;
   $("cleanup-url").value = current.cleanup.baseUrl;
@@ -164,6 +165,12 @@ function collect() {
       apiKey: $("stt-key").value.trim(),
       model: $("stt-model").value.trim(),
       language: $("stt-language").value.trim(),
+      // Preserve the live-preview tuning (interval, caps); only the toggle is
+      // surfaced in the UI.
+      livePreview: {
+        ...current.stt.livePreview,
+        enabled: $("stt-live-preview").checked,
+      },
     },
     cleanup: {
       ...current.cleanup,

--- a/renderer/transcript.js
+++ b/renderer/transcript.js
@@ -1,0 +1,70 @@
+// Pure helper for the overlay's two-layer live transcript: given the latest raw
+// and cleaned partial transcripts, work out what to paint on each layer.
+//
+// The cleaned text is authoritative for whatever it covers; the raw "tail" is
+// the words heard since cleanup last ran — what's been spoken but not yet
+// cleaned — shown faintly after the cleaned line.
+//
+// We can't align the two by literal prefix or by word count: cleanup fixes
+// capitalization and punctuation AND removes filler words / false starts, so the
+// cleaned text is neither a character-prefix of the raw text nor the same length.
+// A plain word-count offset would re-show words the cleaned line already covers
+// whenever cleanup dropped a filler word ("um the the quick" → clean "The quick"
+// → a count offset of 2 would wrongly tail "the quick" again).
+//
+// Instead we ANCHOR on the cleaned line's last content word: find where that word
+// last appears in the raw token stream and tail from just after it. Matching by
+// content (normalized to lowercase, punctuation stripped) survives cleanup's
+// capitalization/punctuation edits and filler removal. If the anchor isn't found
+// (cleanup reworded the ending) we show the cleaned line alone rather than guess.
+// If cleanup hasn't run yet, the whole raw text is the tail.
+//
+// Loaded as a plain <script> in the overlay (exposing `reconcileTranscript` as a
+// global) and required directly in unit tests; the module.exports guard lets the
+// same file serve both without a bundler.
+
+// Lowercase, strip surrounding punctuation, for content comparison.
+function normToken(s) {
+  return s.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+function reconcileTranscript(rawText, cleanText) {
+  const raw = (rawText || "").trim();
+  const clean = (cleanText || "").trim();
+
+  let tail = "";
+  if (!clean) {
+    tail = raw;
+  } else if (raw) {
+    const rawWords = raw.split(/\s+/);
+    const cleanTokens = clean.split(/\s+/).map(normToken).filter(Boolean);
+    const anchor = cleanTokens[cleanTokens.length - 1];
+    const rawTokens = rawWords.map(normToken);
+    // Find the LAST raw word matching the cleaned line's final word; the tail is
+    // everything spoken after it. Last (not first) so a repeated word doesn't
+    // anchor too early.
+    let idx = -1;
+    if (anchor) {
+      for (let i = rawTokens.length - 1; i >= 0; i--) {
+        if (rawTokens[i] === anchor) {
+          idx = i;
+          break;
+        }
+      }
+    }
+    if (idx >= 0 && idx < rawWords.length - 1) {
+      tail = rawWords.slice(idx + 1).join(" ");
+    }
+    // idx not found, or it's the last raw word: nothing fresh to show (cleanup
+    // has caught up, or reworded the ending) — show the cleaned line alone.
+  }
+
+  // Keep a space between the cleaned line and the faint tail when both present.
+  if (clean && tail) tail = ` ${tail}`;
+
+  return { clean, tail, hasText: Boolean(clean || tail.trim()) };
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { reconcileTranscript };
+}

--- a/scripts/engine-smoke.js
+++ b/scripts/engine-smoke.js
@@ -14,7 +14,11 @@
 //   npx electron scripts/engine-smoke.js                            # macOS/Win
 
 const { app } = require("electron");
-const host = require("../main/engines/host");
+const { createHost } = require("../main/engines/host");
+
+// One worker is enough to prove the addons load; the app runs two of these
+// (STT + cleanup) but they fork the same engine-worker.js.
+const host = createHost({ serviceName: "earheart-engine-smoke" });
 
 app.whenReady().then(async () => {
   try {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -430,21 +430,25 @@ test("engines.clean falls back to the raw transcript when cleanup is empty", asy
   // empty/whitespace, clean() must deliver the raw transcript instead.
   let cleanReply = "";
   const calls = [];
-  const host = {
-    request: async (type, args) => {
-      calls.push(type);
-      if (type === "load-cleanup") return { ready: true };
-      if (type === "clean") return cleanReply;
-      throw new Error(`unexpected request: ${type}`);
-    },
-    stop() {},
-    onExit() {},
+  // createHost factory shape (the real host module); this test only drives the
+  // cleanup path, so both services share one fake.
+  const hostModule = {
+    createHost: () => ({
+      request: async (type, args) => {
+        calls.push(type);
+        if (type === "load-cleanup") return { ready: true };
+        if (type === "clean") return cleanReply;
+        throw new Error(`unexpected request: ${type}`);
+      },
+      stop() {},
+      onExit() {},
+    }),
   };
   const managerStub = {
     isInstalled: () => true,
     modelDir: (base, model) => path.join(base, model.kind, model.id),
   };
-  const facade = loadFacadeWith({ host, manager: managerStub });
+  const facade = loadFacadeWith({ host: hostModule, manager: managerStub });
 
   const cfg = { builtin: { model: registry.DEFAULT_CLEANUP_MODEL }, systemPrompt: "rules" };
 
@@ -458,4 +462,159 @@ test("engines.clean falls back to the raw transcript when cleanup is empty", asy
   assert.strictEqual(await facade.clean("hello world", cfg), "Hello, world.");
 
   assert.ok(calls.includes("clean"));
+});
+
+test("engines facade routes STT and cleanup to separate worker hosts", async () => {
+  // The two-worker split: transcribe must only ever talk to the STT host and
+  // clean only to the cleanup host, so a crash or load in one engine can't
+  // affect the other. We hand the facade a `createHost` factory and assert each
+  // host sees only its own request types.
+  const hostsBySvc = {};
+  const hostModule = {
+    createHost({ serviceName }) {
+      const calls = [];
+      const host = {
+        serviceName,
+        calls,
+        request: async (type) => {
+          calls.push(type);
+          if (type === "load-stt" || type === "load-cleanup") return { ready: true };
+          if (type === "transcribe") return "transcribed";
+          if (type === "clean") return "cleaned";
+          if (type === "unload-stt" || type === "unload-cleanup") return {};
+          throw new Error(`unexpected request: ${type}`);
+        },
+        stopped: false,
+        stop() {
+          this.stopped = true;
+        },
+        exitFns: [],
+        onExit(fn) {
+          this.exitFns.push(fn);
+        },
+      };
+      hostsBySvc[serviceName] = host;
+      return host;
+    },
+  };
+  const managerStub = {
+    isInstalled: () => true,
+    modelDir: (base, model) => path.join(base, model.kind, model.id),
+  };
+  const facade = loadFacadeWith({ host: hostModule, manager: managerStub });
+
+  const stt = hostsBySvc["earheart-stt"];
+  const cleanup = hostsBySvc["earheart-cleanup"];
+  assert.ok(stt && cleanup, "both hosts should be created");
+
+  await facade.transcribe(
+    Buffer.from("wav"),
+    { builtin: { model: registry.DEFAULT_STT_MODEL }, language: "" }
+  );
+  await facade.clean(
+    "hello",
+    { builtin: { model: registry.DEFAULT_CLEANUP_MODEL }, systemPrompt: "rules" }
+  );
+
+  // Each host saw only its own engine's request types.
+  assert.ok(stt.calls.includes("load-stt") && stt.calls.includes("transcribe"));
+  assert.ok(!stt.calls.includes("clean") && !stt.calls.includes("load-cleanup"));
+  assert.ok(cleanup.calls.includes("load-cleanup") && cleanup.calls.includes("clean"));
+  assert.ok(!cleanup.calls.includes("transcribe") && !cleanup.calls.includes("load-stt"));
+
+  // unloadIdle only unloads hosts that have a model resident, on their own host.
+  await facade.unloadIdle();
+  assert.ok(stt.calls.includes("unload-stt"));
+  assert.ok(cleanup.calls.includes("unload-cleanup"));
+
+  // stop tears down both workers.
+  facade.stop();
+  assert.ok(stt.stopped && cleanup.stopped);
+});
+
+// Build a two-host facade over fake STT + cleanup workers. Each fake records its
+// calls and its registered onExit listeners, so tests can simulate one worker
+// dying and assert the other is unaffected.
+function loadTwoHostFacade() {
+  const hostsBySvc = {};
+  const hostModule = {
+    createHost({ serviceName }) {
+      const calls = [];
+      const host = {
+        serviceName,
+        calls,
+        request: async (type) => {
+          calls.push(type);
+          if (type === "load-stt" || type === "load-cleanup") return { ready: true };
+          if (type === "transcribe") return "transcribed";
+          if (type === "clean") return "cleaned";
+          if (type === "unload-stt" || type === "unload-cleanup") return {};
+          throw new Error(`unexpected request: ${type}`);
+        },
+        stopped: false,
+        stop() {
+          this.stopped = true;
+        },
+        exitFns: [],
+        onExit(fn) {
+          this.exitFns.push(fn);
+        },
+        die() {
+          for (const fn of this.exitFns) fn();
+        },
+      };
+      hostsBySvc[serviceName] = host;
+      return host;
+    },
+  };
+  const managerStub = {
+    isInstalled: () => true,
+    modelDir: (base, model) => path.join(base, model.kind, model.id),
+  };
+  const facade = loadFacadeWith({ host: hostModule, manager: managerStub });
+  return { facade, hostsBySvc };
+}
+
+const STT_CFG = { builtin: { model: registry.DEFAULT_STT_MODEL }, language: "" };
+const CLEANUP_CFG = { builtin: { model: registry.DEFAULT_CLEANUP_MODEL }, systemPrompt: "rules" };
+const count = (host, type) => host.calls.filter((t) => t === type).length;
+
+test("an STT worker crash forgets only STT loaded-state, not cleanup", async () => {
+  // Crash isolation is the point of the split: if the STT worker dies, the next
+  // transcribe must re-load STT, but cleanup (a separate, still-alive worker)
+  // must NOT be made to re-load. A regression wiring both forget callbacks onto
+  // one host would break this.
+  const { facade, hostsBySvc } = loadTwoHostFacade();
+  await facade.transcribe(Buffer.from("wav"), STT_CFG);
+  await facade.clean("hello", CLEANUP_CFG);
+  const stt = hostsBySvc["earheart-stt"];
+  const cleanup = hostsBySvc["earheart-cleanup"];
+  assert.strictEqual(count(stt, "load-stt"), 1);
+  assert.strictEqual(count(cleanup, "load-cleanup"), 1);
+
+  stt.die(); // the STT worker process exits
+
+  await facade.transcribe(Buffer.from("wav"), STT_CFG);
+  await facade.clean("hello", CLEANUP_CFG);
+  // STT was forgotten on exit -> re-loaded; cleanup was untouched -> not reloaded.
+  assert.strictEqual(count(stt, "load-stt"), 2, "STT should re-load after its worker died");
+  assert.strictEqual(count(cleanup, "load-cleanup"), 1, "cleanup must not re-load when only STT died");
+});
+
+test("unloadIdle unloads only the engines that are actually resident", async () => {
+  // A transcribe-only user (never cleaned) must unload STT but never send
+  // unload-cleanup to a cleanup worker that was never loaded.
+  const { facade, hostsBySvc } = loadTwoHostFacade();
+  await facade.transcribe(Buffer.from("wav"), STT_CFG);
+  const stt = hostsBySvc["earheart-stt"];
+  const cleanup = hostsBySvc["earheart-cleanup"];
+
+  await facade.unloadIdle();
+  assert.ok(stt.calls.includes("unload-stt"));
+  assert.ok(!cleanup.calls.includes("unload-cleanup"), "cleanup was never loaded; must not be unloaded");
+
+  // A second unloadIdle with nothing resident is a no-op on both hosts.
+  const before = stt.calls.length + cleanup.calls.length;
+  await facade.unloadIdle();
+  assert.strictEqual(stt.calls.length + cleanup.calls.length, before, "idle unload with nothing loaded is a no-op");
 });

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -618,3 +618,23 @@ test("unloadIdle unloads only the engines that are actually resident", async () 
   await facade.unloadIdle();
   assert.strictEqual(stt.calls.length + cleanup.calls.length, before, "idle unload with nothing loaded is a no-op");
 });
+
+test("transcribe/clean reject early on an already-aborted signal without touching the worker", async () => {
+  // The "pre-cancelled call returns early rather than spending a model load /
+  // inference" contract: an aborted signal short-circuits before any host request.
+  const { facade, hostsBySvc } = loadTwoHostFacade();
+  const stt = hostsBySvc["earheart-stt"];
+  const cleanup = hostsBySvc["earheart-cleanup"];
+
+  await assert.rejects(
+    () => facade.transcribe(Buffer.from("wav"), STT_CFG, AbortSignal.abort()),
+    /abort/i
+  );
+  assert.strictEqual(stt.calls.length, 0, "no STT worker request for a pre-aborted transcribe");
+
+  await assert.rejects(
+    () => facade.clean("hello", CLEANUP_CFG, AbortSignal.abort()),
+    /abort/i
+  );
+  assert.strictEqual(cleanup.calls.length, 0, "no cleanup worker request for a pre-aborted clean");
+});

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -1,0 +1,157 @@
+// Tests for the live-preview partial-transcription state machine. It's pure
+// logic with injected dependencies (no Electron, no real engines), so the
+// drop-if-busy, staleness, engine-gating, and cancel behaviors can be exercised
+// directly.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { createLivePreview } = require("../main/live-preview");
+
+// A deferred promise so a test can hold a transcribe/cleanup "in flight" and
+// resolve it on demand, to drive the busy/stale races deterministically.
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+const builtinCfg = (over = {}) => ({
+  stt: { engine: "builtin", livePreview: { cleanupPauseMs: 5 }, ...over.stt },
+  cleanup: { enabled: true, engine: "builtin", ...over.cleanup },
+});
+
+// Build a live-preview harness with controllable deps. `current` toggles whether
+// isCurrent() returns true; `sent` collects overlay messages.
+function harness({ cfg = builtinCfg(), current = true } = {}) {
+  const sent = [];
+  const transcribeCalls = [];
+  const cleanupCalls = [];
+  let transcribeImpl = async () => "hello world";
+  let cleanupImpl = async () => "Hello world.";
+  const lp = createLivePreview({
+    runTranscribe: (...a) => {
+      transcribeCalls.push(a);
+      return transcribeImpl(...a);
+    },
+    runCleanup: (...a) => {
+      cleanupCalls.push(a);
+      return cleanupImpl(...a);
+    },
+    sendToOverlay: (channel, payload) => sent.push({ channel, payload }),
+    getSettings: () => cfg,
+    isCurrent: () => current,
+  });
+  return {
+    lp,
+    sent,
+    transcribeCalls,
+    cleanupCalls,
+    setTranscribe: (fn) => (transcribeImpl = fn),
+    setCleanup: (fn) => (cleanupImpl = fn),
+    setCurrent: (v) => (current = v),
+  };
+}
+
+const wav = new ArrayBuffer(8);
+const raws = (h) => h.sent.filter((m) => m.payload.kind === "raw").map((m) => m.payload.text);
+const cleans = (h) => h.sent.filter((m) => m.payload.kind === "cleaned").map((m) => m.payload.text);
+
+test("handleAudio sends a raw partial for the active session", async () => {
+  const h = harness();
+  await h.lp.handleAudio(1, wav);
+  assert.deepStrictEqual(raws(h), ["hello world"]);
+});
+
+test("handleAudio drops the partial when the session isn't current", async () => {
+  const h = harness({ current: false });
+  await h.lp.handleAudio(1, wav);
+  assert.strictEqual(h.transcribeCalls.length, 0, "no transcribe for a stale session");
+  assert.strictEqual(h.sent.length, 0);
+});
+
+test("handleAudio skips when the STT engine isn't builtin (no remote hammering)", async () => {
+  const h = harness({ cfg: builtinCfg({ stt: { engine: "remote" } }) });
+  await h.lp.handleAudio(1, wav);
+  assert.strictEqual(h.transcribeCalls.length, 0);
+  assert.strictEqual(h.sent.length, 0);
+});
+
+test("handleAudio is drop-if-busy: a second call while one is in flight is ignored", async () => {
+  const h = harness();
+  const d = deferred();
+  h.setTranscribe(() => d.promise);
+  const first = h.lp.handleAudio(1, wav); // starts, awaits d
+  await h.lp.handleAudio(1, wav); // should be dropped (busy)
+  assert.strictEqual(h.transcribeCalls.length, 1, "second concurrent partial dropped");
+  d.resolve("done now");
+  await first;
+});
+
+test("identical consecutive raw text is not re-sent", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "same text");
+  await h.lp.handleAudio(1, wav);
+  await h.lp.handleAudio(1, wav);
+  assert.deepStrictEqual(raws(h), ["same text"], "duplicate raw suppressed");
+});
+
+test("a partial that finishes after the session ends is dropped", async () => {
+  const h = harness();
+  const d = deferred();
+  h.setTranscribe(() => d.promise);
+  const p = h.lp.handleAudio(1, wav);
+  h.setCurrent(false); // session ends mid-decode
+  d.resolve("late text");
+  await p;
+  assert.strictEqual(h.sent.length, 0, "stale result not shown");
+});
+
+test("cleanup runs over the full raw text after the pause and is sent", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown fox");
+  h.setCleanup(async (raw) => {
+    assert.strictEqual(raw, "the quick brown fox", "cleanup gets the full raw text");
+    return "The quick brown fox.";
+  });
+  await h.lp.handleAudio(1, wav);
+  // Wait past the 5ms cleanupPauseMs for the scheduled cleanup to fire.
+  await new Promise((r) => setTimeout(r, 20));
+  assert.deepStrictEqual(cleans(h), ["The quick brown fox."]);
+});
+
+test("cleanup is skipped when cleanup is disabled", async () => {
+  const h = harness({ cfg: builtinCfg({ cleanup: { enabled: false, engine: "builtin" } }) });
+  await h.lp.handleAudio(1, wav);
+  await new Promise((r) => setTimeout(r, 20));
+  assert.strictEqual(h.cleanupCalls.length, 0);
+});
+
+test("cleanup is skipped when the cleanup engine is remote", async () => {
+  const h = harness({ cfg: builtinCfg({ cleanup: { enabled: true, engine: "remote" } }) });
+  await h.lp.handleAudio(1, wav);
+  await new Promise((r) => setTimeout(r, 20));
+  assert.strictEqual(h.cleanupCalls.length, 0, "remote cleanup not hit mid-dictation");
+});
+
+test("cancel aborts in-flight work and resets state so later results are dropped", async () => {
+  const h = harness();
+  const d = deferred();
+  h.setTranscribe((wavArg, cfg, signal) => {
+    // The injected signal should be aborted by cancel().
+    return d.promise.then((v) => {
+      assert.ok(signal.aborted, "signal aborted by cancel()");
+      return v;
+    });
+  });
+  const p = h.lp.handleAudio(1, wav);
+  h.lp.cancel();
+  d.resolve("after cancel");
+  await p;
+  assert.strictEqual(h.sent.length, 0, "nothing sent after cancel");
+
+  // After cancel, a fresh partial works again (busy flag was reset).
+  h.setTranscribe(async () => "fresh");
+  await h.lp.handleAudio(1, wav);
+  assert.deepStrictEqual(raws(h), ["fresh"]);
+});

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -155,3 +155,75 @@ test("cancel aborts in-flight work and resets state so later results are dropped
   await h.lp.handleAudio(1, wav);
   assert.deepStrictEqual(raws(h), ["fresh"]);
 });
+
+test("cleanup re-arms when the raw text grew during a cleanup pass", async () => {
+  // The catch-up loop: if more is spoken while a cleanup runs, a second pass must
+  // fire over the newer raw text so the cleaned line keeps up.
+  const h = harness();
+  let rawText = "first chunk";
+  h.setTranscribe(async () => rawText);
+  const d1 = deferred();
+  let cleanupN = 0;
+  h.setCleanup(async (raw) => {
+    cleanupN++;
+    if (cleanupN === 1) {
+      // While this first cleanup is in flight, more audio arrives.
+      rawText = "first chunk second chunk";
+      await h.lp.handleAudio(1, wav); // updates lastRaw to the longer text
+      return d1.promise;
+    }
+    return `cleaned: ${raw}`;
+  });
+
+  await h.lp.handleAudio(1, wav); // raw "first chunk"
+  await new Promise((r) => setTimeout(r, 20)); // first cleanup starts, awaits d1
+  d1.resolve("cleaned: first chunk"); // first pass completes -> should re-arm
+  await new Promise((r) => setTimeout(r, 20)); // second pass fires over newer raw
+
+  assert.strictEqual(cleanupN, 2, "a second cleanup pass ran over the grown raw text");
+  assert.ok(
+    cleans(h).includes("cleaned: first chunk second chunk"),
+    "the re-armed cleanup cleaned the full grown text"
+  );
+});
+
+test("cancel during a cleanup await prevents a re-armed pause timer", async () => {
+  const h = harness();
+  let rawText = "alpha";
+  h.setTranscribe(async () => rawText);
+  const d = deferred();
+  let cleanupN = 0;
+  h.setCleanup(async () => {
+    cleanupN++;
+    rawText = "alpha beta"; // grow so the reschedule condition would be true
+    await h.lp.handleAudio(1, wav);
+    return d.promise;
+  });
+
+  await h.lp.handleAudio(1, wav);
+  await new Promise((r) => setTimeout(r, 20)); // cleanup in flight
+  h.lp.cancel(); // abort during the cleanup await
+  d.resolve("late cleaned");
+  await new Promise((r) => setTimeout(r, 20)); // give any (wrongly) re-armed timer time
+
+  assert.strictEqual(cleanupN, 1, "no second cleanup after cancel");
+  assert.strictEqual(cleans(h).length, 0, "cancelled cleanup result not sent");
+});
+
+test("a second cleanup over unchanged raw text is a no-op", async () => {
+  // runCleanupPass bails when lastRaw === lastCleanedRaw: re-cleaning the same
+  // text would just re-emit identical output and waste an inference.
+  const h = harness();
+  h.setTranscribe(async () => "steady text");
+  let cleanupN = 0;
+  h.setCleanup(async (raw) => {
+    cleanupN++;
+    return `clean ${raw}`;
+  });
+  await h.lp.handleAudio(1, wav);
+  await new Promise((r) => setTimeout(r, 20)); // first (and only) cleanup
+  // A duplicate raw partial doesn't change lastRaw, so no new cleanup is scheduled.
+  await h.lp.handleAudio(1, wav);
+  await new Promise((r) => setTimeout(r, 20));
+  assert.strictEqual(cleanupN, 1, "unchanged raw text isn't re-cleaned");
+});

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -1,7 +1,7 @@
 // Tests for the live-preview partial-transcription state machine. It's pure
 // logic with injected dependencies (no Electron, no real engines), so the
-// drop-if-busy, staleness, engine-gating, and cancel behaviors can be exercised
-// directly.
+// append-only chunking, drop-if-busy, staleness, engine-gating, and cancel
+// behaviors can be exercised directly.
 
 const { test } = require("node:test");
 const assert = require("node:assert");
@@ -28,7 +28,7 @@ function harness({ cfg = builtinCfg(), current = true } = {}) {
   const transcribeCalls = [];
   const cleanupCalls = [];
   let transcribeImpl = async () => "hello world";
-  let cleanupImpl = async () => "Hello world.";
+  let cleanupImpl = async (raw) => raw;
   const lp = createLivePreview({
     runTranscribe: (...a) => {
       transcribeCalls.push(a);
@@ -54,25 +54,54 @@ function harness({ cfg = builtinCfg(), current = true } = {}) {
 }
 
 const wav = new ArrayBuffer(8);
+// A chunk payload: seq + final flag + audio.
+const chunk = (seq, final) => ({ seq, final, wav });
 const raws = (h) => h.sent.filter((m) => m.payload.kind === "raw").map((m) => m.payload.text);
 const cleans = (h) => h.sent.filter((m) => m.payload.kind === "cleaned").map((m) => m.payload.text);
+const lastRaw = (h) => raws(h).at(-1);
+const lastClean = (h) => cleans(h).at(-1);
+const tick = () => new Promise((r) => setTimeout(r, 25));
 
-test("handleAudio sends a raw partial for the active session", async () => {
+test("an in-progress chunk shows as the live raw tail", async () => {
   const h = harness();
-  await h.lp.handleAudio(1, wav);
-  assert.deepStrictEqual(raws(h), ["hello world"]);
+  h.setTranscribe(async () => "the quick");
+  await h.lp.handleAudio(1, chunk(0, false));
+  assert.strictEqual(lastRaw(h), "the quick");
+});
+
+test("committing a chunk accumulates; the next chunk appends, not replaces", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "first chunk");
+  await h.lp.handleAudio(1, chunk(0, true)); // commit chunk 0
+  assert.strictEqual(lastRaw(h), "first chunk");
+
+  h.setTranscribe(async () => "second part");
+  await h.lp.handleAudio(1, chunk(1, false)); // in-progress chunk 1
+  // Committed chunk 0 is preserved; chunk 1 appends as the live tail.
+  assert.strictEqual(lastRaw(h), "first chunk second part");
+});
+
+test("a growing in-progress chunk replaces only the live tail", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "alpha");
+  await h.lp.handleAudio(1, chunk(0, true)); // commit "alpha"
+  h.setTranscribe(async () => "beta");
+  await h.lp.handleAudio(1, chunk(1, false)); // tail "beta"
+  h.setTranscribe(async () => "beta gamma");
+  await h.lp.handleAudio(1, chunk(1, false)); // same seq grows
+  assert.strictEqual(lastRaw(h), "alpha beta gamma", "tail replaced, commit preserved");
 });
 
 test("handleAudio drops the partial when the session isn't current", async () => {
   const h = harness({ current: false });
-  await h.lp.handleAudio(1, wav);
-  assert.strictEqual(h.transcribeCalls.length, 0, "no transcribe for a stale session");
+  await h.lp.handleAudio(1, chunk(0, false));
+  assert.strictEqual(h.transcribeCalls.length, 0);
   assert.strictEqual(h.sent.length, 0);
 });
 
 test("handleAudio skips when the STT engine isn't builtin (no remote hammering)", async () => {
   const h = harness({ cfg: builtinCfg({ stt: { engine: "remote" } }) });
-  await h.lp.handleAudio(1, wav);
+  await h.lp.handleAudio(1, chunk(0, false));
   assert.strictEqual(h.transcribeCalls.length, 0);
   assert.strictEqual(h.sent.length, 0);
 });
@@ -81,149 +110,139 @@ test("handleAudio is drop-if-busy: a second call while one is in flight is ignor
   const h = harness();
   const d = deferred();
   h.setTranscribe(() => d.promise);
-  const first = h.lp.handleAudio(1, wav); // starts, awaits d
-  await h.lp.handleAudio(1, wav); // should be dropped (busy)
-  assert.strictEqual(h.transcribeCalls.length, 1, "second concurrent partial dropped");
+  const first = h.lp.handleAudio(1, chunk(0, false));
+  await h.lp.handleAudio(1, chunk(0, false)); // dropped (busy)
+  assert.strictEqual(h.transcribeCalls.length, 1);
   d.resolve("done now");
   await first;
 });
 
-test("identical consecutive raw text is not re-sent", async () => {
+test("identical in-progress text is not re-sent", async () => {
   const h = harness();
   h.setTranscribe(async () => "same text");
-  await h.lp.handleAudio(1, wav);
-  await h.lp.handleAudio(1, wav);
-  assert.deepStrictEqual(raws(h), ["same text"], "duplicate raw suppressed");
+  await h.lp.handleAudio(1, chunk(0, false));
+  await h.lp.handleAudio(1, chunk(0, false));
+  assert.deepStrictEqual(raws(h), ["same text"]);
 });
 
-test("a partial that finishes after the session ends is dropped", async () => {
+test("a chunk that finishes decoding after the session ends is dropped", async () => {
   const h = harness();
   const d = deferred();
   h.setTranscribe(() => d.promise);
-  const p = h.lp.handleAudio(1, wav);
+  const p = h.lp.handleAudio(1, chunk(0, false));
   h.setCurrent(false); // session ends mid-decode
   d.resolve("late text");
   await p;
-  assert.strictEqual(h.sent.length, 0, "stale result not shown");
+  assert.strictEqual(h.sent.length, 0);
 });
 
-test("cleanup runs over the full raw text after the pause and is sent", async () => {
+test("cleanup runs only on newly committed text and appends to the cleaned line", async () => {
   const h = harness();
-  h.setTranscribe(async () => "the quick brown fox");
+  h.setTranscribe(async () => "the first chunk");
   h.setCleanup(async (raw) => {
-    assert.strictEqual(raw, "the quick brown fox", "cleanup gets the full raw text");
-    return "The quick brown fox.";
+    assert.strictEqual(raw, "the first chunk", "cleanup gets only the committed chunk text");
+    return "The first chunk.";
   });
-  await h.lp.handleAudio(1, wav);
-  // Wait past the 5ms cleanupPauseMs for the scheduled cleanup to fire.
-  await new Promise((r) => setTimeout(r, 20));
-  assert.deepStrictEqual(cleans(h), ["The quick brown fox."]);
+  await h.lp.handleAudio(1, chunk(0, true));
+  await tick();
+  assert.strictEqual(lastClean(h), "The first chunk.");
+
+  // A second committed chunk cleans only the new text, appended to the line.
+  h.setTranscribe(async () => "second chunk");
+  h.setCleanup(async (raw) => {
+    assert.strictEqual(raw, "second chunk", "second pass cleans only the new chunk");
+    return "Second chunk.";
+  });
+  await h.lp.handleAudio(1, chunk(1, true));
+  await tick();
+  assert.strictEqual(lastClean(h), "The first chunk. Second chunk.", "cleaned line accumulates");
 });
 
 test("cleanup is skipped when cleanup is disabled", async () => {
   const h = harness({ cfg: builtinCfg({ cleanup: { enabled: false, engine: "builtin" } }) });
-  await h.lp.handleAudio(1, wav);
-  await new Promise((r) => setTimeout(r, 20));
+  await h.lp.handleAudio(1, chunk(0, true));
+  await tick();
   assert.strictEqual(h.cleanupCalls.length, 0);
 });
 
 test("cleanup is skipped when the cleanup engine is remote", async () => {
   const h = harness({ cfg: builtinCfg({ cleanup: { enabled: true, engine: "remote" } }) });
-  await h.lp.handleAudio(1, wav);
-  await new Promise((r) => setTimeout(r, 20));
-  assert.strictEqual(h.cleanupCalls.length, 0, "remote cleanup not hit mid-dictation");
+  await h.lp.handleAudio(1, chunk(0, true));
+  await tick();
+  assert.strictEqual(h.cleanupCalls.length, 0);
 });
 
-test("cancel aborts in-flight work and resets state so later results are dropped", async () => {
+test("an in-progress (non-final) chunk does not trigger cleanup", async () => {
+  const h = harness();
+  await h.lp.handleAudio(1, chunk(0, false)); // not committed
+  await tick();
+  assert.strictEqual(h.cleanupCalls.length, 0, "only committed chunks are cleaned");
+});
+
+test("cancel aborts in-flight work and resets accumulators", async () => {
   const h = harness();
   const d = deferred();
-  h.setTranscribe((wavArg, cfg, signal) => {
-    // The injected signal should be aborted by cancel().
-    return d.promise.then((v) => {
+  h.setTranscribe((wavArg, cfg, signal) =>
+    d.promise.then((v) => {
       assert.ok(signal.aborted, "signal aborted by cancel()");
       return v;
-    });
-  });
-  const p = h.lp.handleAudio(1, wav);
+    })
+  );
+  const p = h.lp.handleAudio(1, chunk(0, false));
   h.lp.cancel();
   d.resolve("after cancel");
   await p;
   assert.strictEqual(h.sent.length, 0, "nothing sent after cancel");
 
-  // After cancel, a fresh partial works again (busy flag was reset).
+  // After cancel, accumulators are reset: a fresh chunk 0 starts clean.
   h.setTranscribe(async () => "fresh");
-  await h.lp.handleAudio(1, wav);
+  await h.lp.handleAudio(1, chunk(0, false));
   assert.deepStrictEqual(raws(h), ["fresh"]);
 });
 
-test("cleanup re-arms when the raw text grew during a cleanup pass", async () => {
-  // The catch-up loop: if more is spoken while a cleanup runs, a second pass must
-  // fire over the newer raw text so the cleaned line keeps up.
+test("cleanup re-arms when more committed while a cleanup pass ran", async () => {
   const h = harness();
-  let rawText = "first chunk";
-  h.setTranscribe(async () => rawText);
+  h.setTranscribe(async () => "chunk zero");
   const d1 = deferred();
   let cleanupN = 0;
   h.setCleanup(async (raw) => {
     cleanupN++;
     if (cleanupN === 1) {
-      // While this first cleanup is in flight, more audio arrives.
-      rawText = "first chunk second chunk";
-      await h.lp.handleAudio(1, wav); // updates lastRaw to the longer text
+      // While this first cleanup is in flight, another chunk commits.
+      h.setTranscribe(async () => "chunk one");
+      await h.lp.handleAudio(1, chunk(1, true));
       return d1.promise;
     }
-    return `cleaned: ${raw}`;
+    return `cleaned:${raw}`;
   });
 
-  await h.lp.handleAudio(1, wav); // raw "first chunk"
-  await new Promise((r) => setTimeout(r, 20)); // first cleanup starts, awaits d1
-  d1.resolve("cleaned: first chunk"); // first pass completes -> should re-arm
-  await new Promise((r) => setTimeout(r, 20)); // second pass fires over newer raw
+  await h.lp.handleAudio(1, chunk(0, true)); // commit chunk 0 -> schedules cleanup
+  await tick(); // first cleanup starts, awaits d1
+  d1.resolve("cleaned:chunk zero");
+  await tick(); // re-arm fires for the newly committed chunk 1
 
-  assert.strictEqual(cleanupN, 2, "a second cleanup pass ran over the grown raw text");
-  assert.ok(
-    cleans(h).includes("cleaned: first chunk second chunk"),
-    "the re-armed cleanup cleaned the full grown text"
-  );
+  assert.strictEqual(cleanupN, 2, "a second cleanup pass ran for the later chunk");
+  assert.ok(cleans(h).some((t) => t.includes("chunk one")), "the later chunk was cleaned");
 });
 
 test("cancel during a cleanup await prevents a re-armed pause timer", async () => {
   const h = harness();
-  let rawText = "alpha";
-  h.setTranscribe(async () => rawText);
+  h.setTranscribe(async () => "c-zero");
   const d = deferred();
   let cleanupN = 0;
   h.setCleanup(async () => {
     cleanupN++;
-    rawText = "alpha beta"; // grow so the reschedule condition would be true
-    await h.lp.handleAudio(1, wav);
+    h.setTranscribe(async () => "c-one");
+    await h.lp.handleAudio(1, chunk(1, true)); // more committed during the await
     return d.promise;
   });
 
-  await h.lp.handleAudio(1, wav);
-  await new Promise((r) => setTimeout(r, 20)); // cleanup in flight
-  h.lp.cancel(); // abort during the cleanup await
+  await h.lp.handleAudio(1, chunk(0, true));
+  await tick(); // cleanup in flight
+  h.lp.cancel();
   d.resolve("late cleaned");
-  await new Promise((r) => setTimeout(r, 20)); // give any (wrongly) re-armed timer time
+  await tick();
 
   assert.strictEqual(cleanupN, 1, "no second cleanup after cancel");
   assert.strictEqual(cleans(h).length, 0, "cancelled cleanup result not sent");
-});
-
-test("a second cleanup over unchanged raw text is a no-op", async () => {
-  // runCleanupPass bails when lastRaw === lastCleanedRaw: re-cleaning the same
-  // text would just re-emit identical output and waste an inference.
-  const h = harness();
-  h.setTranscribe(async () => "steady text");
-  let cleanupN = 0;
-  h.setCleanup(async (raw) => {
-    cleanupN++;
-    return `clean ${raw}`;
-  });
-  await h.lp.handleAudio(1, wav);
-  await new Promise((r) => setTimeout(r, 20)); // first (and only) cleanup
-  // A duplicate raw partial doesn't change lastRaw, so no new cleanup is scheduled.
-  await h.lp.handleAudio(1, wav);
-  await new Promise((r) => setTimeout(r, 20));
-  assert.strictEqual(cleanupN, 1, "unchanged raw text isn't re-cleaned");
 });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -205,7 +205,7 @@ test("live preview defaults are present and overridable", () => {
   const lp = DEFAULTS.stt.livePreview;
   assert.strictEqual(lp.enabled, true);
   assert.ok(lp.intervalMs > 0);
-  assert.ok(lp.maxSeconds >= 0);
+  assert.ok(lp.chunkSeconds > 0);
   assert.ok(lp.cleanupPauseMs > 0);
 
   // A saved file that only flips the toggle keeps the rest of the tuning.

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -245,6 +245,15 @@ test("reconcileTranscript tails after the anchor despite filler before it", () =
   assert.strictEqual(r.hasText, true);
 });
 
+test("reconcileTranscript anchors on the LAST occurrence of a repeated word", () => {
+  // The anchor word ("timer") appears twice; only a last-match scan tails the
+  // words after its final occurrence. A first-match implementation would wrongly
+  // tail "then set the timer for tea".
+  const r = reconcileTranscript("set the timer then set the timer for tea", "Set the timer");
+  assert.strictEqual(r.tail, " for tea");
+  assert.strictEqual(r.hasText, true);
+});
+
 test("reconcileTranscript shows raw only when there's no cleaned text yet", () => {
   const r = reconcileTranscript("hello world", "");
   assert.strictEqual(r.clean, "");

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10,6 +10,7 @@ const { encodeWav, encodeSilenceWav, wavToFloat32 } = require("../main/util/wav"
 const { stripThinking } = require("../main/services/cleanup");
 const { deepMerge, migrateLegacy, DEFAULTS } = require("../main/settings");
 const { listRemoteModels } = require("../main/services/models-remote");
+const { reconcileTranscript } = require("../renderer/transcript");
 
 test("encodeWav produces a valid RIFF header", () => {
   const samples = new Int16Array([0, 1000, -1000, 32767, -32768]);
@@ -196,6 +197,100 @@ test("new installs default to in-process engines", () => {
   assert.strictEqual(DEFAULTS.cleanup.enabled, true);
   assert.ok(DEFAULTS.stt.builtin.model);
   assert.ok(DEFAULTS.cleanup.builtin.model);
+});
+
+/* ---------------- live preview ---------------- */
+
+test("live preview defaults are present and overridable", () => {
+  const lp = DEFAULTS.stt.livePreview;
+  assert.strictEqual(lp.enabled, true);
+  assert.ok(lp.intervalMs > 0);
+  assert.ok(lp.maxSeconds >= 0);
+  assert.ok(lp.cleanupPauseMs > 0);
+
+  // A saved file that only flips the toggle keeps the rest of the tuning.
+  const off = deepMerge(DEFAULTS, { stt: { livePreview: { enabled: false } } });
+  assert.strictEqual(off.stt.livePreview.enabled, false);
+  assert.strictEqual(off.stt.livePreview.intervalMs, lp.intervalMs);
+  assert.strictEqual(off.stt.livePreview.cleanupPauseMs, lp.cleanupPauseMs);
+});
+
+/* ---------------- two-layer transcript reconcile ---------------- */
+
+test("reconcileTranscript shows freshly-spoken words as the faint tail", () => {
+  // Cleanup has processed the first four words (fixing case); the fifth was
+  // spoken since, so it shows as the not-yet-cleaned tail. Anchoring on the
+  // cleaned line's last word survives cleanup's capitalization changes.
+  const r = reconcileTranscript("the quick brown fox jumps", "The quick brown fox");
+  assert.strictEqual(r.clean, "The quick brown fox");
+  assert.strictEqual(r.tail, " jumps");
+  assert.strictEqual(r.hasText, true);
+});
+
+test("reconcileTranscript doesn't re-show words when cleanup removed filler", () => {
+  // The whole reason cleanup exists: it drops "um" and collapses the stutter, so
+  // the cleaned line has fewer words than the raw words it represents. Anchoring
+  // on the last cleaned word ("quick") instead of a word-count offset means the
+  // already-covered words are NOT duplicated into the tail.
+  const r = reconcileTranscript("um the the quick", "The quick");
+  assert.strictEqual(r.clean, "The quick");
+  assert.strictEqual(r.tail, ""); // "quick" is the last raw word — nothing fresh
+  assert.strictEqual(r.hasText, true);
+});
+
+test("reconcileTranscript tails after the anchor despite filler before it", () => {
+  // Filler before the anchor word, plus genuinely fresh words after it.
+  const r = reconcileTranscript("um so the quick brown fox runs fast", "So the quick brown fox");
+  assert.strictEqual(r.tail, " runs fast");
+  assert.strictEqual(r.hasText, true);
+});
+
+test("reconcileTranscript shows raw only when there's no cleaned text yet", () => {
+  const r = reconcileTranscript("hello world", "");
+  assert.strictEqual(r.clean, "");
+  assert.strictEqual(r.tail, "hello world");
+  assert.strictEqual(r.hasText, true);
+});
+
+test("reconcileTranscript shows the cleaned line alone when the ending was reworded", () => {
+  // Cleanup reworded the tail ("alice" never appears in raw), so the anchor isn't
+  // found: show the authoritative cleaned line without guessing a tail.
+  const r = reconcileTranscript("send it to bob", "Send it to Bob, no to Alice.");
+  assert.strictEqual(r.clean, "Send it to Bob, no to Alice.");
+  assert.strictEqual(r.tail, "");
+  assert.strictEqual(r.hasText, true);
+});
+
+test("reconcileTranscript reports no text when both are empty", () => {
+  const r = reconcileTranscript("", "");
+  assert.strictEqual(r.hasText, false);
+  assert.strictEqual(r.clean, "");
+  assert.strictEqual(r.tail, "");
+});
+
+test("reconcileTranscript treats the anchor as the last raw word as no tail", () => {
+  const r = reconcileTranscript("all done", "All done.");
+  assert.strictEqual(r.clean, "All done.");
+  assert.strictEqual(r.tail, "");
+  assert.strictEqual(r.hasText, true);
+});
+
+test("reconcileTranscript collapses internal whitespace in the tail", () => {
+  // The tail is rebuilt from split tokens, so runs of spaces normalize to one.
+  const r = reconcileTranscript("the quick   brown  fox jumps", "The quick brown fox");
+  assert.strictEqual(r.tail, " jumps");
+});
+
+test("reconcileTranscript hides whitespace-only input", () => {
+  // Whitespace-only clean is treated as no clean; whitespace-only raw with no
+  // clean yields no visible text so the overlay panel stays hidden.
+  const a = reconcileTranscript("hello world", "   ");
+  assert.strictEqual(a.clean, "");
+  assert.strictEqual(a.tail, "hello world");
+  assert.strictEqual(a.hasText, true);
+
+  const b = reconcileTranscript("   ", "");
+  assert.strictEqual(b.hasText, false);
 });
 
 /* ---------------- remote model listing ---------------- */


### PR DESCRIPTION
## Summary

Adds a **live transcript preview** to Earheart: press the hotkey and the text fills in as you speak, with a cleaned-up version settling in behind the raw words on pauses. The final transcript on stop is unchanged. Built around an append-only chunked design so cost stays flat regardless of how long you talk, and a unified overlay card that grows to show the whole transcript.

Default-on for the built-in engine; toggle under Settings → Speech-to-text.

## What's inside

**Engine layer**
- Split the single in-process engine worker into **two** (STT + cleanup) via a `createHost()` factory, so they run in parallel and a native crash in one can't take down the other. Each lazily forks, so a transcribe-only user never spawns the cleanup worker.

**Live preview pipeline** (`main/live-preview.js`, injected-deps, unit-tested)
- **Append-only chunked transcription.** The overlay ships audio in ~5s chunks; each is transcribed once and accumulated. Only the in-progress chunk is re-decoded each tick, so decode cost is flat (~370ms/chunk) instead of O(n²) over the whole buffer.
  - Measured before/after: whole-buffer decode climbed 0.4s → 1.7s → **6.3s** at 73s and crashed the app; chunked stays flat through 66s+ of continuous dictation.
- Cleanup is incremental too — only newly committed text is cleaned and appended.
- Drop-if-busy per stage, session/abort guarding, builtin-engine-only gating.

**Overlay (redesigned + design-reviewed)**
- One unified card: transcript on top (cleaned line + faint raw tail), grows freely; a slim control row (meter / status / timer / stop / cancel) at the bottom.
- Drag grip handle, accent discipline (red reserved for the stop button), aligned spacing, 15px transcript, ~40px hit targets, `:focus-visible`, eased height growth, `aria-live` status for screen readers.

## Testing

- 70 unit tests (was 16) covering the two-host routing + crash isolation, the live-preview state machine (chunking, drop-if-busy, cancel/abort, cleanup re-arm), and the two-layer reconcile.
- `make smoke` boots clean.
- Ran through two `/review-pr` rounds (correctness/architecture/tests/security — converged) and a five-lens visual-design review (converged).

## Notes

- New IPC channels (`audio:partial`, `pipeline:partial`, `overlay:resize`) are whitelisted in `preload.js`.
- The overlay window is now `resizable: true` (required so the card can grow — macOS ignores programmatic height changes on a non-resizable window); it's frameless so there are no user-facing resize handles.
- Design doc: `docs/live-transcription-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
