### PR TITLE
fix: drop the Intel macos-13 build that stalled releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,12 @@ jobs:
       # One platform failing must not cancel the other platforms' uploads.
       fail-fast: false
       matrix:
-        # macos-latest is Apple Silicon (arm64); macos-13 is Intel (x64). Each
-        # builds for its own arch so the per-arch native addons npm installed on
-        # that host are the ones that ship — see electron-builder.yml.
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        # macos-latest is Apple Silicon (arm64) — the only macOS build we ship;
+        # Intel Macs run it under Rosetta. The Intel (x64) macos-13 leg was
+        # dropped: its GitHub-hosted runner repeatedly sat queued with no host,
+        # which left the publish-release gate (needs all builds) waiting forever
+        # and stranded v0.7.0/v0.8.0 as unpublished drafts.
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,11 +42,12 @@ linux:
     entry:
       StartupWMClass: earheart
 
-# The release matrix builds macOS on two runners — arm64 on macos-latest and
-# x64 on the Intel macos-13 runner — so the per-arch native addons
-# (sherpa-onnx-darwin-* and @node-llama-cpp/mac-*) are the ones npm actually
-# installed on that host. Each run defaults to the host arch; cross-compiling
-# both from one runner would bundle the wrong-arch native binaries.
+# macOS builds on macos-latest (arm64) only; the build defaults to the host arch,
+# so the per-arch native addons (sherpa-onnx-darwin-arm64 and
+# @node-llama-cpp/mac-arm64) npm installed on that host are the ones that ship.
+# Cross-compiling x64 from this runner would bundle the wrong-arch native
+# binaries, so we don't — Intel Macs run the arm64 build under Rosetta. (The
+# x64 macos-13 runner was dropped from the release matrix; see release.yml.)
 mac:
   target:
     - dmg


### PR DESCRIPTION
## Problem

The release builds for v0.7.0 and v0.8.0 stalled, leaving them as unpublished **draft** releases. Root cause: the Intel (x64) **`macos-13`** leg of the release matrix repeatedly sat in `status=queued` with no GitHub-hosted runner ever picking it up, while every other platform (ubuntu, macos-latest arm64, windows) succeeded.

Because `publish-release` `needs: [create-release, build]` and gates on `needs.build.result == 'success'`, it waits for the *entire* matrix — so a `macos-13` job stuck queued forever means the release never flips from draft to published.

(v0.8.0 was manually published and the orphaned v0.7.0 draft deleted; this prevents a recurrence.)

## Fix

Drop `macos-13` from the release matrix. macOS now ships **arm64 only** (`macos-latest`); Intel Macs run it under Rosetta. With no Intel-mac job, the publish gate can no longer be blocked by a missing x64 runner.

- `release.yml`: matrix is now `[ubuntu-latest, macos-latest, windows-latest]`.
- `electron-builder.yml`: updated the stale "builds macOS on two runners" note.

## Tradeoff

We stop shipping a native x64 macOS build. Intel-mac users get the arm64 build via Rosetta (works, slightly slower startup) rather than a native binary. If a native Intel build is wanted back later, re-add `macos-13` *and* make the publish gate tolerant of one platform missing (e.g. a per-job timeout so a stuck runner fails terminally instead of hanging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
