### PR TITLE
fix(live-preview): re-clean whole transcript so live tracks the final

### DIFF
--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -2,12 +2,21 @@
 // side-channel state machine separate from the pipeline's authoritative
 // record→transcribe→clean→deliver flow, which just wires it.
 //
-// Append-only chunking is what keeps cost flat: the overlay ships audio in
-// chunks and we re-decode only the current in-progress chunk, so decode (and
-// incremental cleanup) cost is bounded by one chunk — not the whole growing
-// buffer, which was O(n²) and stalled the app after ~30s. The accumulator
-// comments below describe the resulting state. All best-effort and silent: a
-// dropped or failed partial is cosmetic and must never disturb the dictation.
+// Append-only chunking is what keeps DECODE cost flat: the overlay ships audio
+// in chunks and we re-decode only the current in-progress chunk, so decode cost
+// is bounded by one chunk — not the whole growing buffer, which was O(n²) and
+// stalled the app after ~30s. The accumulator comments below describe the
+// resulting state.
+//
+// Cleanup, by contrast, re-cleans the WHOLE committed transcript on each pause
+// rather than appending per-chunk: `clean(a) + clean(b)` reads very differently
+// from `clean(a + b)` (filler removal, sentence merging and punctuation all need
+// surrounding context), so cleaning the whole thing is what makes the live
+// cleaned line track the authoritative final whole-text clean. It's O(n) but
+// gated to pauses and drop-if-busy, so it stays cheap in practice.
+//
+// All best-effort and silent: a dropped or failed partial is cosmetic and must
+// never disturb the dictation.
 //
 // Dependencies are injected so the module stays free of the pipeline's private
 // session/state and is unit-testable:
@@ -29,9 +38,9 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
 
   // Append-only accumulators.
   let committedRaw = ""; // text from finalized chunks (never re-decoded)
-  let committedClean = ""; // cleaned text from finalized chunks
+  let committedClean = ""; // whole committed raw, cleaned in one pass (mirrors the final clean)
   let liveRaw = ""; // decode of the current in-progress chunk (replaced each tick)
-  let uncleanedRaw = ""; // committed raw text awaiting cleanup
+  let lastCleanedRaw = ""; // the committedRaw value committedClean was produced from
   let lastSeq = -1; // highest chunk seq we've committed
   let pauseTimer = null; // fires a cleanup pass once a chunk has committed + settled
 
@@ -39,7 +48,7 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
     committedRaw = "";
     committedClean = "";
     liveRaw = "";
-    uncleanedRaw = "";
+    lastCleanedRaw = "";
     lastSeq = -1;
   }
 
@@ -89,7 +98,6 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
         lastSeq = seq;
         committedRaw = joinText(committedRaw, text);
         liveRaw = "";
-        uncleanedRaw = joinText(uncleanedRaw, text);
         pushRaw();
         scheduleCleanup(sid, cfg, signal);
       } else {
@@ -105,9 +113,10 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
     }
   }
 
-  // After a chunk commits and the dictation settles for the pause window, clean
-  // ONLY the newly committed text (uncleanedRaw) and append it to the cleaned
-  // line. Flat cost — we never re-clean the whole transcript.
+  // After a chunk commits and the dictation settles for the pause window,
+  // re-clean the WHOLE committed transcript and replace the cleaned line with the
+  // result. Cleaning the whole thing (rather than appending per-chunk) is what
+  // makes the live cleaned line read like the authoritative final clean.
   function scheduleCleanup(sid, cfg, signal) {
     // Only clean live when cleanup is on and runs in-process: a remote cleanup
     // endpoint shouldn't be hit repeatedly mid-dictation. The final pass on stop
@@ -124,31 +133,26 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
   async function runCleanupPass(sid, cfg, signal) {
     if (stale(sid, signal)) return;
     if (cleanupBusy) return; // drop-if-busy
-    const toClean = uncleanedRaw.trim();
-    if (!toClean) return; // nothing new committed to clean
+    const toClean = committedRaw.trim();
+    if (!toClean || toClean === lastCleanedRaw) return; // nothing new committed to clean
     cleanupBusy = true;
-    uncleanedRaw = "";
     try {
       const cleaned = await runCleanup(toClean, cfg.cleanup, signal);
-      if (stale(sid, signal)) {
-        // Put the text back so a later (non-stale) pass still cleans it.
-        uncleanedRaw = joinText(toClean, uncleanedRaw);
-        return;
-      }
+      if (stale(sid, signal)) return; // lastCleanedRaw unchanged; a later pass retries
       const text = (cleaned || "").trim();
       if (text) {
-        committedClean = joinText(committedClean, text);
+        committedClean = text;
+        lastCleanedRaw = toClean;
         sendToOverlay("pipeline:partial", { kind: "cleaned", text: committedClean });
       }
     } catch {
-      // Cosmetic: a failed partial cleanup just leaves the raw tail showing.
-      // Restore the pending text so the next pass retries it.
-      uncleanedRaw = joinText(toClean, uncleanedRaw);
+      // Cosmetic: a failed pass just leaves the raw tail showing. lastCleanedRaw
+      // is unchanged, so the next pause re-cleans the whole transcript and retries.
     } finally {
       cleanupBusy = false;
-      // More may have committed while we were cleaning; if so, clean it after the
+      // More may have committed while we were cleaning; if so, re-clean after the
       // next pause. Bail if stale (cancelled/ended) so a dead pass can't re-arm.
-      if (!stale(sid, signal) && uncleanedRaw.trim()) {
+      if (!stale(sid, signal) && committedRaw.trim() !== lastCleanedRaw) {
         scheduleCleanup(sid, cfg, signal);
       }
     }

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -136,26 +136,42 @@ test("a chunk that finishes decoding after the session ends is dropped", async (
   assert.strictEqual(h.sent.length, 0);
 });
 
-test("cleanup runs only on newly committed text and appends to the cleaned line", async () => {
+test("cleanup re-cleans the whole committed transcript and replaces the cleaned line", async () => {
   const h = harness();
   h.setTranscribe(async () => "the first chunk");
   h.setCleanup(async (raw) => {
-    assert.strictEqual(raw, "the first chunk", "cleanup gets only the committed chunk text");
+    assert.strictEqual(raw, "the first chunk", "first pass cleans the whole committed transcript");
     return "The first chunk.";
   });
   await h.lp.handleAudio(1, chunk(0, true));
   await tick();
   assert.strictEqual(lastClean(h), "The first chunk.");
 
-  // A second committed chunk cleans only the new text, appended to the line.
+  // A second committed chunk re-cleans the WHOLE transcript (both chunks) and the
+  // cleaned line is replaced with that result — not appended per-chunk. Cleaning
+  // the whole thing is what makes the live cleaned line read like the final clean.
   h.setTranscribe(async () => "second chunk");
   h.setCleanup(async (raw) => {
-    assert.strictEqual(raw, "second chunk", "second pass cleans only the new chunk");
-    return "Second chunk.";
+    assert.strictEqual(raw, "the first chunk second chunk", "second pass cleans the full transcript");
+    return "The first chunk, second chunk.";
   });
   await h.lp.handleAudio(1, chunk(1, true));
   await tick();
-  assert.strictEqual(lastClean(h), "The first chunk. Second chunk.", "cleaned line accumulates");
+  assert.strictEqual(lastClean(h), "The first chunk, second chunk.", "cleaned line is replaced, not appended");
+});
+
+test("no new commit means no redundant re-clean", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "only chunk");
+  await h.lp.handleAudio(1, chunk(0, true)); // commit -> one cleanup pass
+  await tick();
+  const passesAfterFirst = h.cleanupCalls.length;
+  // A growing in-progress (non-final) chunk commits nothing new, so the cleaned
+  // line must not be re-cleaned.
+  h.setTranscribe(async () => "only chunk more");
+  await h.lp.handleAudio(1, chunk(1, false));
+  await tick();
+  assert.strictEqual(h.cleanupCalls.length, passesAfterFirst, "no extra clean without a new commit");
 });
 
 test("cleanup is skipped when cleanup is disabled", async () => {


### PR DESCRIPTION
## Problem

The live transcript shown while recording diverged noticeably from the final text users actually get. The biggest cause was **cleanup**: the live cleaned line was a concatenation of independently-cleaned 5-second chunks (`clean(a) + clean(b) + …`), while the final pass cleans the **whole** transcript in one shot (`clean(a + b + …)`).

Cleanup removes fillers, merges sentences, and fixes punctuation using surrounding context, so per-chunk cleaning reads very differently from whole-text cleaning — which is what made the preview a poor predictor of the final.

## Change

Re-clean the **whole committed transcript** on each pause and replace the cleaned line with the result, mirroring the final whole-text clean. Implementation notes:

- Dropped the `uncleanedRaw` fragment accumulator; added `lastCleanedRaw` to track what the cleaned line was produced from. A failed or stale pass leaves `lastCleanedRaw` unchanged, so the next pause simply re-cleans the whole transcript and retries.
- **Decode is untouched** — transcription stays append-only chunked (only the in-progress chunk is re-decoded each tick), so the O(n²) decode stall the original design avoided is still avoided.
- Cleanup stays bounded by its existing **pause-gating + drop-if-busy** guards, so it self-throttles on long dictations (the cleaned line just refreshes less often) rather than stalling or queuing.

## Trade-offs

- Each live cleanup pass now scales with transcript length (the largest is ~comparable to the final clean). Drop-if-busy caps concurrency to one, so it degrades gracefully.
- The cleaned line can now visibly re-punctuate earlier sentences as more context arrives — expected, and exactly what makes it match the final. If it ever reads as jittery, `cleanupPauseMs` is the knob.
- Only affects in-process (builtin) cleanup; remote cleanup is still skipped during live recording.

## Tests

- Updated the test that asserted per-chunk appending to assert whole-transcript re-cleaning.
- Added a guard test: no new commit → no redundant re-clean.
- Full suite passes (71 pass, 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)