### PR TITLE
fix(wizard): default to built-in engines; close Settings on save

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,102 @@
+name: Bug report
+description: Something in Earheart isn't working the way you expect.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! A clear, reproducible report
+        is the fastest path to a fix. Please fill in as much as you can.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What went wrong, and what did you expect instead?
+      placeholder: |
+        I pressed the hotkey, spoke, and pressed it again, but no text was pasted.
+        I expected the transcript to land in the focused app.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact sequence that triggers the bug.
+      placeholder: |
+        1. Launch Earheart
+        2. Focus a text field in <app>
+        3. Press Ctrl/Cmd+Shift+Space, speak, press again
+        4. …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: e.g. macOS 15.5, Windows 11 23H2, Ubuntu 24.04 (and desktop, e.g. GNOME/Wayland).
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Earheart version
+      description: From the tray menu / installer filename, or the commit if running from source.
+      placeholder: v0.8.1
+    validations:
+      required: true
+
+  - type: dropdown
+    id: stt-engine
+    attributes:
+      label: Speech-to-text engine
+      description: Settings → Speech-to-text.
+      options:
+        - Built-in (Parakeet, in-process)
+        - Local server (stt-server)
+        - Remote / hosted (OpenAI-compatible)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cleanup-engine
+    attributes:
+      label: Cleanup engine
+      description: Settings → Cleanup.
+      options:
+        - Built-in (Gemma, in-process)
+        - Remote / hosted (OpenAI-compatible)
+        - Cleanup disabled
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / errors
+      description: |
+        Any error text, console output, or relevant log lines. Launch from a
+        terminal (`npm start`) to capture main-process logs if you can.
+      render: shell
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, the affected target app, network setup, or other context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & ideas (Discussions)
+    url: https://github.com/cleanunicorn/earheart/discussions
+    about: Ask a question, share a setup, or float an idea before filing an issue.
+  - name: STT server (stt-server)
+    url: https://github.com/cleanunicorn/earheart/blob/master/stt-server/README.md
+    about: Options, GPU providers and models for the optional local Parakeet server.
+  - name: Contributing guide
+    url: https://github.com/cleanunicorn/earheart/blob/master/CONTRIBUTING.md
+    about: Dev setup, architecture, and how releases are cut.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea or improvement for Earheart.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Earheart is intentionally small and hackable. Proposals that keep it
+        lean — few runtime dependencies, private by default — are the easiest
+        to land. See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for the
+        design constraints worth keeping.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: The use case or frustration behind the request. What can't you do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like to see. How might it look or behave?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed, or existing settings/workarounds you've tried.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, links, or related issues.

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -42,6 +42,12 @@ function init({ applyHotkey, onSettingsChanged }) {
     return { settings: saved, hotkey: hotkeyResult };
   });
 
+  // Close the settings window. The renderer calls this after a successful save
+  // so the user doesn't have to dismiss it manually.
+  ipcMain.handle("settings:close", () => {
+    windows.closeSettings();
+  });
+
   // Settings → Advanced: re-run the setup wizard on demand. The wizard
   // itself doesn't change anything until it is completed.
   ipcMain.handle("wizard:open", () => {

--- a/main/windows.js
+++ b/main/windows.js
@@ -261,6 +261,10 @@ function closeWizard() {
   if (wizardWindow && !wizardWindow.isDestroyed()) wizardWindow.close();
 }
 
+function closeSettings() {
+  if (settingsWindow && !settingsWindow.isDestroyed()) settingsWindow.close();
+}
+
 function sendToSettings(channel, payload) {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
     settingsWindow.webContents.send(channel, payload);
@@ -287,4 +291,5 @@ module.exports = {
   broadcast,
   openWizard,
   closeWizard,
+  closeSettings,
 };

--- a/preload.js
+++ b/preload.js
@@ -28,6 +28,7 @@ const SEND = new Set([
 const INVOKE = new Set([
   "settings:get",
   "settings:save",
+  "settings:close",
   "wizard:complete",
   "wizard:skip",
   "wizard:open",

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -381,15 +381,19 @@ $("save").addEventListener("click", async () => {
   }
   current = result.settings;
   if (result.hotkey.ok) {
+    // Clean save — close the window so the user doesn't have to dismiss it.
     save.textContent = "Saved";
     save.className = "status ok";
     hotkeyStatus.textContent = "";
-  } else {
-    save.textContent = "Saved, but the hotkey could not be registered";
-    save.className = "status err";
-    hotkeyStatus.textContent = result.hotkey.error;
-    hotkeyStatus.className = "status err";
+    earheart.invoke("settings:close");
+    return;
   }
+  // The hotkey couldn't be registered: keep the window open so the error is
+  // visible and the user can pick a combination that works.
+  save.textContent = "Saved, but the hotkey could not be registered";
+  save.className = "status err";
+  hotkeyStatus.textContent = result.hotkey.error;
+  hotkeyStatus.className = "status err";
   setTimeout(() => {
     save.textContent = "";
   }, 4000);

--- a/renderer/wizard.html
+++ b/renderer/wizard.html
@@ -106,18 +106,7 @@
 
       <!-- 4. Speech-to-text -->
       <section class="step" id="step-stt">
-        <h2>Where should speech become text?</h2>
-        <div class="field">
-          <label class="choice">
-            <input type="radio" name="stt-mode" value="builtin" checked />
-            On this computer, built in
-            <span class="muted">(recommended — no setup)</span>
-          </label>
-          <label class="choice">
-            <input type="radio" name="stt-mode" value="remote" />
-            A remote service <span class="muted">(OpenAI, Groq, your own server, …)</span>
-          </label>
-        </div>
+        <h2>Speech becomes text on this computer</h2>
 
         <div id="stt-builtin-fields">
           <div class="value-card">
@@ -137,30 +126,10 @@
           </div>
         </div>
 
-        <div id="stt-remote-fields" hidden>
-          <p class="lead">
-            Any service that speaks the OpenAI audio transcription API works.
-          </p>
-          <div class="field">
-            <label for="stt-url">Base URL</label>
-            <input id="stt-url" placeholder="https://api.openai.com/v1" />
-          </div>
-          <div class="grid-2">
-            <div class="field">
-              <label for="stt-key">API key</label>
-              <input id="stt-key" type="password" autocomplete="off" />
-            </div>
-            <div class="field">
-              <label for="stt-model">Model</label>
-              <input id="stt-model" placeholder="whisper-1" />
-            </div>
-          </div>
-        </div>
-
-        <div class="row" id="stt-test-row" hidden>
-          <button id="stt-test">Test connection</button>
-          <span id="stt-test-result" class="status"></span>
-        </div>
+        <p class="hint">
+          Prefer a remote service (OpenAI, Groq, your own server)? You can
+          switch to one anytime in Settings.
+        </p>
       </section>
 
       <!-- 5. Cleanup -->
@@ -179,17 +148,6 @@
         </div>
 
         <div id="cleanup-fields">
-          <div class="field">
-            <label class="choice">
-              <input type="radio" name="cleanup-mode" value="builtin" checked />
-              On this computer, built in <span class="muted">(no setup)</span>
-            </label>
-            <label class="choice">
-              <input type="radio" name="cleanup-mode" value="external" />
-              An OpenAI-compatible service <span class="muted">(Ollama, LM Studio, OpenAI, …)</span>
-            </label>
-          </div>
-
           <div id="cleanup-builtin-fields">
             <div class="value-card">
               <p class="lead">
@@ -204,26 +162,10 @@
             </div>
           </div>
 
-          <div id="cleanup-external-fields" hidden>
-            <div class="field">
-              <label for="cleanup-url">Base URL</label>
-              <input id="cleanup-url" placeholder="http://127.0.0.1:11434/v1" />
-            </div>
-            <div class="grid-2">
-              <div class="field">
-                <label for="cleanup-key">API key <span class="muted">(optional for local servers)</span></label>
-                <input id="cleanup-key" type="password" autocomplete="off" />
-              </div>
-              <div class="field">
-                <label for="cleanup-model">Model</label>
-                <input id="cleanup-model" placeholder="llama3.2" />
-              </div>
-            </div>
-            <div class="row">
-              <button id="cleanup-test">Test connection</button>
-              <span id="cleanup-test-result" class="status"></span>
-            </div>
-          </div>
+          <p class="hint">
+            Prefer an OpenAI-compatible service (Ollama, LM Studio, OpenAI)? You
+            can point cleanup at one anytime in Settings.
+          </p>
         </div>
       </section>
 

--- a/renderer/wizard.js
+++ b/renderer/wizard.js
@@ -126,44 +126,18 @@ async function loadMicrophones() {
   }
 }
 
-/* ---------- speech-to-text mode ---------- */
-
-function sttMode() {
-  return document.querySelector('input[name="stt-mode"]:checked').value;
-}
-
-function syncSttMode() {
-  const mode = sttMode();
-  $("stt-builtin-fields").hidden = mode !== "builtin";
-  $("stt-remote-fields").hidden = mode !== "remote";
-  // The connection test only makes sense for an external endpoint.
-  $("stt-test-row").hidden = mode !== "remote";
-}
-
-document
-  .querySelectorAll('input[name="stt-mode"]')
-  .forEach((radio) => radio.addEventListener("change", syncSttMode));
-
 /* ---------- cleanup ---------- */
-
-function cleanupMode() {
-  return document.querySelector('input[name="cleanup-mode"]:checked').value;
-}
+//
+// The wizard always sets up the built-in (on-device) engines. Switching speech-
+// to-text or cleanup to a remote/OpenAI-compatible service is left to Settings,
+// so first-run setup stays on the happy path. The wizard preserves whatever
+// remote config already exists in settings (collect() spreads it through).
 
 function syncCleanupEnabled() {
   $("cleanup-fields").classList.toggle("disabled", !$("cleanup-enabled").checked);
 }
 
-function syncCleanupMode() {
-  const builtin = cleanupMode() === "builtin";
-  $("cleanup-builtin-fields").hidden = !builtin;
-  $("cleanup-external-fields").hidden = builtin;
-}
-
 $("cleanup-enabled").addEventListener("change", syncCleanupEnabled);
-document
-  .querySelectorAll('input[name="cleanup-mode"]')
-  .forEach((radio) => radio.addEventListener("change", syncCleanupMode));
 
 function populateCleanupModels() {
   const select = $("cleanup-builtin-model");
@@ -190,8 +164,6 @@ function syncCleanupNote() {
 /* ---------- collect wizard choices into a settings object ---------- */
 
 function collect() {
-  const mode = sttMode();
-  const cMode = cleanupMode();
   return {
     ...current,
     output: {
@@ -200,31 +172,17 @@ function collect() {
     },
     stt: {
       ...current.stt,
-      engine: mode,
+      engine: "builtin",
       builtin: { ...current.stt.builtin },
-      ...(mode === "remote"
-        ? {
-            baseUrl: $("stt-url").value.trim() || defaults.stt.baseUrl,
-            apiKey: $("stt-key").value.trim(),
-            model: $("stt-model").value.trim() || defaults.stt.model,
-          }
-        : {}),
     },
     cleanup: {
       ...current.cleanup,
       enabled: $("cleanup-enabled").checked,
-      engine: cMode === "external" ? "remote" : "builtin",
+      engine: "builtin",
       builtin: {
         ...current.cleanup.builtin,
         model: $("cleanup-builtin-model").value,
       },
-      ...(cMode === "external"
-        ? {
-            baseUrl: $("cleanup-url").value.trim() || defaults.cleanup.baseUrl,
-            apiKey: $("cleanup-key").value.trim(),
-            model: $("cleanup-model").value.trim(),
-          }
-        : {}),
     },
     audio: {
       ...current.audio,
@@ -233,36 +191,7 @@ function collect() {
   };
 }
 
-/* ---------- connection tests ---------- */
-
-function bindTest(buttonId, resultId, channel, getCfg) {
-  $(buttonId).addEventListener("click", async () => {
-    const el = $(resultId);
-    el.textContent = "Testing…";
-    el.className = "status";
-    const result = await earheart.invoke(channel, getCfg());
-    if (result.ok) {
-      el.textContent = result.sample ? `OK — "${result.sample}"` : "OK";
-      el.className = "status ok";
-    } else {
-      el.textContent = result.error;
-      el.className = "status err";
-    }
-  });
-}
-
-bindTest("stt-test", "stt-test-result", "stt:test", () => collect().stt);
-bindTest("cleanup-test", "cleanup-test-result", "cleanup:test", () => ({
-  ...collect().cleanup,
-  enabled: true,
-}));
-
 /* ---------- summary ---------- */
-
-const STT_LABELS = {
-  builtin: "Built-in Parakeet (on this computer)",
-  remote: null, // shown as the base URL
-};
 
 function renderSummary() {
   const next = collect();
@@ -270,18 +199,13 @@ function renderSummary() {
   const rows = [
     ["Hotkey", next.hotkey],
     ["Microphone", mic.selectedOptions[0]?.textContent || "System default"],
-    [
-      "Speech-to-text",
-      STT_LABELS[next.stt.engine] || next.stt.baseUrl,
-    ],
+    ["Speech-to-text", "Built-in Parakeet (on this computer)"],
   ];
   if (!next.cleanup.enabled) {
     rows.push(["Cleanup", "Off"]);
-  } else if (next.cleanup.engine === "builtin") {
+  } else {
     const m = modelStatus.cleanup.find((x) => x.id === next.cleanup.builtin.model);
     rows.push(["Cleanup", `Built-in ${m ? m.label : ""} (on this computer)`]);
-  } else {
-    rows.push(["Cleanup", next.cleanup.model || "external service"]);
   }
   rows.push([
     "Output",
@@ -530,15 +454,7 @@ async function finish() {
   modelStatus = await earheart.invoke("models:status");
 
   hotkeyInput.value = current.hotkey;
-  $("cleanup-url").value = current.cleanup.baseUrl;
-  $("cleanup-model").value = current.cleanup.model;
   $("cleanup-enabled").checked = current.cleanup.enabled;
-  document.querySelector(
-    `input[name="stt-mode"][value="${current.stt.engine}"]`
-  ).checked = true;
-  document.querySelector(
-    `input[name="cleanup-mode"][value="${current.cleanup.engine === "builtin" ? "builtin" : "external"}"]`
-  ).checked = true;
   document.querySelector(
     `input[name="output-mode"][value="${current.output.mode}"]`
   ).checked = true;
@@ -549,9 +465,7 @@ async function finish() {
     syncCleanupNote();
   });
 
-  syncSttMode();
   syncCleanupEnabled();
-  syncCleanupMode();
 
   if (platform === "darwin") $("demo-mod").textContent = "⌘";
   if (platform !== "linux") $("wayland-note").style.display = "none";


### PR DESCRIPTION
Closes #21.

## Problem

The setup wizard offered remote / OpenAI-compatible engine choices for both speech-to-text and cleanup, each with its own **Test connection** button. Because the wizard restored the engine radio from saved settings on init (`renderer/wizard.js`), any config that had ever selected a remote engine re-opened the wizard showing the remote fields **and** a test button — for a service the user wasn't configuring. During first-run setup that's especially confusing, since the on-device models aren't even downloaded yet.

Separately, saving in **Settings** left the window open with only a transient "Saved" status, so the user had to dismiss it manually.

## Changes

**Wizard defaults to built-in engines** — removed the STT/cleanup engine radios, the remote config fields, and both "Test connection" buttons from the wizard. `collect()` now always sets `engine: "builtin"` for both stages. Remote/local-server switching is left to **Settings**, which already has the full engine UI (and a working test button). Existing remote config (`baseUrl`/`apiKey`/`model`) is preserved through `collect()`'s `...current` spread, so switching back in Settings is lossless. Each step gained a one-line hint pointing advanced users to Settings.

This also removes the bug's root cause by construction: there's no remote path in the wizard to restore, so the stray test button can't reappear.

**Settings closes on save** — added a `settings:close` IPC channel (`preload.js`, `main/ipc.js`, `main/windows.js`) and call it after a clean save. The window stays open only when the hotkey fails to register, so that error remains visible.

## Verification

- `npm test` — 70 pass, 1 skipped, 0 fail
- `--smoke-test` (full app boot) — exit 0
- `engine-smoke` (worker + native engines load) — exit 0
- `node --check` on all touched files; no orphaned CSS selectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)