### PR TITLE
docs: align README with built-in-only wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ wizard downloads the speech and cleanup models for you.
 If you'd rather run the [Parakeet STT server](stt-server/) as a separate
 process (e.g. to share it with other tools or use a GPU), start it yourself and
 point Earheart's speech-to-text at its URL (default `http://127.0.0.1:8484/v1`)
-in the setup wizard or Settings. Running it needs
+in Settings → Speech-to-text. Running it needs
 [uv](https://docs.astral.sh/uv/getting-started/installation/) installed:
 
 ```bash
@@ -134,8 +134,8 @@ winget install astral-sh.uv                       # Windows
 cd stt-server && uv run earheart-stt              # start the server
 ```
 
-Or point Earheart at a hosted transcription service (OpenAI, Groq, …) — the
-setup wizard and Settings let you enter its URL and API key instead.
+Or point Earheart at a hosted transcription service (OpenAI, Groq, …) —
+Settings → Speech-to-text lets you enter its URL and API key instead.
 
 > **Upgrading from 0.4.x?** The in-process engines are new defaults; your
 > existing configured STT/cleanup endpoints are preserved and keep working
@@ -162,9 +162,10 @@ npm run dist     # installers for the current platform land in dist/
 </p>
 
 On first launch a short setup wizard walks through hotkey, microphone,
-speech-to-text, cleanup and output. The defaults give you fully local, private
-dictation that runs **inside the app**: keep "On this computer, built in" for
-both speech-to-text and cleanup.
+speech-to-text, cleanup and output. It sets up the **on-device engines** for
+both speech-to-text and cleanup, so first-run dictation is fully local and
+private with nothing to configure. Prefer a remote service? Switch any time in
+Settings → Speech-to-text or Settings → Cleanup.
 
 The wizard's last step downloads the models that run on your machine — a small
 Parakeet speech model (≈ 670 MB) and a small Gemma cleanup model (≈ 800 MB) —
@@ -186,7 +187,7 @@ fully local example with [Ollama](https://ollama.com):
 ollama pull llama3.1:8b
 ```
 
-Then in the wizard (or Settings → Cleanup): base URL
+Then in Settings → Cleanup: base URL
 `http://127.0.0.1:11434/v1`, model `llama3.1:8b`. For a hosted service
 instead, use its base URL, API key and model name (e.g. OpenRouter, Groq,
 OpenAI).

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -42,8 +42,10 @@ function init({ applyHotkey, onSettingsChanged }) {
     return { settings: saved, hotkey: hotkeyResult };
   });
 
-  // Close the settings window. The renderer calls this after a successful save
-  // so the user doesn't have to dismiss it manually.
+  // Close the settings window. The renderer calls this only after a clean save
+  // (settings saved *and* the hotkey registered) so the user doesn't have to
+  // dismiss it manually; on a hotkey-registration failure the renderer keeps the
+  // window open instead, so the error stays visible.
   ipcMain.handle("settings:close", () => {
     windows.closeSettings();
   });


### PR DESCRIPTION
Follow-up to #22, which merged before the post-review docs fixes landed.

#22 made the setup wizard always configure the on-device engines (remote/OpenAI-compatible switching moved to Settings), but the README still told users to enter a remote base URL / API key "in the wizard" and to "keep 'On this computer, built in'" — a choice the wizard no longer presents. This brings the docs current.

## Changes

- **README** — remote STT and cleanup setup now point at Settings, not the wizard; the first-run section says the wizard *presets* on-device engines and that remote switching happens in Settings.
- **main/ipc.js** — a clarifying comment on the `settings:close` contract (renderer invokes it only on a clean save; keeps the window open on hotkey-registration failure so the error stays visible).

Docs/comments only — no behavior change. `npm test` green (70 pass, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)