### PR TITLE
ci: validate PR titles follow Conventional Commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,66 @@
+name: PR title
+
+# The PR title is load-bearing: auto-release.yml reads its conventional-commit
+# prefix to decide the version bump (feat → minor, fix/perf/refactor → patch,
+# type! → major, anything else → no release). A typo'd or free-form title
+# silently ships the wrong bump (or no release at all), so validate the title
+# follows Conventional Commits before the PR can merge.
+#
+# Format checked:  type(optional scope)!: description
+#   type   — one of the Conventional Commits types below
+#   scope  — optional, in parentheses, e.g. feat(overlay):
+#   !      — optional, marks a breaking change (drives a major bump)
+#   :<sp>  — a colon and a single space, then a non-empty description
+
+on:
+  pull_request:
+    # `edited` matters most: it fires when the title is changed after opening,
+    # so a fixed-up title re-runs the check.
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title is Conventional Commits style
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # The regex lives in a variable: bash cannot parse `[^)]` inside an
+          # inline [[ =~ ]] expression (same reason as auto-release.yml).
+          title_re='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+'
+          if [[ "$TITLE" =~ $title_re ]]; then
+            echo "PR title OK: $TITLE"
+            exit 0
+          fi
+          echo "::error title=Invalid PR title::\"$TITLE\" is not a Conventional Commits title"
+          cat <<'EOF'
+          The PR title must follow Conventional Commits, because auto-release.yml
+          turns its prefix into the release version bump.
+
+          Format:  type(optional scope)!: description
+
+          Allowed types:
+            feat      a new feature                 → minor release
+            fix       a bug fix                      → patch release
+            perf      a performance improvement      → patch release
+            refactor  a code change, no behavior     → patch release
+            docs      documentation only             → no release
+            style     formatting, no code change     → no release
+            test      adding or fixing tests         → no release
+            build     build system or dependencies   → no release
+            ci        CI configuration               → no release
+            chore     anything else                  → no release
+            revert    reverts a previous commit      → no release
+
+          Add ! before the colon for a breaking change (feat!: ...) → major release.
+
+          Examples:
+            feat(overlay): add a copy-to-clipboard button
+            fix: accept first mouse so overlay controls work
+            chore!: drop support for Node 20
+          EOF
+          exit 1


### PR DESCRIPTION
## What

Adds `.github/workflows/pr-title.yml`, a workflow that lints every PR's title against the [Conventional Commits](https://www.conventionalcommits.org/) format and fails if it doesn't match.

## Why

The PR title is load-bearing for releases: `auto-release.yml` derives the version bump from the title's conventional-commit prefix:

| Prefix | Release |
| --- | --- |
| `feat:` | minor |
| `fix:` / `perf:` / `refactor:` | patch |
| `type!:` (breaking) | major |
| anything else (`docs:`, `chore:`, free-form, …) | none |

A typo'd or free-form title silently ships the wrong bump — or no release at all. This check catches that before merge.

## How

- **Self-contained bash regex**, matching the repo's existing style (`auto-release.yml` already parses the title this way) — no third-party action to pin or trust, and the allowed types stay in sync with the release logic.
- Accepts `type(optional scope)!: description` across the standard types: `feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert`.
- Triggers on `opened, edited, reopened, synchronize` — `edited` ensures a fixed-up title re-runs the check.
- On failure, prints the offending title plus a help block mapping each type to its release effect.
- Minimal `contents: read` permission (reads the title from the event payload; no API calls).

## Notes

- This PR's own title (`ci: …`) exercises the new rule.
- To actually block merges, the `lint-title` check needs to be added to **required status checks** in branch protection for `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TewEQGmScfnhzpi4Yar6CE)_