### PR TITLE
fix: correct the OVERLAY_HEIGHT breakdown comment to sum to 92

### DIFF
--- a/main/windows.js
+++ b/main/windows.js
@@ -8,7 +8,7 @@ const PRELOAD = path.join(__dirname, "..", "preload.js");
 const RENDERER = path.join(__dirname, "..", "renderer");
 
 const OVERLAY_WIDTH = 360;
-// Base card: grip (~11px) + 56px control row + 12px margin top/bottom.
+// Base card: grip (~12px) + 56px control row + 12px margin top/bottom.
 const OVERLAY_HEIGHT = 92;
 // Matches the card's fade-out transition in overlay.css.
 const OVERLAY_FADE_MS = 200;


### PR DESCRIPTION
## What

Corrects the base-card breakdown comment above `OVERLAY_HEIGHT` in `main/windows.js`: it listed `grip (~11px) + 56px + 12px*2 = 91`, one pixel short of the actual value `92`. The grip region is ~12px (4px bar + ~8px spacing), so the figure now matches.

## Why this PR exists

This is a deliberate, low-risk change to **exercise the release pipeline end-to-end**: a `fix:` title should make `auto-release.yml` cut a patch release (`v0.8.4` → `v0.8.5`) when merged, then dispatch the installer build/publish workflow on the new tag.

It also confirms the new `lint-title` gate accepts a well-formed `fix:` title (a non-empty description), in contrast to the bare `fix: ` it would reject.

## Notes

- Comment-only change — no behavior or test impact.
- Merging this **will publish a real `v0.8.5` release** via the auto-release workflow. Hold off merging if you don't want that tag/build cut right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TewEQGmScfnhzpi4Yar6CE)_