### PR TITLE
feat: add start-on-login (autostart) support across platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
 - **Auto-paste, clipboard, or both** — paste straight into the focused app
   (with clipboard restore), paste *and* keep the transcript on the clipboard,
   or clipboard-only if you prefer to paste yourself.
+- **Start on login (optional)** — have Earheart launch into the tray
+  automatically when you sign in, so the hotkey is always ready. Off by
+  default; toggle it under Settings → General. Works on Windows, macOS and
+  Linux.
 - **Local history** — recent transcriptions are kept in a local JSON file so a
   mis-aimed paste never loses a dictation. Can be disabled.
 - **No telemetry, no accounts, no cloud requirement.**

--- a/main/autostart.js
+++ b/main/autostart.js
@@ -1,0 +1,96 @@
+// Start-on-login (autostart) across Windows, macOS and Linux.
+//
+// Windows and macOS expose a native login-items API through Electron's
+// app.setLoginItemSettings / app.getLoginItemSettings, so we let the OS track
+// the registration. Linux has no such API; instead the freedesktop XDG
+// autostart spec says any .desktop file in ~/.config/autostart is launched by
+// the desktop environment at login, so on Linux we write (or remove) that file
+// ourselves.
+//
+// Either way the app is launched with --hidden so logging in lands you in the
+// tray with the hotkey ready, not in a settings window.
+
+const { app } = require("electron");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const LINUX_DESKTOP_FILE = "earheart.desktop";
+
+// The command the desktop environment should run at login. On Linux AppImages
+// the relaunchable path lives in $APPIMAGE — process.execPath points inside the
+// mounted image and would be stale next boot — so prefer it; fall back to
+// execPath for .deb installs and `npm start` development runs.
+function linuxLaunchCommand() {
+  const exec = process.env.APPIMAGE || process.execPath;
+  return `${exec} --hidden`;
+}
+
+// A minimal but complete XDG autostart entry. X-GNOME-Autostart-enabled keeps
+// GNOME from treating the entry as disabled.
+function linuxDesktopEntry(command = linuxLaunchCommand()) {
+  return [
+    "[Desktop Entry]",
+    "Type=Application",
+    "Name=Earheart",
+    "Comment=Private, hotkey-driven voice dictation",
+    `Exec=${command}`,
+    "Icon=earheart",
+    "Terminal=false",
+    "X-GNOME-Autostart-enabled=true",
+    "",
+  ].join("\n");
+}
+
+function linuxAutostartPath() {
+  const configHome =
+    process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
+  return path.join(configHome, "autostart", LINUX_DESKTOP_FILE);
+}
+
+function applyLinux(enabled) {
+  const file = linuxAutostartPath();
+  if (enabled) {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, linuxDesktopEntry());
+  } else {
+    try {
+      fs.unlinkSync(file);
+    } catch (err) {
+      // Already absent is success — nothing to remove.
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+}
+
+// Set whether Earheart launches at login. Idempotent and safe to call on every
+// startup to reconcile the OS state with the saved setting.
+function apply(enabled) {
+  if (process.platform === "linux") {
+    applyLinux(enabled);
+    return;
+  }
+  // Windows + macOS: native login item. openAsHidden is honoured on macOS; the
+  // --hidden argument covers Windows (and is harmless on macOS).
+  app.setLoginItemSettings({
+    openAtLogin: enabled,
+    openAsHidden: enabled,
+    args: ["--hidden"],
+  });
+}
+
+// Whether autostart is currently registered with the OS. Used as the source of
+// truth so the settings UI reflects reality even if it drifted.
+function isEnabled() {
+  if (process.platform === "linux") return fs.existsSync(linuxAutostartPath());
+  return app.getLoginItemSettings().openAtLogin;
+}
+
+module.exports = {
+  apply,
+  isEnabled,
+  // Exported for unit tests (pure, no Electron).
+  linuxDesktopEntry,
+  linuxLaunchCommand,
+  linuxAutostartPath,
+};

--- a/main/ipc.js
+++ b/main/ipc.js
@@ -7,23 +7,46 @@ const history = require("./history");
 const windows = require("./windows");
 const route = require("./services/route");
 const engines = require("./engines");
+const autostart = require("./autostart");
 const { listRemoteModels } = require("./services/models-remote");
 const { encodeSilenceWav } = require("./util/wav");
 
 // In-flight model downloads, so the UI can cancel them. Keyed by kind:modelId.
 const downloads = new Map();
 
+// Push the start-on-boot choice to the OS, swallowing failures (e.g. a
+// read-only autostart dir) so a save never fails over a login-item glitch.
+function applyAutostart(cfg) {
+  try {
+    autostart.apply(cfg.startOnBoot);
+  } catch (err) {
+    console.warn(`[earheart] could not apply start-on-boot: ${err.message}`);
+  }
+}
+
 function init({ applyHotkey, onSettingsChanged }) {
-  ipcMain.handle("settings:get", () => ({
-    settings: settings.get(),
-    defaults: settings.DEFAULTS,
-    platform: process.platform,
-    version: app.getVersion(),
-  }));
+  ipcMain.handle("settings:get", () => {
+    // Shallow copy so reporting the live OS state doesn't mutate the cache.
+    const cfg = { ...settings.get() };
+    // Report the real OS login-item state so the toggle reflects reality even
+    // if it was changed outside the app (e.g. the autostart file was removed).
+    try {
+      cfg.startOnBoot = autostart.isEnabled();
+    } catch {
+      // Fall back to the stored value if the OS query fails.
+    }
+    return {
+      settings: cfg,
+      defaults: settings.DEFAULTS,
+      platform: process.platform,
+      version: app.getVersion(),
+    };
+  });
 
   ipcMain.handle("settings:save", (event, next) => {
     const saved = settings.save(next);
     const hotkeyResult = applyHotkey(saved.hotkey);
+    applyAutostart(saved);
     onSettingsChanged?.();
     return { settings: saved, hotkey: hotkeyResult };
   });
@@ -34,6 +57,7 @@ function init({ applyHotkey, onSettingsChanged }) {
   ipcMain.handle("wizard:complete", (event, next) => {
     const saved = settings.save(next);
     const hotkeyResult = applyHotkey(saved.hotkey);
+    applyAutostart(saved);
     onSettingsChanged?.();
     if (hotkeyResult.ok) {
       windows.openSettings({ fromWizard: true });

--- a/main/main.js
+++ b/main/main.js
@@ -9,6 +9,7 @@ const hotkeys = require("./hotkeys");
 const tray = require("./tray");
 const ipc = require("./ipc");
 const engines = require("./engines");
+const autostart = require("./autostart");
 
 const isSmokeTest = process.argv.includes("--smoke-test");
 const startHidden = process.argv.includes("--hidden");
@@ -41,6 +42,14 @@ function main() {
     // this is a fresh install and the user gets the setup wizard.
     const firstRun = settings.isFirstRun();
     const cfg = settings.get();
+
+    // Reconcile the OS login item with the saved setting on every launch, so a
+    // moved AppImage or an externally-cleared registration self-heals.
+    try {
+      autostart.apply(cfg.startOnBoot);
+    } catch (err) {
+      console.warn(`[earheart] could not apply start-on-boot: ${err.message}`);
+    }
 
     // The renderer asks for microphone and clipboard access; grant those.
     // Everything the renderer can reach is our own local files (no remote

--- a/main/settings.js
+++ b/main/settings.js
@@ -28,6 +28,11 @@ const DEFAULTS = {
   // Global hotkey (Electron accelerator format). Press once to start
   // recording, press again to stop and transcribe.
   hotkey: "CommandOrControl+Shift+Space",
+  // Launch Earheart automatically at login (it lands in the tray, ready for
+  // the hotkey). Pushed to the OS by main/autostart.js — a native login item
+  // on Windows/macOS, an XDG autostart .desktop file on Linux — on save, and
+  // reconciled on every startup.
+  startOnBoot: false,
   output: {
     // "paste" = type into focused app (restores clipboard afterwards),
     // "paste-copy" = paste AND keep the transcript on the clipboard,

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -75,6 +75,18 @@
             <option value="">System default</option>
           </select>
         </div>
+
+        <div class="field">
+          <label>Startup</label>
+          <label class="choice">
+            <input type="checkbox" id="start-on-boot" />
+            Start Earheart when I log in
+          </label>
+          <p class="hint">
+            Launches Earheart in the background (system tray) after you sign in,
+            so the hotkey is always ready. Works on Windows, macOS and Linux.
+          </p>
+        </div>
       </section>
 
       <!-- STT -->

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -138,6 +138,8 @@ function populate() {
   syncEngine("stt");
   syncEngine("cleanup");
 
+  $("start-on-boot").checked = !!current.startOnBoot;
+
   $("history-enabled").checked = current.history.enabled;
   $("max-seconds").value = current.audio.maxRecordingSeconds;
   $("idle-unload").value = current.engines?.idleUnloadMinutes ?? 2;
@@ -149,6 +151,7 @@ function collect() {
   return {
     ...current,
     hotkey: current.hotkey,
+    startOnBoot: $("start-on-boot").checked,
     output: {
       ...current.output,
       mode: document.querySelector('input[name="output-mode"]:checked').value,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -235,12 +235,15 @@ test("linux launch command starts hidden and prefers $APPIMAGE", () => {
 });
 
 test("linux autostart path honours XDG_CONFIG_HOME", () => {
+  const path = require("node:path");
   const saved = process.env.XDG_CONFIG_HOME;
   try {
     process.env.XDG_CONFIG_HOME = "/tmp/cfg";
+    // Build the expected path with path.join so the separator matches the host
+    // OS — the test runs on Windows CI too, where join uses backslashes.
     assert.strictEqual(
       autostart.linuxAutostartPath(),
-      "/tmp/cfg/autostart/earheart.desktop"
+      path.join("/tmp/cfg", "autostart", "earheart.desktop")
     );
   } finally {
     if (saved === undefined) delete process.env.XDG_CONFIG_HOME;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9,6 +9,7 @@ const http = require("node:http");
 const { encodeWav, encodeSilenceWav, wavToFloat32 } = require("../main/util/wav");
 const { stripThinking } = require("../main/services/cleanup");
 const { deepMerge, migrateLegacy, DEFAULTS } = require("../main/settings");
+const autostart = require("../main/autostart");
 const { listRemoteModels } = require("../main/services/models-remote");
 const { reconcileTranscript } = require("../renderer/transcript");
 
@@ -197,6 +198,54 @@ test("new installs default to in-process engines", () => {
   assert.strictEqual(DEFAULTS.cleanup.enabled, true);
   assert.ok(DEFAULTS.stt.builtin.model);
   assert.ok(DEFAULTS.cleanup.builtin.model);
+});
+
+/* ---------------- start on boot (autostart) ---------------- */
+
+test("start-on-boot defaults to off and survives the merge both ways", () => {
+  assert.strictEqual(DEFAULTS.startOnBoot, false);
+  // A stored true must not be reset to the default false.
+  assert.strictEqual(deepMerge(DEFAULTS, { startOnBoot: true }).startOnBoot, true);
+  assert.strictEqual(deepMerge(DEFAULTS, { startOnBoot: false }).startOnBoot, false);
+});
+
+test("linux autostart entry is a valid XDG desktop file launched hidden", () => {
+  const entry = autostart.linuxDesktopEntry("/opt/Earheart.AppImage --hidden");
+  assert.match(entry, /^\[Desktop Entry\]/);
+  assert.match(entry, /\nType=Application\n/);
+  assert.match(entry, /\nExec=\/opt\/Earheart\.AppImage --hidden\n/);
+  // GNOME treats a missing flag as disabled, so it must be present and true.
+  assert.match(entry, /\nX-GNOME-Autostart-enabled=true\n/);
+});
+
+test("linux launch command starts hidden and prefers $APPIMAGE", () => {
+  const saved = process.env.APPIMAGE;
+  try {
+    process.env.APPIMAGE = "/home/u/Earheart.AppImage";
+    assert.strictEqual(
+      autostart.linuxLaunchCommand(),
+      "/home/u/Earheart.AppImage --hidden"
+    );
+    delete process.env.APPIMAGE;
+    assert.ok(autostart.linuxLaunchCommand().endsWith(" --hidden"));
+  } finally {
+    if (saved === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = saved;
+  }
+});
+
+test("linux autostart path honours XDG_CONFIG_HOME", () => {
+  const saved = process.env.XDG_CONFIG_HOME;
+  try {
+    process.env.XDG_CONFIG_HOME = "/tmp/cfg";
+    assert.strictEqual(
+      autostart.linuxAutostartPath(),
+      "/tmp/cfg/autostart/earheart.desktop"
+    );
+  } finally {
+    if (saved === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = saved;
+  }
 });
 
 /* ---------------- live preview ---------------- */


### PR DESCRIPTION
## Summary
Adds cross-platform support for launching Earheart automatically at login, with the app starting hidden in the system tray so the hotkey is immediately available.

## Key Changes
- **New autostart module** (`main/autostart.js`): Implements platform-specific login item registration
  - Windows/macOS: Uses Electron's native `app.setLoginItemSettings()` API
  - Linux: Writes/removes XDG autostart `.desktop` files in `~/.config/autostart/`
  - All platforms launch with `--hidden` flag to start in tray, not a window

- **Settings integration**: 
  - Added `startOnBoot` boolean to settings defaults (off by default)
  - New UI toggle in Settings → General → Startup section
  - Settings page displays real OS state via `autostart.isEnabled()` so UI reflects reality even if autostart was changed externally

- **Startup reconciliation**: 
  - On every app launch, reconciles OS login item state with saved setting
  - Handles edge cases like moved AppImages or externally-cleared registrations
  - Gracefully handles failures (e.g., read-only autostart directories) without breaking settings saves

- **Linux-specific details**:
  - Respects `XDG_CONFIG_HOME` environment variable per freedesktop spec
  - Prefers `$APPIMAGE` path for AppImage installs (mounted images would be stale on next boot)
  - Falls back to `process.execPath` for .deb installs and development runs
  - Generates valid XDG desktop entries with GNOME autostart flag

- **Tests**: Added unit tests for Linux desktop file generation, launch command construction, and XDG config path handling

## Notable Implementation Details
- The `autostart.isEnabled()` function queries the OS directly, making it the source of truth for the UI toggle
- Error handling is defensive: OS failures are logged but never cause settings operations to fail
- The module exports pure functions for Linux path/entry generation to enable unit testing without Electron dependencies

https://claude.ai/code/session_013wQhFX87cdkzxkVhJkopoZ