### PR TITLE
fix: start-on-boot toggle reads back as off on Windows

### DIFF
--- a/main/autostart.js
+++ b/main/autostart.js
@@ -17,6 +17,12 @@ const os = require("node:os");
 
 const LINUX_DESKTOP_FILE = "earheart.desktop";
 
+// Arguments the login item launches with, so login lands in the tray (not a
+// window). Shared by the set and get calls below: on Windows
+// getLoginItemSettings compares the stored launch command against the args you
+// query with, so the two MUST match or the read-back state drifts.
+const LOGIN_ITEM_ARGS = ["--hidden"];
+
 // The command the desktop environment should run at login. On Linux AppImages
 // the relaunchable path lives in $APPIMAGE — process.execPath points inside the
 // mounted image and would be stale next boot — so prefer it; fall back to
@@ -75,21 +81,32 @@ function apply(enabled) {
   app.setLoginItemSettings({
     openAtLogin: enabled,
     openAsHidden: enabled,
-    args: ["--hidden"],
+    args: LOGIN_ITEM_ARGS,
   });
+}
+
+// Decide whether autostart is on from an Electron login-item settings object.
+// On Windows, openAtLogin only reads true when the query args match the ones the
+// item was registered with — so we always query with LOGIN_ITEM_ARGS — but
+// executableWillLaunchAtLogin reflects the run key directly (it ignores args),
+// which is the most faithful "will it actually launch?" signal. macOS/Linux
+// don't set that field, so fall back to openAtLogin there.
+function loginItemEnabled(item) {
+  return item.executableWillLaunchAtLogin ?? item.openAtLogin ?? false;
 }
 
 // Whether autostart is currently registered with the OS. Used as the source of
 // truth so the settings UI reflects reality even if it drifted.
 function isEnabled() {
   if (process.platform === "linux") return fs.existsSync(linuxAutostartPath());
-  return app.getLoginItemSettings().openAtLogin;
+  return loginItemEnabled(app.getLoginItemSettings({ args: LOGIN_ITEM_ARGS }));
 }
 
 module.exports = {
   apply,
   isEnabled,
   // Exported for unit tests (pure, no Electron).
+  loginItemEnabled,
   linuxDesktopEntry,
   linuxLaunchCommand,
   linuxAutostartPath,

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -83,8 +83,7 @@
             Start Earheart when I log in
           </label>
           <p class="hint">
-            Launches Earheart in the background (system tray) after you sign in,
-            so the hotkey is always ready. Works on Windows, macOS and Linux.
+            Launches Earheart in the background (system tray) after you sign in.
           </p>
         </div>
       </section>

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -234,6 +234,36 @@ test("linux launch command starts hidden and prefers $APPIMAGE", () => {
   }
 });
 
+test("loginItemEnabled trusts Windows' run key even when openAtLogin lies", () => {
+  // The Windows bug: we register the login item with --hidden, but
+  // getLoginItemSettings() compares the stored command against the args it's
+  // queried with, so a no-args (or mismatched) query reports openAtLogin:false
+  // even though the run key is present and fires at boot.
+  // executableWillLaunchAtLogin ignores args and reflects the run key, so the
+  // toggle reads back as enabled — matching what actually happens on reboot.
+  assert.strictEqual(
+    autostart.loginItemEnabled({
+      openAtLogin: false,
+      executableWillLaunchAtLogin: true,
+    }),
+    true
+  );
+  // Disabled on Windows: no run key, both signals agree.
+  assert.strictEqual(
+    autostart.loginItemEnabled({
+      openAtLogin: false,
+      executableWillLaunchAtLogin: false,
+    }),
+    false
+  );
+  // macOS/Linux don't report executableWillLaunchAtLogin, so fall back to
+  // openAtLogin both ways.
+  assert.strictEqual(autostart.loginItemEnabled({ openAtLogin: true }), true);
+  assert.strictEqual(autostart.loginItemEnabled({ openAtLogin: false }), false);
+  // A bare object (no fields at all) reads as off, never undefined.
+  assert.strictEqual(autostart.loginItemEnabled({}), false);
+});
+
 test("linux autostart path honours XDG_CONFIG_HOME", () => {
   const path = require("node:path");
   const saved = process.env.XDG_CONFIG_HOME;


### PR DESCRIPTION
## What

Fixes the start-on-boot toggle reading back as **unchecked** after you enable it and reopen Settings on Windows — even though the app *does* launch at the next reboot.

## Root cause

`main/autostart.js` registers the Windows login item with `args: ["--hidden"]` (so login lands in the tray, not a window):

```js
app.setLoginItemSettings({ openAtLogin: true, openAsHidden: true, args: ["--hidden"] });
```

But `isEnabled()` queried the state with **no args**:

```js
return app.getLoginItemSettings().openAtLogin;
```

Per the [Electron docs](https://www.electronjs.org/docs/latest/api/app#appgetloginitemsettingsoptions):

> If you provided `path` and `args` options to `app.setLoginItemSettings`, then you need to pass the same arguments here for `openAtLogin` to be set correctly.

Electron compares the stored launch command (`"…earheart.exe" --hidden`) against the args you query with. The empty-args query didn't match, so `openAtLogin` reported `false` — while the registry **run key was present and firing at login**. Hence: toggle shows off, reboot still works.

## Other OSes

Checked — the bug is **Windows-only**:
- **Linux** reads back via `fs.existsSync()` on the same `.desktop` file it writes — already consistent.
- **macOS** ignores `args` for login items, so `openAtLogin` already read back correctly.

The fix is a no-op on both.

## Fix

- Extract a shared `LOGIN_ITEM_ARGS` constant used by **both** the set and get calls so they can never drift apart again.
- Query `getLoginItemSettings({ args: LOGIN_ITEM_ARGS })`.
- Prefer `executableWillLaunchAtLogin` (Windows-only; reflects the run key directly and *ignores* args — the truest "will it actually launch?" signal), falling back to `openAtLogin` on macOS/Linux.
- Simplify the Settings hint to one user-facing line and drop the "Works on Windows, macOS and Linux" note — each user only runs one OS.

## Testing

- Added a unit test for the read-back decision (`loginItemEnabled`) covering the exact bug: `openAtLogin: false` + `executableWillLaunchAtLogin: true` → enabled.
- `npm test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)