### PR TITLE
fix(overlay): fill recording row, smooth dragging, and restore live preview

### DIFF
--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -31,10 +31,15 @@ function joinText(a, b) {
   return `${a} ${b}`;
 }
 
-function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettings, isCurrent }) {
+function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettings, isCurrent, onError }) {
+  const reportError = onError || (() => {});
   let sttBusy = false;
   let cleanupBusy = false;
   let abortController = null; // aborts in-flight partial work when recording ends
+  // The last partial-error message we surfaced. A persistent failure (e.g. the
+  // model isn't downloaded) recurs every tick; dedupe so it's logged once, and
+  // reset on any successful decode so a later, different failure still surfaces.
+  let lastErrorLogged = "";
 
   // Decode accumulators — append-only; only the in-progress chunk is re-decoded,
   // so decode cost stays flat however long the dictation runs.
@@ -105,6 +110,7 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
       const wav = Buffer.from(wavArrayBuffer);
       const raw = await runTranscribe(wav, cfg.stt, signal);
       if (stale(sid, signal)) return;
+      lastErrorLogged = ""; // a decode succeeded; let the next failure surface
       const text = (raw || "").trim();
 
       if (final && seq > lastSeq) {
@@ -120,8 +126,16 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
         liveRaw = text;
         pushRaw();
       }
-    } catch {
-      // Cosmetic: ignore failed partials entirely; the final pass is authoritative.
+    } catch (err) {
+      // A failed partial is cosmetic — the final pass is authoritative, so never
+      // let it disturb the dictation. But report it (deduped) instead of eating
+      // it silently: a persistently blank preview is almost always a surfaced-here
+      // error (model loading, not downloaded, or a decode failure).
+      const msg = err?.message || String(err);
+      if (msg !== lastErrorLogged) {
+        lastErrorLogged = msg;
+        reportError(err);
+      }
     } finally {
       sttBusy = false;
     }

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -38,6 +38,10 @@ const livePreview = createLivePreview({
   sendToOverlay: windows.sendToOverlay,
   getSettings: settings.get,
   isCurrent: (sid) => sid === session && state === "recording",
+  // Partials are best-effort and must never disturb the dictation, but silently
+  // swallowing their errors hid real breakage (STT model still loading or not
+  // downloaded) — so surface them here for diagnosis without interrupting.
+  onError: (err) => logger.warn("live preview partial failed:", err.message),
 });
 
 // Idle eviction: after a dictation finishes, wait the configured idle window
@@ -107,6 +111,13 @@ function startRecording() {
   const cfg = settings.get();
   const sid = ++session;
   setState("recording");
+  const liveOn = cfg.stt.engine === "builtin" && cfg.stt.livePreview?.enabled;
+  // Warm the built-in STT model as recording begins so the first live-preview
+  // partials aren't all dropped while it loads. The drop-if-busy guard discards
+  // every partial tick until a decode is free, so a cold multi-second first load
+  // would starve the whole preview on short dictations (no text ever appears).
+  // Best effort — the authoritative final pass calls ensureStt again regardless.
+  if (liveOn) engines.ensureStt(cfg.stt.builtin.model).catch(() => {});
   const win = windows.createOverlay();
   const begin = () => {
     if (session !== sid) return; // cancelled before the overlay was ready
@@ -117,11 +128,8 @@ function startRecording() {
       maxSeconds: cfg.audio.maxRecordingSeconds,
       // Live preview only runs on the builtin engine (the HTTP path would be
       // hammered with repeated full-file uploads). The overlay gates on
-      // `enabled`; we also gate on the engine here.
-      livePreview:
-        cfg.stt.engine === "builtin" && cfg.stt.livePreview?.enabled
-          ? cfg.stt.livePreview
-          : { enabled: false },
+      // `enabled`; we also gate on the engine here (see `liveOn` above).
+      livePreview: liveOn ? cfg.stt.livePreview : { enabled: false },
     });
   };
   // The overlay may still be loading right after launch (or after a renderer

--- a/renderer/overlay.css
+++ b/renderer/overlay.css
@@ -170,10 +170,14 @@ body {
   }
 }
 
+/* The waveform is the hero of the recording row: it flexes to fill all the space
+   between the pulse dot and the timer, so there's no dead gap. min-width:0 lets
+   it shrink below the canvas's intrinsic width; overlay.js keeps the canvas
+   backing store matched to this flexed box so the bars never stretch. */
 #meter {
-  width: 120px;
+  flex: 1;
+  min-width: 0;
   height: 36px;
-  flex-shrink: 0;
 }
 
 #card:not([data-status="recording"]) #meter,
@@ -207,12 +211,14 @@ body {
   text-overflow: ellipsis;
 }
 
+/* Sits right after the waveform (no flex stretch), reading as its caption. The
+   waveform's flex:1 owns the leftover width, so the timer hugs the meter and the
+   Stop/Cancel buttons follow. */
 #timer {
   font-size: 13px;
   font-variant-numeric: tabular-nums;
   color: #b8b3c4;
-  flex: 1;
-  text-align: right;
+  flex-shrink: 0;
 }
 
 button {

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -445,14 +445,38 @@ card.addEventListener("pointerdown", (event) => {
   earheart.send("overlay:drag-start", { x: event.screenX, y: event.screenY });
 });
 
+// Coalesce the drag stream to one send per animation frame. pointermove can fire
+// far faster than a transparent, always-on-top window can be repositioned, and an
+// unbatched send-per-event floods the IPC channel so the window trails a stale
+// backlog (the "lags behind" feel). We keep only the freshest coordinate and send
+// it once per frame; this is lossless because the main process positions from a
+// recorded origin (see windows.js), not from accumulated deltas, so dropping the
+// intermediate points never desyncs the card from the cursor.
+let pendingDrag = null;
+let dragRaf = null;
+function flushDrag() {
+  dragRaf = null;
+  if (pendingDrag) {
+    earheart.send("overlay:drag", pendingDrag);
+    pendingDrag = null;
+  }
+}
+
 card.addEventListener("pointermove", (event) => {
   if (!dragging) return;
-  earheart.send("overlay:drag", { x: event.screenX, y: event.screenY });
+  pendingDrag = { x: event.screenX, y: event.screenY };
+  if (dragRaf === null) dragRaf = requestAnimationFrame(flushDrag);
 });
 
 function endDrag() {
   dragging = false;
   card.classList.remove("dragging");
+  // Send the final position immediately so the card settles exactly under the
+  // release point even if a frame was still pending.
+  if (dragRaf !== null) {
+    cancelAnimationFrame(dragRaf);
+    flushDrag();
+  }
 }
 
 card.addEventListener("pointerup", endDrag);

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -67,6 +67,22 @@ function setStatus(status, title, detail) {
   detailText.textContent = detail || "";
 }
 
+// The meter now flexes to fill the control row, so its rendered width varies with
+// the card size and device pixel ratio. Keep the canvas backing store matched to
+// its CSS box (× dpr) so the bars stay crisp and un-stretched at any width; a
+// ResizeObserver (wired up below) calls this whenever that box changes.
+function resizeMeter() {
+  const rect = meter.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  const w = Math.max(1, Math.round(rect.width * dpr));
+  const h = Math.max(1, Math.round(rect.height * dpr));
+  if (meter.width !== w || meter.height !== h) {
+    meter.width = w;
+    meter.height = h;
+    drawMeter(); // repaint into the resized buffer (a resize clears the canvas)
+  }
+}
+
 function drawMeter() {
   meterCtx.clearRect(0, 0, meter.width, meter.height);
   const barWidth = meter.width / displayLevels.length;
@@ -407,6 +423,11 @@ earheart.on("overlay:show", () => {
   card.classList.add("visible");
 });
 earheart.on("overlay:hide", () => card.classList.remove("visible"));
+
+// Keep the waveform canvas's backing store matched to its flexed CSS box. The
+// observer fires once on observe() (sizing the canvas before the first draw) and
+// again on any later change (window/DPR/layout), so the bars are always crisp.
+new ResizeObserver(resizeMeter).observe(meter);
 
 document.getElementById("stop").addEventListener("click", stopRecording);
 document.getElementById("cancel").addEventListener("click", cancelRecording);


### PR DESCRIPTION
Three overlay/dictation fixes. Grouped on one branch per the working constraints; each is an independent commit and can be split on request.

## 1. Fill the recording row with the waveform (the original ask)

The recording control row left a large empty gap between the waveform meter and the timer. The cause was `#timer { flex: 1; text-align: right }`: while recording, the status `#message` element is hidden, so nothing occupied the middle — the timer inflated to swallow the leftover width and pushed `0:07` against the Stop button. That inflated, empty timer box *was* the gap.

Give that width to the waveform instead, so the animated element is the focal point:
- **`renderer/overlay.css`** — `#meter` is now `flex: 1` (was fixed `120px`) and stretches to fill the row; `#timer` drops its stretch and sits right after the meter as its caption, then the buttons.
- **`renderer/overlay.js`** — the meter draws into a fixed canvas backing store, so a CSS-only stretch would blur the bars. A `ResizeObserver` + `resizeMeter()` keeps the backing store matched to the flexed box (× `devicePixelRatio`) so the bars stay crisp.

Non-recording states are unaffected (meter/timer are `display:none` there).

## 2. Smooth out overlay dragging (`perf(overlay)`)

Dragging streamed an IPC send on **every** `pointermove` with no coalescing. High-rate pointers (trackpads, 120Hz mice) fire moves faster than a transparent, always-on-top window can be repositioned, so sends queued on the IPC channel and the card chased a stale backlog — the "lags behind" feel.

**`renderer/overlay.js`** now coalesces to at most one send per animation frame, keeping only the freshest coordinate. Lossless, because the main process positions from a recorded origin (not accumulated deltas), so dropping intermediate points never desyncs the card. The final position is flushed on release.

## 3. Restore the live transcript preview (`fix(live-preview)`)

The live preview could show nothing at all with the built-in engine and the setting enabled. The wiring, settings key, and engine gating were all correct — the failures were on the partial-decode path and were being hidden:
- **Cold-start starvation** — the first partial triggered a multi-second STT model load, and the drop-if-busy guard discarded every partial tick until it finished, so short dictations never showed text. `main/pipeline.js` now warms the model at record-start (best effort).
- **Silent failures** — `handleAudio` swallowed every partial error in an empty `catch`, so a persistently blank preview gave no diagnostic. `main/live-preview.js` now reports the error (deduped per message, reset on any successful decode) via an injected `onError` wired to `logger.warn`. Partials stay best-effort and never disturb the dictation.

If the preview is still blank after this, the logged message will name the true cause (e.g. model not downloaded).

## Testing

- Staged the recording overlay headlessly (same harness as `scripts/screenshots.js`) — the waveform fills the row up to `0:07`, no dead gap.
- `npm test`: **103 pass, 0 fail, 1 skipped** (including the full `live-preview` suite, 24/24). *(An earlier run showed 6 "failures" that were purely environmental — test files that couldn't load before `node_modules` was installed; with deps present the suite is clean.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)