### PR TITLE
fix(overlay): remember the dragged overlay position across restarts

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -55,8 +55,16 @@ function init({ applyHotkey, onSettingsChanged }) {
     };
   });
 
+  // The overlay position (settings.overlay) is owned by the main process: it
+  // changes when the user drags the card, not through any form. The settings
+  // and wizard windows save a payload spread from the snapshot they opened
+  // with, so their `overlay` can be stale — dragging the card while a form is
+  // open, then saving the form, would roll the position back. Re-inject the
+  // live value on every form save.
+  const keepLiveOverlay = (next) => ({ ...next, overlay: settings.get().overlay });
+
   ipcMain.handle("settings:save", (event, next) => {
-    const saved = settings.save(next);
+    const saved = settings.save(keepLiveOverlay(next));
     const hotkeyResult = applyHotkey(saved.hotkey);
     applyAutostart(saved);
     onSettingsChanged?.();
@@ -67,7 +75,7 @@ function init({ applyHotkey, onSettingsChanged }) {
   // window so the user can review what was pre-configured. If the chosen
   // hotkey can't be registered, the wizard stays open to let them fix it.
   ipcMain.handle("wizard:complete", (event, next) => {
-    const saved = settings.save(next);
+    const saved = settings.save(keepLiveOverlay(next));
     const hotkeyResult = applyHotkey(saved.hotkey);
     applyAutostart(saved);
     onSettingsChanged?.();

--- a/main/settings.js
+++ b/main/settings.js
@@ -109,6 +109,15 @@ const DEFAULTS = {
     // a manual check surfaces it again.
     skippedVersion: "",
   },
+  // Where the user last dragged the recording overlay: `{ x, y }` screen
+  // coordinates of the base-height card's top-left corner. Empty until the
+  // card is first dragged — the overlay then gets the default bottom-center
+  // spot. Owned by main/windows.js (persisted on drag end, validated against
+  // the connected displays on startup); the settings/wizard forms never edit
+  // it, so main/ipc.js re-injects the live value when they save. Kept free of
+  // placeholder values (deepMerge treats a null base as a mergeable object,
+  // so a `x: null` default would corrupt the saved coordinate).
+  overlay: {},
   // Cleanup models the user added from a custom Hugging Face URL. Each entry is
   // a registry-shaped model definition (see main/services/hf-gguf.js). Managed
   // only by the models:add-custom / models:remove-custom IPC handlers; the

--- a/main/windows.js
+++ b/main/windows.js
@@ -3,6 +3,7 @@
 
 const { BrowserWindow, ipcMain, screen } = require("electron");
 const path = require("node:path");
+const settings = require("./settings");
 
 const PRELOAD = path.join(__dirname, "..", "preload.js");
 const RENDERER = path.join(__dirname, "..", "renderer");
@@ -30,6 +31,26 @@ function clampToWorkArea(x, y, height = OVERLAY_HEIGHT) {
     x: Math.min(Math.max(x, workArea.x), workArea.x + workArea.width - OVERLAY_WIDTH),
     y: Math.min(Math.max(y, workArea.y), workArea.y + workArea.height - height),
   };
+}
+
+// Restore the position the user last dragged the card to, saved in settings.
+// Only honoured if the base-height card still fits entirely on a connected
+// display's work area: a spot remembered from a monitor that's since been
+// unplugged (or a resolution that shrank) must not strand the card off-screen,
+// so it falls back to the default bottom-center instead. Display changes while
+// the app is running are handled separately: overlayPosition() re-clamps on
+// every show.
+function restoreOverlayPosition() {
+  const { x, y } = settings.get().overlay ?? {};
+  if (typeof x !== "number" || typeof y !== "number") return;
+  const fits = screen.getAllDisplays().some(
+    ({ workArea }) =>
+      x >= workArea.x &&
+      y >= workArea.y &&
+      x + OVERLAY_WIDTH <= workArea.x + workArea.width &&
+      y + OVERLAY_HEIGHT <= workArea.y + workArea.height
+  );
+  if (fits) overlayCustomPosition = { x, y };
 }
 
 function overlayPosition() {
@@ -71,6 +92,15 @@ ipcMain.on("overlay:drag", (event, { x, y } = {}) => {
   overlayCustomPosition = { x: next.x, y: next.y + h - OVERLAY_HEIGHT };
 });
 
+// Persist the dragged position once, when the drag ends (saving from the
+// per-frame drag stream would rewrite the settings file on every mousemove),
+// so the card comes back to the same spot after a restart.
+ipcMain.on("overlay:drag-end", () => {
+  overlayDragOrigin = null;
+  if (!overlayCustomPosition) return;
+  settings.save({ ...settings.get(), overlay: { ...overlayCustomPosition } });
+});
+
 // The live transcript grows the overlay's content upward (the card stays pinned
 // to the bottom edge so it doesn't jump). The renderer reports the height its
 // content needs; we resize the window and shift its top up by the delta, then
@@ -98,6 +128,7 @@ ipcMain.on("overlay:resize", (event, { height } = {}) => {
 
 function createOverlay() {
   if (overlayWindow && !overlayWindow.isDestroyed()) return overlayWindow;
+  restoreOverlayPosition();
   const { x, y } = overlayPosition();
   overlayWindow = new BrowserWindow({
     width: OVERLAY_WIDTH,

--- a/preload.js
+++ b/preload.js
@@ -24,6 +24,7 @@ const SEND = new Set([
   "pipeline:cancel",
   "overlay:drag-start",
   "overlay:drag",
+  "overlay:drag-end",
   "overlay:resize",
 ]);
 

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -533,6 +533,8 @@ card.addEventListener("pointermove", (event) => {
 });
 
 function endDrag() {
+  // pointercancel can trail pointerup; only the first end of a real drag counts.
+  if (!dragging) return;
   dragging = false;
   card.classList.remove("dragging");
   // Send the final position immediately so the card settles exactly under the
@@ -541,6 +543,8 @@ function endDrag() {
     cancelAnimationFrame(dragRaf);
     flushDrag();
   }
+  // Tell the main process the drag is over so it persists the resting spot.
+  earheart.send("overlay:drag-end");
 }
 
 card.addEventListener("pointerup", endDrag);


### PR DESCRIPTION
## Summary

The overlay's dragged position lived only in memory, so every launch reset the card to the default bottom-center spot.

- Persist the card's resting position to `settings.json` when a drag ends — a new `overlay:drag-end` IPC message, sent once per drag rather than per mousemove.
- Restore it when the overlay window is created, but only if the base-height card still fits entirely on a connected display's work area: a spot remembered from an unplugged monitor or a shrunken resolution falls back to the default bottom-center instead of stranding the card off-screen. (Display changes while the app is running were already handled — `overlayPosition()` re-clamps on every show.)
- The settings/wizard forms save payloads spread from the snapshot they opened with, so `main/ipc.js` now re-injects the live `overlay` slice on their saves to keep a mid-session drag from being rolled back.
- The settings default is an empty `overlay: {}` (coordinates absent until first saved) because `deepMerge` treats a `null` base as a mergeable object and would corrupt a saved coordinate into `{}`.

## Test plan

- [x] `npm test` — 104 tests pass
- [ ] Drag the overlay, restart the app: the card reappears where it was left
- [ ] Remove the saved position's display (or shrink resolution below the saved spot), restart: the card falls back to bottom-center

🤖 Generated with [Claude Code](https://claude.com/claude-code)