### PR TITLE
feat(cleanup): add a user dictionary of preferred terms

### DIFF
--- a/main/cleanup-styles.js
+++ b/main/cleanup-styles.js
@@ -62,11 +62,31 @@ function styleById(id) {
   return STYLES.find((s) => s.id === id) || STYLES.find((s) => s.id === DEFAULT_STYLE);
 }
 
+// User dictionary: names, jargon and product terms STT tends to mishear
+// (cleanup.dictionary, an array of strings). Rendered as a prompt block so the
+// cleanup model corrects near-miss transcriptions to the exact spellings
+// listed. Empty (or all-blank) lists add nothing, so the prompt is unchanged
+// for anyone who never filled the dictionary in.
+function dictionaryDirective(terms) {
+  const list = (terms || []).map((t) => String(t).trim()).filter(Boolean);
+  if (list.length === 0) return "";
+  return (
+    "\n\nPreferred vocabulary: the speaker uses these exact terms and " +
+    "spellings. When a word or phrase in the transcript is a mishearing, " +
+    "misspelling or wrong casing of one of them, replace it with the term " +
+    "exactly as written below. Never force a term in where the speaker " +
+    "clearly said something else.\n" +
+    list.map((t) => `- ${t}`).join("\n")
+  );
+}
+
 // Resolve a cleanup config slice into the prompt + sampling actually used.
 // custom → the user's raw numbers and their base prompt untouched; otherwise
 // the chosen preset's sampling plus its directive appended to the base prompt.
+// The dictionary applies in every mode — preferring the user's spellings is
+// orthogonal to how aggressively the model is allowed to edit.
 function resolveCleanup(cfg) {
-  const base = cfg.systemPrompt || "";
+  const base = (cfg.systemPrompt || "") + dictionaryDirective(cfg.dictionary);
   if (cfg.style === "custom") {
     return { systemPrompt: base, sampling: { ...(cfg.custom || {}) } };
   }

--- a/main/settings.js
+++ b/main/settings.js
@@ -86,6 +86,12 @@ const DEFAULTS = {
     custom: { ...styleById(DEFAULT_STYLE).sampling },
     timeoutMs: 60000,
     systemPrompt: DEFAULT_CLEANUP_PROMPT,
+    // Preferred terms (names, jargon, product words) the speaker uses and STT
+    // tends to mishear. Injected into the cleanup prompt so near-misses get
+    // corrected to these exact spellings — see dictionaryDirective in
+    // main/cleanup-styles.js. Array of strings; deepMerge replaces arrays
+    // wholesale, so a saved list survives the merge intact.
+    dictionary: [],
   },
   audio: {
     deviceId: "", // empty = system default microphone

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -325,6 +325,21 @@
           </div>
 
           <div class="card">
+            <div class="card-title">Dictionary</div>
+            <div class="field">
+              <label for="cleanup-dictionary">Preferred terms <span class="muted">(one per line)</span></label>
+              <textarea id="cleanup-dictionary" rows="6" spellcheck="false"
+                placeholder="Earheart&#10;sherpa-onnx&#10;Kubernetes"></textarea>
+              <p class="hint">
+                Names, jargon and product terms that often get misheard. When
+                the transcript comes close to one, cleanup corrects it to the
+                exact spelling listed here. Keep the list short and specific —
+                a handful of terms works better than hundreds.
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
             <div class="card-title">System prompt</div>
             <div class="field">
               <textarea id="cleanup-prompt" rows="8" spellcheck="false" aria-label="System prompt"></textarea>

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -165,6 +165,7 @@ function populate() {
   $("cleanup-key").value = current.cleanup.apiKey;
   $("cleanup-model").value = current.cleanup.model;
   populateCleanupStyle();
+  $("cleanup-dictionary").value = (current.cleanup.dictionary || []).join("\n");
   $("cleanup-prompt").value = current.cleanup.systemPrompt;
   selectEngine("cleanup", current.cleanup.engine);
   $("cleanup-builtin-model").value = current.cleanup.builtin.model;
@@ -223,6 +224,12 @@ function collect() {
       apiKey: $("cleanup-key").value.trim(),
       model: $("cleanup-model").value.trim(),
       ...collectCleanupStyle(),
+      // One term per line in the textarea; stored as an array of trimmed,
+      // non-empty lines.
+      dictionary: $("cleanup-dictionary")
+        .value.split("\n")
+        .map((t) => t.trim())
+        .filter(Boolean),
       systemPrompt: $("cleanup-prompt").value,
     },
     audio: {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -9,6 +9,7 @@ const http = require("node:http");
 const { encodeWav, encodeSilenceWav, wavToFloat32, wavDurationSec } = require("../main/util/wav");
 const { stripThinking } = require("../main/services/cleanup");
 const { deepMerge, migrateLegacy, DEFAULTS } = require("../main/settings");
+const { resolveCleanup } = require("../main/cleanup-styles");
 const autostart = require("../main/autostart");
 const { listRemoteModels } = require("../main/services/models-remote");
 const { reconcileTranscript } = require("../renderer/transcript");
@@ -248,6 +249,55 @@ test("customModels defaults to empty and a stored list survives the merge", () =
   // deepMerge replaces arrays wholesale, so a saved custom-models list is kept
   // intact (not element-merged against the empty default) when settings load.
   assert.deepStrictEqual(deepMerge(DEFAULTS, { customModels: stored }).customModels, stored);
+});
+
+/* ---------------- cleanup dictionary ---------------- */
+
+test("dictionary defaults to empty and a stored list survives the merge", () => {
+  assert.deepStrictEqual(DEFAULTS.cleanup.dictionary, []);
+  const stored = ["Earheart", "sherpa-onnx"];
+  assert.deepStrictEqual(
+    deepMerge(DEFAULTS, { cleanup: { dictionary: stored } }).cleanup.dictionary,
+    stored
+  );
+});
+
+test("resolveCleanup injects dictionary terms into the prompt for every style", () => {
+  const preset = resolveCleanup({
+    systemPrompt: "Base prompt.",
+    style: "clean",
+    dictionary: ["Earheart", "sherpa-onnx"],
+  });
+  assert.match(preset.systemPrompt, /Preferred vocabulary/);
+  assert.match(preset.systemPrompt, /- Earheart\n- sherpa-onnx/);
+  // The style directive still applies after the dictionary block.
+  assert.match(preset.systemPrompt, /Editing style:/);
+
+  // The dictionary is orthogonal to the editing style, so custom mode (raw
+  // sampling numbers, base prompt untouched otherwise) gets it too.
+  const custom = resolveCleanup({
+    systemPrompt: "Base prompt.",
+    style: "custom",
+    custom: { temperature: 0.3 },
+    dictionary: ["Earheart"],
+  });
+  assert.match(custom.systemPrompt, /Preferred vocabulary/);
+  assert.match(custom.systemPrompt, /- Earheart/);
+});
+
+test("resolveCleanup leaves the prompt unchanged for an empty or blank dictionary", () => {
+  const base = { systemPrompt: "Base prompt.", style: "custom", custom: {} };
+  assert.strictEqual(resolveCleanup(base).systemPrompt, "Base prompt.");
+  assert.strictEqual(
+    resolveCleanup({ ...base, dictionary: [] }).systemPrompt,
+    "Base prompt."
+  );
+  // Whitespace-only entries (blank textarea lines) must not produce an empty
+  // vocabulary block.
+  assert.strictEqual(
+    resolveCleanup({ ...base, dictionary: ["  ", ""] }).systemPrompt,
+    "Base prompt."
+  );
 });
 
 /* ---------------- start on boot (autostart) ---------------- */


### PR DESCRIPTION
## What

Adds a **Dictionary** card to Settings → Cleanup: a list of preferred terms (one per line) — names, jargon, product words that STT tends to mishear. Terms are stored as `cleanup.dictionary` and injected into the cleanup prompt as a "Preferred vocabulary" block, so the cleanup model corrects near-miss transcriptions (mishearings, misspellings, wrong casing) to the exact spellings listed, while explicitly told never to force a term where the speaker clearly said something else.

## Why

Domain-specific vocabulary (project names, technical terms, people) is exactly what generic STT models get wrong most often. The built-in Parakeet model can't be vocabulary-biased directly, so the cleanup pass is the natural enforcement point.

## How

- The injection happens in `resolveCleanup()` (`main/cleanup-styles.js`) — the single choke point shared by the built-in Gemma engine, remote OpenAI-compatible services, and the live-preview cleanup pass. No extra plumbing needed.
- Applies in every editing style, including "custom" — preferring the user's spellings is orthogonal to how aggressively the model edits.
- An empty or blank dictionary adds nothing to the prompt, so existing configs behave exactly as before. `deepMerge` replaces arrays wholesale, so a saved list survives settings merges intact (same shape as `customModels`).
- UI hint steers users toward a short, specific list — a huge term list would dilute the small default model's attention.

## How to test

- `npm test` — 145 tests pass (3 new: default/merge survival, prompt injection in preset + custom styles, empty/blank list no-op)
- `make smoke` — OK
- `npx electron scripts/engine-smoke.js --no-sandbox` — OK
- Manual: Settings → Cleanup → Dictionary, add a term like `sherpa-onnx`, dictate something that sounds like it, confirm the cleaned transcript uses the exact spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)