### PR TITLE
feat(tray): add "Copy last transcription" menu item

### DIFF
--- a/main/tray.js
+++ b/main/tray.js
@@ -1,10 +1,11 @@
 // System tray icon and menu. The icon doubles as a recording indicator.
 
-const { Tray, Menu, nativeImage } = require("electron");
+const { Tray, Menu, nativeImage, clipboard } = require("electron");
 const path = require("node:path");
 const windows = require("./windows");
 const settings = require("./settings");
 const updates = require("./updates");
+const history = require("./history");
 
 let tray = null;
 let pipeline = null;
@@ -20,6 +21,7 @@ function icon(name) {
 function buildMenu(app) {
   const cfg = settings.get();
   const state = pipeline.getState();
+  const lastEntry = history.list()[0];
   return Menu.buildFromTemplate([
     {
       label:
@@ -62,6 +64,17 @@ function buildMenu(app) {
       click: () => {
         cfg.output.mode = "clipboard";
         settings.save(cfg);
+      },
+    },
+    { type: "separator" },
+    {
+      label: "Copy last transcription",
+      enabled: !!lastEntry,
+      // Re-read at click time so we copy the freshest entry even if the menu
+      // was built a moment before the dictation landed.
+      click: () => {
+        const entry = history.list()[0];
+        if (entry) clipboard.writeText(entry.text);
       },
     },
     { type: "separator" },


### PR DESCRIPTION
## What

Adds a new right-click tray menu item: **"Copy last transcription"**, which puts the most recent transcript's final text back on the clipboard.

## Why

After a dictation finishes, the transcript is delivered once and then out of easy reach — the only way to get it back is via the per-item Copy button in Settings → History. This gives a one-click path to reuse the last dictation when the paste landed in the wrong window or wasn't used. It's exactly what the history store already exists for ("so a transcript is never lost if a paste goes to the wrong window").

## How

Fully localized to `main/tray.js`:

- New item placed in its own section after the output-mode radio group.
- **Source:** the persisted history store (`history.list()[0].text`) — the final delivered text (cleaned when cleanup is on). Survives app restarts.
- **Fresh on click:** the handler re-reads `history.list()[0]` at click time, so it copies the newest transcript even if the menu was built a moment before the dictation landed.
- **Silent:** just writes to the clipboard, no notification — matching the existing "Copy to clipboard only" output mode.
- **Disabled** when there's no history (fresh profile, or History turned off in Settings).

The menu already rebuilds on every pipeline state change, so the item's enabled state tracks new dictations automatically.

## Testing

- `node --check main/tray.js` passes.
- `node --test` — 144 passing, 1 pre-existing skip.
- Manual: dictate → tray → **Copy last transcription** → paste matches the last transcript; second dictation copies the newer one; item greys out with no history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)