### PR TITLE
chore: rename default branch master -> main

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/cleanunicorn/earheart/discussions
     about: Ask a question, share a setup, or float an idea before filing an issue.
   - name: STT server (stt-server)
-    url: https://github.com/cleanunicorn/earheart/blob/master/stt-server/README.md
+    url: https://github.com/cleanunicorn/earheart/blob/main/stt-server/README.md
     about: Options, GPU providers and models for the optional local Parakeet server.
   - name: Contributing guide
-    url: https://github.com/cleanunicorn/earheart/blob/master/CONTRIBUTING.md
+    url: https://github.com/cleanunicorn/earheart/blob/main/CONTRIBUTING.md
     about: Dev setup, architecture, and how releases are cut.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
       value: |
         Earheart is intentionally small and hackable. Proposals that keep it
         lean — few runtime dependencies, private by default — are the easiest
-        to land. See [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) for the
+        to land. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the
         design constraints worth keeping.
 
   - type: textarea

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,6 +1,6 @@
 name: Auto release
 
-# Cuts a release automatically when a PR merges to master, sized by the
+# Cuts a release automatically when a PR merges to main, sized by the
 # conventional-commit prefix of the PR title:
 #
 #   feat!: / fix!: / any `type!:`  → major
@@ -8,14 +8,14 @@ name: Auto release
 #   fix: / perf: / refactor:       → patch
 #   anything else (chore:, docs:, ci:, free-form, "[skip release]") → no release
 #
-# The version bump lands as a commit on master plus a `v<version>` tag, and
+# The version bump lands as a commit on main plus a `v<version>` tag, and
 # the Release builds workflow is dispatched on that tag to build and publish
 # the installers.
 
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: write
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: master
+          ref: main
 
       - name: Decide version bump from the PR title
         id: bump
@@ -59,7 +59,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           npm version "${{ steps.bump.outputs.bump }}" -m "release: v%s"
-          git push origin master --follow-tags
+          git push origin main --follow-tags
 
       - name: Trigger release builds
         if: steps.bump.outputs.bump != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 Guidance for AI agents (and humans) contributing to **Earheart**. This project
-follows the **GitHub flow**: `master` is always releasable, all work happens on
+follows the **GitHub flow**: `main` is always releasable, all work happens on
 short-lived branches, and every change lands through a reviewed pull request.
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) for full setup, build, and architecture
@@ -9,22 +9,22 @@ details. This file is the operational checklist for *how to work* here.
 
 ## Golden rules
 
-1. **Never commit directly to `master`.** It is protected and is the release
+1. **Never commit directly to `main`.** It is protected and is the release
    branch — merging to it auto-publishes a release (see below). Always branch.
-2. **Never push to `master` or force-push a shared branch.**
+2. **Never push to `main` or force-push a shared branch.**
 3. **The PR title is load-bearing.** It drives the released version bump, so it
    must be a valid Conventional Commits string (see [PR titles](#pr-titles)).
-4. **Keep `master` green.** Run the checks locally before opening a PR.
+4. **Keep `main` green.** Run the checks locally before opening a PR.
 5. **Never lose the user's words.** A core design constraint of the app — if you
    touch the pipeline, preserve the raw-transcript fallbacks.
 
 ## The GitHub flow, step by step
 
-### 1. Start from an up-to-date `master`
+### 1. Start from an up-to-date `main`
 
 ```bash
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 ```
 
 ### 2. Create a branch
@@ -93,10 +93,10 @@ CI wraps them with `xvfb-run`.
 
 ```bash
 git push -u origin fix/windows-autostart-readback
-gh pr create --base master --fill
+gh pr create --base main --fill
 ```
 
-Target **`master`**. Then set a valid title and a clear body (see below).
+Target **`main`**. Then set a valid title and a clear body (see below).
 
 ## PR titles
 
@@ -152,7 +152,7 @@ Keep it short and useful:
 
 ## What merging does (so you pick the right title)
 
-When a PR merges to `master`, [auto-release.yml](.github/workflows/auto-release.yml)
+When a PR merges to `main`, [auto-release.yml](.github/workflows/auto-release.yml)
 reads the PR title's prefix and, for a release-affecting type, bumps
 `package.json`, commits `release: vX.Y.Z`, tags it, and dispatches the
 multi-platform release builds. The release goes live only after all three

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ tag pushes (`v*`) — see [.github/workflows/release.yml](.github/workflows/rele
 
 ## Releasing
 
-Releases are cut **automatically when a PR merges to master**, sized by the
+Releases are cut **automatically when a PR merges to main**, sized by the
 conventional-commit prefix of the PR title
 ([.github/workflows/auto-release.yml](.github/workflows/auto-release.yml)):
 
@@ -94,7 +94,7 @@ conventional-commit prefix of the PR title
 | `fix: …`, `perf: …`, `refactor: …` | patch |
 | anything else (`chore:`, `docs:`, free-form, `[skip release]`) | none |
 
-The workflow bumps `package.json`, commits `release: vX.Y.Z` to master, tags
+The workflow bumps `package.json`, commits `release: vX.Y.Z` to main, tags
 it, and dispatches the release builds. Those builds create the GitHub release
 as a draft, each platform uploads its installers into it, and the release is
 flipped live only after all three platforms succeed — so a half-built release

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,13 @@ dist-win-docker: ## Cross-build Windows packages from Linux via Docker+Wine
 
 # ----- releasing -------------------------------------------------------------
 
-# Releases also happen automatically when a PR merges to master, sized by the
+# Releases also happen automatically when a PR merges to main, sized by the
 # PR title (see .github/workflows/auto-release.yml). This target is the manual
 # path: bump version, commit, tag, push — CI builds and publishes installers.
 .PHONY: release
 release: ## Cut a release: bump, tag, push (BUMP=patch|minor|major, default patch)
 	npm version $(or $(BUMP),patch)
-	git push origin master --follow-tags
+	git push origin main --follow-tags
 
 # ----- speech-to-text server (Python) ---------------------------------------
 


### PR DESCRIPTION
The GitHub default branch was renamed from \`master\` to \`main\`. This updates the in-repo references to match.

- \`ci.yml\` / \`auto-release.yml\`: trigger branches, checkout ref, and release push target
- Issue templates: \`blob/master\` → \`blob/main\` links
- \`AGENTS.md\`, \`CONTRIBUTING.md\`, \`Makefile\`: docs and release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)