### PR TITLE
fix: run cleanup on CPU under Windows-on-ARM emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ is just the version number (e.g. `0.8.0`).
 - **Most people:** `Earheart-Setup-<version>.exe` — the installer.
 - Don't want to install? `Earheart-<version>.exe` — a portable build you can
   run directly.
+- **Windows on ARM (Snapdragon X):** use the same x64 files above — Windows
+  runs them under built-in emulation, and both transcription and cleanup work.
+  There is no separate ARM installer yet.
 
 **🍎 macOS**
 

--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -117,7 +117,7 @@ async function transcribe({ wav, language }) {
 
 /* ---------------- cleanup (node-llama-cpp / Gemma) ---------------- */
 
-async function loadCleanup({ modelPath, contextSize }) {
+async function loadCleanup({ modelPath, contextSize, cpuOnly }) {
   if (llamaModel && cleanupModelPath === modelPath) return { ready: true };
   // node-llama-cpp v3 is ESM-only; reach it via dynamic import from CommonJS.
   let mod;
@@ -131,9 +131,14 @@ async function loadCleanup({ modelPath, contextSize }) {
   // whose free VRAM can't actually fit the model + context (a busy desktop
   // GPU), and the failure only surfaces at loadModel/createContext. Without
   // the retry that machine loses cleanup entirely (every dictation falls back
-  // to the raw transcript). EARHEART_LLAMA_GPU=off skips the GPU attempt.
-  const attempts =
-    process.env.EARHEART_LLAMA_GPU === "off" ? [false] : [null, false];
+  // to the raw transcript).
+  //
+  // Skip the GPU attempt entirely when the caller asks for CPU-only. That's
+  // set on an emulated Windows-on-ARM / Rosetta host (see index.js), where the
+  // GPU probe faults hard enough to kill this process — an uncatchable crash
+  // the retry below can't rescue. EARHEART_LLAMA_GPU=off forces the same path.
+  const forceCpu = cpuOnly === true || process.env.EARHEART_LLAMA_GPU === "off";
+  const attempts = forceCpu ? [false] : [null, false];
   let lastErr = null;
   for (const gpu of attempts) {
     try {

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -97,6 +97,25 @@ async function transcribe(wav, cfg, signal, { onDecodeMs } = {}) {
 
 let loadedCleanup = null;
 
+// Windows on ARM (and macOS Rosetta) runs our x64 build as an emulated process.
+// STT (sherpa-onnx) tolerates that, but node-llama-cpp's GPU auto-probe faults
+// hard under emulation — a native crash the worker's try/catch can't catch, so
+// it takes the whole cleanup process down and every dictation falls back to the
+// raw transcript. That is the "transcription works but cleanup doesn't" report
+// on Snapdragon X machines. There is no in-process arm64 STT binary yet (so we
+// can't ship a native arm64 build without losing transcription); the fix that
+// keeps both halves working is to run cleanup on the CPU backend under
+// emulation. `app.runningUnderARM64Translation` is Electron's own signal for
+// exactly this — true only when an x64/x86 build runs on an arm64 host — and it
+// sees through the emulation that virtualizes env vars and GetNativeSystemInfo.
+function runningEmulated() {
+  try {
+    return app.runningUnderARM64Translation === true;
+  } catch {
+    return false;
+  }
+}
+
 // Load the cleanup model into the worker if it isn't already. Throws if the
 // model isn't downloaded yet — callers surface that (or fall back to HTTP).
 async function ensureCleanup(modelId) {
@@ -107,6 +126,9 @@ async function ensureCleanup(modelId) {
   if (loadedCleanup !== modelId) {
     await cleanupHost.request("load-cleanup", {
       modelPath: path.join(manager.modelDir(modelsDir(), model), model.gguf.file),
+      // Skip the GPU probe on an emulated (Windows-on-ARM / Rosetta) host so
+      // the load can't crash the worker; run cleanup on the CPU backend there.
+      cpuOnly: runningEmulated(),
     });
     loadedCleanup = modelId;
   }

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -18,7 +18,7 @@ const Module = require("node:module");
 // Load main/engines/index.js with `electron`, `./host`, and `./model-manager`
 // replaced by the supplied fakes, so the facade can be exercised without the
 // Electron runtime or the native engines. Returns the facade module.
-function loadFacadeWith({ host, manager: managerStub }) {
+function loadFacadeWith({ host, manager: managerStub, app: appExtra }) {
   const indexPath = require.resolve("../main/engines/index");
   const electronPath = require.resolve("electron", {
     paths: [path.dirname(indexPath)],
@@ -26,7 +26,7 @@ function loadFacadeWith({ host, manager: managerStub }) {
   const hostPath = require.resolve("../main/engines/host");
   const managerPath = require.resolve("../main/engines/model-manager");
   const stubs = {
-    [electronPath]: { app: { getPath: () => os.tmpdir() } },
+    [electronPath]: { app: { getPath: () => os.tmpdir(), ...appExtra } },
     [hostPath]: host,
     [managerPath]: managerStub,
   };
@@ -526,6 +526,44 @@ test("engines.clean forwards onProgress to the worker host request", async () =>
 
   // Without the options arg, clean() still works and passes no callback.
   assert.strictEqual(await facade.clean("hello", cfg), "cleaned");
+});
+
+test("engines cleanup load forces CPU-only under ARM64 emulation", async () => {
+  // On an emulated Windows-on-ARM (or Rosetta) host the GPU probe crashes the
+  // cleanup worker, so the facade must tell the worker to skip it. The signal
+  // is Electron's app.runningUnderARM64Translation; assert it rides along on
+  // the load-cleanup request and is absent (falsy) on a native host.
+  const managerStub = {
+    isInstalled: () => true,
+    modelDir: (base, model) => path.join(base, model.kind, model.id),
+  };
+  const cfg = { builtin: { model: registry.DEFAULT_CLEANUP_MODEL }, systemPrompt: "rules" };
+
+  function loadCleanupPayload(appExtra) {
+    let payload = null;
+    const hostModule = {
+      createHost: () => ({
+        request: async (type, args) => {
+          if (type === "load-cleanup") {
+            payload = args;
+            return { ready: true };
+          }
+          if (type === "clean") return "ok";
+          throw new Error(`unexpected request: ${type}`);
+        },
+        stop() {},
+        onExit() {},
+      }),
+    };
+    const facade = loadFacadeWith({ host: hostModule, manager: managerStub, app: appExtra });
+    return facade.clean("hi", cfg).then(() => payload);
+  }
+
+  const emulated = await loadCleanupPayload({ runningUnderARM64Translation: true });
+  assert.strictEqual(emulated.cpuOnly, true, "emulated host must request CPU-only cleanup");
+
+  const native = await loadCleanupPayload({ runningUnderARM64Translation: false });
+  assert.strictEqual(native.cpuOnly, false, "native host keeps the GPU auto-probe");
 });
 
 test("engines.transcribe unwraps the worker reply and reports decode timing", async () => {


### PR DESCRIPTION
The Windows build ships x64 only, so on a Snapdragon X (arm64) host it runs
under Prism emulation. sherpa-onnx (transcription) tolerates emulation, but
node-llama-cpp's GPU auto-probe faults hard there — an uncatchable native
crash that takes the cleanup worker down, so every dictation falls back to
the raw transcript. That's the "transcription works but cleanup doesn't"
report on Windows ARM.

We can't ship a native arm64 build: node-llama-cpp has a win-arm64 binary but
sherpa-onnx-node has none, so an arm64 process would lose transcription
instead. Keep the single x64 build and, when running emulated, skip the GPU
probe and load cleanup on the CPU backend so both halves work.

Detect emulation with Electron's app.runningUnderARM64Translation (true only
for an x64/x86 build on an arm64 host) and pass cpuOnly through to the worker's
load-cleanup; EARHEART_LLAMA_GPU=off still forces the same path. Document that
Windows-on-ARM users run the x64 build under emulation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P179XGM7ahwrWrziYtQwfC