### PR TITLE
fix(updates): re-sign the mac bundle on self-update so it launches on Apple Silicon

### DIFF
--- a/main/updates.js
+++ b/main/updates.js
@@ -507,6 +507,29 @@ fi
 open "$OLD"
 `;
 
+// Apple Silicon refuses to exec an arm64 binary that has no valid code
+// signature — the kernel kills it before our JS ever runs, so a bundle that
+// arrives unsigned (or with a signature the extract/move invalidated) launches
+// to nothing: "the update installed but the app won't open." A fresh install
+// dodges this only because the shipped bundle happens to be signed; the
+// self-update must not assume that. Verify the extracted bundle and, only when
+// the seal is missing or broken, repair it with an ad-hoc signature (`-`). A
+// bundle that already verifies — including a real Developer ID signature, if we
+// ever ship one — is left untouched so we never downgrade a good signature to
+// ad-hoc. Throwing here aborts the update before the swap, leaving the working
+// old app in place, rather than swapping in a bundle that can't start.
+function ensureMacSignature(bundle) {
+  const verify = spawnSync("/usr/bin/codesign", ["--verify", "--deep", "--strict", bundle]);
+  if (verify.status === 0) return;
+  logger.warn("updated app has no valid signature; re-signing ad-hoc so it can launch");
+  const sign = spawnSync("/usr/bin/codesign", ["--force", "--deep", "--sign", "-", bundle]);
+  if (sign.status !== 0) {
+    throw new Error(
+      `Could not sign the updated app: ${(sign.stderr || sign.status || "").toString().trim()}`
+    );
+  }
+}
+
 function installMac(zipPath) {
   const bundle = path.resolve(process.execPath, "..", "..", "..");
   if (!bundle.endsWith(".app")) {
@@ -540,6 +563,10 @@ function installMac(zipPath) {
       `Downloaded app reports version ${version ? version[1] : "unknown"}, expected ${state.latest}`
     );
   }
+
+  // Make sure the bundle will actually launch on Apple Silicon (a valid
+  // signature is mandatory there) before we commit to swapping it in.
+  ensureMacSignature(newBundle);
 
   // Our own download carries no quarantine flag (Electron doesn't opt into
   // LSFileQuarantineEnabled), but stripping it here costs nothing.


### PR DESCRIPTION
Apple Silicon won't exec an arm64 .app that has no valid code signature — the
kernel kills it before any JS runs, so a self-update that swaps in an unsigned
(or extract/move-invalidated) bundle installs fine but then "won't open". A
fresh download only avoids this because the shipped bundle happens to be signed;
the in-app updater assumed the same and didn't guard it.

Verify the extracted bundle before the swap and, only when the signature is
missing or broken, repair it with an ad-hoc signature. A bundle that already
verifies (including a real Developer ID signature, should we ever ship one) is
left untouched, so we never downgrade a good signature to ad-hoc. The check runs
in the live process, so a failure aborts the update before the swap and leaves
the working old app in place instead of swapping in one that can't start.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015XcfPubazQtqKXQeB4tDAa