### PR TITLE
fix: re-assert the overlay's topmost position on every show

### DIFF
--- a/main/windows.js
+++ b/main/windows.js
@@ -4,6 +4,7 @@
 const { BrowserWindow, ipcMain, screen } = require("electron");
 const path = require("node:path");
 const settings = require("./settings");
+const logger = require("./util/logger");
 
 const PRELOAD = path.join(__dirname, "..", "preload.js");
 const RENDERER = path.join(__dirname, "..", "renderer");
@@ -173,6 +174,9 @@ function createOverlay() {
     },
   });
   overlayWindow.setAlwaysOnTop(true, "screen-saver");
+  // macOS/Linux only — documented as a no-op on Windows, where a window's virtual
+  // desktop is fixed at creation and there is no public API to pin it to all of
+  // them. showOverlay() re-asserts topmost instead; see raiseWithinTopmostBand.
   overlayWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
   overlayWindow.loadFile(path.join(RENDERER, "overlay.html"));
   overlayWindow.webContents.on("render-process-gone", () => {
@@ -201,6 +205,29 @@ function destroyOverlay() {
   overlayWindow = null;
 }
 
+// On Windows, "always on top" is a *band* (HWND_TOPMOST), not a single bit: every
+// window that enters that band is inserted above the ones already in it. Our card
+// spends most of its life hidden, and showInactive() deliberately doesn't activate
+// it — so anything that went topmost while we were hidden (a media popup, a call
+// window, a launcher, a game bar) stays above us when we come back, and the card
+// paints underneath it. Clicks meant for Stop/Cancel then land on that other
+// window, which is why the buttons feel dead while the card is plainly visible.
+// Windows-only: macOS and Linux honour the level set at creation.
+function raiseWithinTopmostBand(win) {
+  if (process.platform !== "win32") return;
+  if (!win.isAlwaysOnTop()) {
+    // Reordering within the band is expected; losing the style itself is not, and
+    // means something cleared it out from under us. Worth knowing about.
+    logger.warn("overlay lost its always-on-top style; re-applying");
+  }
+  // HWND_NOTOPMOST then HWND_TOPMOST: leaving the band and re-entering is what
+  // puts us back on top of it. moveTop() alone only reorders within the band and
+  // is not always honoured for a window shown inactive.
+  win.setAlwaysOnTop(false);
+  win.setAlwaysOnTop(true, "screen-saver");
+  win.moveTop();
+}
+
 function showOverlay() {
   const win = getOverlay();
   if (!win) return;
@@ -227,6 +254,9 @@ function showOverlay() {
   const [w, h] = win.getSize();
   win.setSize(w, h + 1);
   win.setSize(w, h);
+  // Only now that the window is actually on screen: re-entering the topmost band
+  // puts the card above whatever went topmost while it was hidden.
+  raiseWithinTopmostBand(win);
   win.webContents.send("overlay:show");
 }
 


### PR DESCRIPTION
## What & why

The recording overlay sometimes appears **underneath** other windows on Windows 11. When it does, Stop/Cancel and drag stop working — clicks meant for the card land on whatever is drawn above it. The tray still says "recording" and the dictation itself is fine; only the card's z-order is wrong.

On Windows, always-on-top is a *band* (`HWND_TOPMOST`), not a single bit: whatever enters that band most recently sits above what is already in it. The overlay is hidden between dictations and shown with `showInactive()` (it must never steal focus from the app being dictated into), so anything that goes topmost while the card is hidden — a media popup, a call window, a launcher, Game Bar — is inserted above it and stays there when the card comes back. Nothing ever re-raises it.

That explains the intermittency: whether it happens depends on what happened to go topmost since the last dictation. Windows 11 compounds it with [known deferred topmost-restoration behaviour](https://learn.microsoft.com/en-us/answers/questions/5562457/topmost-windows-temporarily-lose-z-order-priority).

## How

`showOverlay()` now leaves and re-enters the topmost band once the window is actually on screen, which puts the card back on top of it. `moveTop()` alone only reorders within the band and is not reliably honoured for a window shown inactive.

Windows-only — macOS and Linux honour the level set at creation, and this churn buys nothing there. A `logger.warn` fires if the always-on-top *style* was lost rather than merely reordered: that would be a different failure with a different fix, and it should never happen.

Also documents that `setVisibleOnAllWorkspaces()` is a no-op on Windows — true, and ruled out along the way, but not the cause here.

## Known limits

- Re-raises **at show time only**. If something goes topmost mid-dictation the card can still fall behind; a periodic re-assert while visible would be the follow-up, not added speculatively.
- Cannot beat a **higher band**. UIAccess windows (Magnifier, on-screen keyboard, some accessibility and remote-desktop tools) and exclusive-fullscreen apps outrank the normal topmost band and nothing in user space gets above them.

## How to test

All five CI checks run locally on Linux, green:

- `npm test` — 162 pass, 1 skipped
- `make smoke`
- `npx electron scripts/engine-smoke.js --no-sandbox`
- `npx electron scripts/overlay-smoke.js --no-sandbox` — 10/10
- `npx electron scripts/settings-smoke.js --no-sandbox` — 8/8

The fix itself is Windows-only and needs manual verification there: leave apps that go always-on-top around, dictate repeatedly, and confirm the card is on top and clickable every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGBVpW9JAF2yXZJ9vpaQEW