### PR TITLE
docs: reposition Earheart around talking to coding agents

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -8,49 +8,73 @@ web
 
 ## Users
 
-**Primary: developers & power users.** Keyboard-centric technical users who live
-in editors, terminals, chat, and docs. Comfortable with endpoints, self-hosting,
-and Ollama — but they still expect the out-of-box path to require zero setup.
-Their needs win when design decisions conflict.
+**Primary: developers who work with coding agents.** People prompting Claude
+Code, Codex, Cursor, or an agent web UI for hours a day — in a terminal, an
+editor chat pane, or a browser. They already know good prompts are long
+(context, constraints, what they already tried) and that typing them is the
+slow part of the loop. Comfortable with endpoints, self-hosting, and Ollama,
+but they still expect the out-of-box path to require zero setup. Their needs
+win when design decisions conflict.
+
+Their prompts are proprietary by nature — their own code, file layout,
+architecture, unshipped work — which makes on-device processing a requirement
+rather than a preference.
+
+**Served audience: everyday dictation users.** The same keyboard-centric
+technical users, dictating into email, notes, issues and docs. The hotkey is
+identical and this path must never degrade to serve the agent path.
 
 **Served audience: motor/RSI users.** People who type all day and feel it, or
 cannot type comfortably at all. For them dictation is relief or necessity, so
 minimal-interaction flows and reliability matter above all (confirmed
 commitment; see Accessibility & Inclusion).
 
-Situation for both: mid-task inside someone else's app — an editor, an email, a
-chat box. The job: turn speech into clean text exactly where the cursor is,
-faster than typing, without giving up privacy.
+Situation for all three: mid-task inside someone else's app — an agent's input
+box, an editor, an email. The job: turn speech into clean text exactly where the
+cursor is, faster than typing, without giving up privacy.
 
 ## Product Purpose
 
-Earheart is private, hotkey-driven voice dictation for Windows, macOS, and
-Linux. Press a global hotkey, speak, press again — speech is transcribed
-(NVIDIA Parakeet), optionally cleaned up by a small LLM (punctuation, filler
-words, false starts), and pasted into whatever app has focus, or copied to the
-clipboard.
+Earheart is the voice input layer for coding agents: hotkey-driven dictation
+for Windows, macOS, and Linux that puts a spoken prompt into Claude Code,
+Codex, Cursor, or any other app with focus. Press a global hotkey, speak, press
+again — speech is transcribed (NVIDIA Parakeet), cleaned up by a small
+on-device LLM (punctuation, filler words, false starts), and pasted where the
+cursor is, or copied to the clipboard. It remains a general dictation tool; the
+agent loop is where it's aimed.
 
-**Success:** become the go-to open-source dictation app — the name people reach
-for instead of paid cloud tools. Stars, downloads, and contributors are the
-scoreboard.
+**Success:** become the default way developers talk to their agents — the tool
+people install alongside Claude Code or Codex. Stars, downloads, and
+contributors are the scoreboard.
 
 ## Positioning
 
-**Lead claim (confirmed): private by default, zero setup.** Both engines run
-in-process out of the box — no cloud, no account, no separate program, no
-Python, nothing ever leaves the machine — and it still takes zero
-configuration. The first-run wizard downloads two small models and everything
-after runs locally, faster than realtime on CPU.
+**Lead claim: talk to your coding agents, privately.** Speaking a prompt is
+several times faster than typing it, and better prompts get written when the
+cost of a third paragraph is a breath instead of a minute. Because both engines
+run in-process, prompts full of proprietary code never leave the machine —
+which is the difference between "nice for dictation" and "usable at work."
 
 Supporting truths (real, but not the lead):
 
+- **Zero setup, no integration** — it pastes into whatever has focus, so every
+  agent works on day one with no plugin, API key or account. The first-run
+  wizard downloads two small models; everything after runs locally, faster than
+  realtime on CPU.
 - **Open, modular, yours** — MIT open source; every stage is an
   OpenAI-compatible HTTP endpoint you can repoint (local server, Ollama,
   hosted APIs). Switching is just a base URL in Settings.
+- **Tuned for technical speech** — verbatim/clean/polished cleanup styles and a
+  user dictionary so identifiers, tool names and jargon survive transcription.
 - **Never loses your words** — raw-transcript fallback when cleanup fails,
   local history against mis-aimed pastes, clipboard restore.
 - **Cross-platform equal citizen** — first-class Linux support (X11 and
   Wayland) alongside Windows and macOS, which desktop dictation rarely offers.
+
+**Not claimed (yet):** Earheart does not submit the prompt for you, does not
+speak the agent's replies, and has no MCP or agent-side integration. These are
+tracked as roadmap issues under the `agents` label — never describe them as
+shipped.
 
 ## Operating Context
 
@@ -105,7 +129,11 @@ Supporting truths (real, but not the lead):
 
 ## Brand Commitments
 
-- Name: **Earheart**. Existing app icon and tray icons in `assets/`.
+- Name: **Earheart**. Existing app icon and tray icons in `assets/`. The name
+  does not change with the agent-forward positioning — only the copy around it.
+- Tagline: **"Talk to your coding agents."** Used as the README and repo
+  headline. The one-line expansion is "Press a hotkey, speak your prompt, press
+  again — it lands in Claude Code, Codex, Cursor, or whatever else has focus."
 - License: MIT; open-source identity is part of the brand.
 - Voice (confirmed as a good default, **not binding**): plain-spoken,
   friendly, technically honest, reassuring without overpromising — e.g. the

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 <h1 align="center">Earheart</h1>
 
 <p align="center">
-  Private, hotkey-driven voice dictation for Windows, macOS and Linux.<br/>
-  Press a key, speak, press again — your words appear where you type.
+  <b>Talk to your coding agents.</b><br/>
+  Press a hotkey, speak your prompt, press again — it lands in Claude Code,
+  Codex, Cursor, or whatever else has focus.<br/>
+  Fully local. No cloud, no account, nothing leaves your machine.
 </p>
 
 <p align="center">
@@ -21,16 +23,31 @@
 
 ---
 
-Earheart records your voice when you press a global hotkey, transcribes it
-with a speech-to-text service, optionally cleans the transcript up with a
-language model, and then **pastes the result into whatever app you're typing
-in** (or just copies it to your clipboard).
+Working with an agent is a conversation, but you type it like a form. The
+prompts that actually work are long — context, constraints, the three things
+you already tried, the "no, not like that." Typing all of that is the slow part
+of the loop, and the reason people send a one-liner instead and then spend four
+turns correcting it.
 
-Out of the box both steps run **inside the app, on your computer** — no
-separate program, no Python, no account. The setup wizard downloads a small
+Earheart turns that part into talking. Press a global hotkey, say what you
+want, press it again: your speech is transcribed on-device (NVIDIA Parakeet),
+tidied up on-device (a small Gemma model drops the *ums*, false starts and
+backtracking), and **pasted straight into whatever app has focus** — the
+terminal running Claude Code, the Codex composer, Cursor's chat box, a GitHub
+issue, an email.
+
+**Nothing leaves your machine**, which matters more for agent prompts than for
+ordinary dictation: what you say to an agent is your own code, your file
+layout, your architecture, your unshipped work. Out of the box both models run
+**inside the app, on your computer** — no separate program, no Python, no
+account, no telemetry. The setup wizard downloads a small
 [Parakeet](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3) speech model and
 a small [Gemma](https://huggingface.co/google) cleanup model (with a progress
-bar) and runs them in-process. Nothing ever leaves your machine.
+bar) and runs them in-process.
+
+It is still a general-purpose dictation app — the hotkey works the same in your
+email client, your notes and your browser. Agents are just where it earns its
+keep. See [Talking to agents](#talking-to-agents) for the practical setup.
 
 Prefer to point Earheart elsewhere? Both steps are also **modular,
 OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
@@ -64,9 +81,15 @@ OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
   settling in behind the raw words on pauses. The final transcript on stop is
   unchanged. Toggle it under Settings → Speech-to-text.
 - **LLM cleanup (on by default)** — punctuation, filler-word removal, false
-  starts. By default a small Gemma model runs **in-process**; or point cleanup
-  at any OpenAI-compatible chat API. The prompt is fully editable. If cleanup
-  fails, the raw transcript is delivered instead — your words are never lost.
+  starts, so a rambled prompt arrives as something an agent can actually read.
+  By default a small Gemma model runs **in-process**; or point cleanup at any
+  OpenAI-compatible chat API. If cleanup fails, the raw transcript is delivered
+  instead — your words are never lost.
+- **Cleanup styles and a personal dictionary** — one slider picks how far
+  cleanup may stray from your exact words (**Verbatim** → **Clean** →
+  **Polished**), and the prompt underneath is fully editable. The dictionary in
+  Settings → Cleanup fixes the terms speech-to-text always mangles: your repo
+  and product names, `pnpm`, `kubectl`, `useEffect`, colleagues' names.
 - **Auto-paste, clipboard, or both** — paste straight into the focused app
   (with clipboard restore), paste *and* keep the transcript on the clipboard,
   or clipboard-only if you prefer to paste yourself.
@@ -246,6 +269,44 @@ the wizard:
 
 A mis-aimed paste never loses your words: the History section in Settings
 keeps recent transcriptions in a local file (you can turn this off).
+
+## Talking to agents
+
+Earheart pastes into the focused window, so it works with any agent you can
+type into — no integration, no plugin, no API key. Put the cursor in the
+agent's input, hold the thought, press the hotkey, and say the whole prompt
+including the parts you'd normally leave out because typing them is tedious.
+
+| Where you're prompting | What to know |
+| --- | --- |
+| **Claude Code / Codex CLI** (terminal) | Paste lands in the TUI input like any paste. On Linux, auto-paste needs `xdotool`/`wtype` — see [Platform notes](#linux). |
+| **Cursor, VS Code, JetBrains chat** | Nothing special — click the chat box and dictate. |
+| **claude.ai, ChatGPT, agent web UIs** | Same. The overlay never steals focus, so the composer keeps it. |
+| **Anywhere via a shortcut** | Bind a system shortcut, mouse button or foot pedal to `earheart --toggle` instead of using the built-in hotkey. |
+
+Three settings are worth a minute for agent work:
+
+- **Cleanup style** (Settings → Cleanup). **Clean** — the default — is the
+  right one for prompts: it removes the *ums* and the restarts but keeps your
+  wording and your intent. Switch to **Verbatim** when you're dictating exact
+  strings, commands or code and want nothing touched. Avoid **Polished** for
+  prompts; smoothing prose is not what you want done to an instruction.
+- **Dictionary** (Settings → Cleanup). Speech-to-text has never heard of your
+  repo. Add the words you say fifty times a day — service names, `pnpm`,
+  `kubectl`, `PostgreSQL`, `useEffect`, your teammates' names — and near-misses
+  get corrected to the exact spelling.
+- **Cleanup prompt** (Settings → Cleanup). Editable. Agent prompts are not
+  prose, and you can say so — e.g. tell it to keep file paths, flags and
+  identifiers exactly as spoken and never to answer the transcript. (The
+  default prompt already forbids acting on the transcript's content: your
+  dictation is text to clean, never instructions to follow.)
+
+**What it doesn't do yet.** You still press Enter yourself — Earheart pastes,
+it doesn't submit. The agent can't ask *you* a question by voice, and it can't
+talk back. Those are the next things we're building; the ideas are filed as
+issues under the
+[`agents`](https://github.com/cleanunicorn/earheart/issues?q=is%3Aissue+label%3Aagents)
+label, and opinions on them are welcome.
 
 ## Using other services
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,7 +37,7 @@ linux:
     - deb
   category: Utility
   icon: assets/icon.png
-  synopsis: Private, hotkey-driven voice dictation
+  synopsis: Voice dictation for coding agents — private and fully local
   desktop:
     entry:
       StartupWMClass: earheart

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "earheart",
   "version": "0.23.0",
-  "description": "Private, hotkey-driven voice dictation for your desktop. Speech-to-text with NVIDIA Parakeet, cleanup with any OpenAI-compatible LLM.",
+  "description": "Talk to your coding agents. Hotkey-driven voice dictation that speaks your prompt into Claude Code, Codex, Cursor — or any app you're typing in. Fully local: NVIDIA Parakeet speech-to-text and on-device LLM cleanup, no cloud.",
   "main": "main/main.js",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Earheart's audience is already developers, and the place dictation pays for
itself is prompting an agent: good prompts are long, typing them is the slow
part of the loop, and their contents (own code, file layout, unshipped work)
are exactly what you don't want leaving the machine.

Lead with that everywhere the project describes itself, without dropping the
general dictation and RSI audiences the product commits to:

- README: new tagline, agent-framed intro, and a "Talking to agents" section
  covering per-agent setup, the three settings that matter (cleanup style,
  dictionary, cleanup prompt) and an explicit list of what does NOT exist yet.
- PRODUCT.md: primary user is now the agent-prompting developer; everyday
  dictation and motor/RSI move to served audiences. New lead claim, plus a
  "not claimed (yet)" block so future copy doesn't oversell the roadmap.
- package.json / electron-builder synopsis / DESIGN.md: matching descriptions.

Copy only — no behaviour change. In-app strings (wizard, settings footer,
desktop entry) still carry the old tagline and are a separate pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JvnDgCY92gz4QCRhrTNCKv