### PR TITLE
feat: run sherpa-onnx Whisper models, not just transducers

### DIFF
--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -75,20 +75,24 @@ async function loadStt({ dir, sherpa, modelId }) {
   // Drop the previous recognizer before swapping models (the cleanup engine
   // does the same via disposeCleanup).
   await disposeStt();
+  const encoder = path.join(dir, sherpa.encoder);
+  const decoder = path.join(dir, sherpa.decoder);
+  // Two model families, told apart by the joiner: a transducer has one, an
+  // encoder-decoder (Whisper) doesn't. sherpa reads whichever sub-config is
+  // set, so pass exactly one.
+  const family = sherpa.joiner
+    ? { transducer: { encoder, decoder, joiner: path.join(dir, sherpa.joiner) } }
+    : { whisper: { encoder, decoder } };
   recognizer = new sherpaOnnx.OfflineRecognizer({
     featConfig: { sampleRate: SAMPLE_RATE, featureDim: FEATURE_DIM },
     modelConfig: {
-      transducer: {
-        encoder: path.join(dir, sherpa.encoder),
-        decoder: path.join(dir, sherpa.decoder),
-        joiner: path.join(dir, sherpa.joiner),
-      },
+      ...family,
       tokens: path.join(dir, sherpa.tokens),
       // Cap 8, not 4: decode is memory-bound and stops scaling there (~20%
       // faster than 4 threads on an 8+-core desktop; more threads regress).
       numThreads: Math.max(1, Math.min(8, require("node:os").cpus().length - 1)),
       provider: "cpu",
-      modelType: sherpa.modelType || "nemo_transducer",
+      modelType: sherpa.modelType || (sherpa.joiner ? "nemo_transducer" : "whisper"),
       debug: false,
     },
   });

--- a/main/services/hf-models.js
+++ b/main/services/hf-models.js
@@ -228,11 +228,17 @@ function buildCleanupModel(repoFull, variant) {
   };
 }
 
-/* ---------------- STT: sherpa-onnx transducer bundles ---------------- */
+/* ---------------- STT: sherpa-onnx model bundles ---------------- */
 
-// The in-process STT engine runs sherpa-onnx offline transducers: an
-// encoder/decoder/joiner .onnx trio plus a tokens.txt — the shape of the
-// csukuangfj/sherpa-onnx-* bundles the built-in Parakeet models come from.
+// The in-process STT engine runs two sherpa-onnx offline model families:
+//   - transducer  encoder/decoder/joiner .onnx + tokens.txt — the shape of the
+//                 csukuangfj/sherpa-onnx-* bundles the built-in Parakeet
+//                 models come from
+//   - whisper     encoder/decoder .onnx + tokens.txt, no joiner — the
+//                 csukuangfj/sherpa-onnx-whisper-* exports
+// A missing joiner is what tells them apart; the engine picks the matching
+// sherpa model config from the `sherpa` map each variant carries.
+//
 // Repos often ship several precisions of the same model side by side
 // ("encoder.onnx" and "encoder.int8.onnx"), so group the files by precision
 // the way GGUF repos group by quantization.
@@ -291,16 +297,43 @@ function dirOf(filePath) {
   return filePath.slice(0, filePath.lastIndexOf("/") + 1);
 }
 
-// Name a few of the files we did find, so "this isn't a transducer bundle"
-// never reads as "your repo is empty" when it plainly isn't.
+// sherpa's Whisper exports prefix every file of a bundle with the model name
+// ("tiny.en-encoder.onnx", "tiny.en-tokens.txt"), so the symbol table can only
+// be matched by that shared prefix rather than a fixed "tokens.txt".
+const TOKENS_RE = /(^|[-_.])tokens\.txt$/i;
+
+function bundlePrefix(name) {
+  const m = name.match(/^(.*?)[-_.]?(?:encoder|decoder|joiner)/i);
+  return m ? m[1].toLowerCase() : "";
+}
+
+function tokensPrefix(name) {
+  return name.replace(/[-_.]?tokens\.txt$/i, "").toLowerCase();
+}
+
+// The symbol table belonging to a given encoder: same prefix first, then an
+// unprefixed tokens.txt, then whatever the repo has. Candidates arrive
+// shallowest-first, so the fallbacks stay deterministic.
+function tokensFor(candidates, encoder) {
+  const prefix = bundlePrefix(encoder.name);
+  return (
+    candidates.find((f) => tokensPrefix(f.name) === prefix) ||
+    candidates.find((f) => tokensPrefix(f.name) === "") ||
+    candidates[0]
+  );
+}
+
+// Name a few of the files we did find, so "this isn't a model Earheart can
+// run" never reads as "your repo is empty" when it plainly isn't.
 function samplePaths(files, limit = 3) {
   return files.slice(0, limit).map((f) => f.path).join(", ") + (files.length > limit ? ", …" : "");
 }
 
 /**
- * List the transducer precisions (int8 / fp16 / fp32 / …) available in a
- * sherpa-onnx model repo. Same return shape as listGgufQuants; each variant
- * additionally carries the `sherpa` file map the engine wires together.
+ * List the precisions (int8 / fp16 / fp32 / …) available in a sherpa-onnx
+ * transducer or Whisper repo. Same return shape as listGgufQuants; each variant
+ * additionally carries the `sherpa` file map the engine wires together — with a
+ * `joiner` for transducers and without one for Whisper.
  * @returns {Promise<{repo,commit,recommended,variants:Array<{label,totalBytes,files,sherpa}>}>}
  */
 async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {}) {
@@ -316,43 +349,45 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
   if (allOnnx.length === 0) {
     throw new Error(
       "No .onnx files found in this repository — Earheart needs a sherpa-onnx transducer " +
-        "bundle (encoder, decoder and joiner .onnx plus tokens.txt)"
+        "bundle (encoder, decoder, joiner) or Whisper export (encoder, decoder), plus tokens.txt"
     );
   }
   const onnx = byDepth.filter((f) => componentOf(f.name));
   if (onnx.length === 0) {
     throw new Error(
       `Found ${allOnnx.length} .onnx file${allOnnx.length === 1 ? "" : "s"} ` +
-        `(${samplePaths(allOnnx)}), but none of them is a transducer encoder, decoder or ` +
-        "joiner — Earheart can only run sherpa-onnx transducer bundles for speech-to-text, " +
-        "not single-file ONNX models"
+        `(${samplePaths(allOnnx)}), but none of them is an encoder, decoder or joiner — ` +
+        "Earheart can only run sherpa-onnx transducer bundles and Whisper exports for " +
+        "speech-to-text, not single-file ONNX models"
     );
   }
-  // Which of the three roles the repo has at all, before worrying about
-  // precisions or the symbol table. A repo missing one outright is a different
-  // kind of model, and saying so beats complaining about a missing tokens.txt.
-  const missing = ["encoder", "decoder", "joiner"].filter(
-    (part) => !onnx.some((f) => componentOf(f.name) === part)
+  // Which roles the repo has at all, before worrying about precisions or the
+  // symbol table. Encoder + decoder with no joiner is the encoder-decoder
+  // (seq2seq) shape sherpa loads as Whisper; anything else is a model family
+  // the engine has no config for, and saying which part is missing beats
+  // complaining about a tokens.txt that was never the real problem.
+  const has = (part) => onnx.some((f) => componentOf(f.name) === part);
+  const family = has("joiner") ? "transducer" : "whisper";
+  const missing = ["encoder", "decoder", ...(family === "transducer" ? ["joiner"] : [])].filter(
+    (part) => !has(part)
   );
   if (missing.length) {
-    // Encoder and decoder but no joiner is the encoder-decoder (seq2seq) shape
-    // — Whisper and its distillations — which sherpa runs from a different
-    // model config than the transducer one the engine wires up.
-    const seq2seq = missing.length === 1 && missing[0] === "joiner";
     throw new Error(
       `Found ${onnx.length} .onnx file${onnx.length === 1 ? "" : "s"} ` +
-        `(${samplePaths(onnx)}), but no ${missing.join(" or ")} — ` +
-        (seq2seq ? "this looks like an encoder-decoder model (Whisper and similar), " +
-          "not a transducer. " : "") +
-        "Earheart can only run sherpa-onnx transducer bundles (encoder, decoder and joiner " +
-        ".onnx plus tokens.txt)"
+        `(${samplePaths(onnx)}), but no ${missing.join(" or ")} — Earheart can only run ` +
+        "sherpa-onnx transducer bundles (encoder, decoder, joiner) and Whisper exports " +
+        "(encoder, decoder), plus tokens.txt"
     );
   }
-  const tokens = byDepth.find((f) => f.name === "tokens.txt");
-  if (!tokens) {
+  // sherpa's Whisper exports name it "<model>-tokens.txt"; transducer bundles
+  // use a plain "tokens.txt". Match either, and pair one to each encoder below.
+  const tokensFiles = byDepth.filter((f) => TOKENS_RE.test(f.name));
+  if (tokensFiles.length === 0) {
     throw new Error(
-      "Found the encoder, decoder and joiner .onnx files, but no tokens.txt — sherpa-onnx " +
-        "needs the bundle's symbol table, so this doesn't look like a sherpa-onnx model repo"
+      `Found the ${family === "whisper" ? "encoder and decoder" : "encoder, decoder and joiner"} ` +
+        ".onnx files, but no tokens.txt — sherpa-onnx needs the bundle's symbol table. " +
+        "Hugging Face / optimum ONNX exports keep the vocabulary in tokenizer.json instead; " +
+        "look for a sherpa-onnx conversion of the same model (csukuangfj/sherpa-onnx-…)"
     );
   }
 
@@ -367,9 +402,15 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
   const pick = (part, precision) =>
     component.get(`${part}:${precision}`) || component.get(`${part}:fp32`);
 
-  // sherpa-onnx needs to know the transducer flavor; the NeMo bundles (the
-  // Parakeet family this feature targets) say so in their repo names.
-  const modelType = /nemo|parakeet/i.test(`${owner}/${repo}`) ? "nemo_transducer" : "transducer";
+  // sherpa-onnx needs to know the model flavor; for transducers the NeMo
+  // bundles (the Parakeet family this feature targets) say so in their repo
+  // names.
+  const modelType =
+    family === "whisper"
+      ? "whisper"
+      : /nemo|parakeet/i.test(`${owner}/${repo}`)
+        ? "nemo_transducer"
+        : "transducer";
 
   const toFile = (f) => ({
     name: f.name,
@@ -386,9 +427,10 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
     const encoder = component.get(`encoder:${precision}`);
     if (!encoder) continue;
     const decoder = pick("decoder", precision);
-    const joiner = pick("joiner", precision);
-    if (!decoder || !joiner) continue;
-    const parts = [encoder, decoder, joiner];
+    if (!decoder) continue;
+    const joiner = family === "transducer" ? pick("joiner", precision) : null;
+    if (family === "transducer" && !joiner) continue;
+    const parts = joiner ? [encoder, decoder, joiner] : [encoder, decoder];
     // External-data sidecars (e.g. the fp32 Parakeet's "encoder.weights") must
     // sit next to their .onnx for the loader to find them. Match within the
     // .onnx's own directory so a nested layout can't pull in a same-named
@@ -401,6 +443,7 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
             dirOf(f.path) === dirOf(p.path) && f.name.startsWith(p.name.replace(ONNX_RE, ""))
         )
     );
+    const tokens = tokensFor(tokensFiles, encoder);
     const all = [...parts, ...sidecars, tokens];
     variants.push({
       label: precision,
@@ -409,20 +452,22 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
       sherpa: {
         encoder: encoder.name,
         decoder: decoder.name,
-        joiner: joiner.name,
+        // Omitted for Whisper — its absence is what selects the engine's
+        // whisper model config over the transducer one.
+        ...(joiner ? { joiner: joiner.name } : {}),
         tokens: tokens.name,
         modelType,
       },
     });
   }
-  // All three roles are present by here, so the only way to reach this is a
-  // precision that never lines up (e.g. an fp16 encoder whose joiner ships
-  // int8-only, with no fp32 of either to fall back to).
+  // Every role the family needs is present by here, so the only way to reach
+  // this is a precision that never lines up (e.g. an fp16 encoder whose joiner
+  // ships int8-only, with no fp32 of either to fall back to).
   if (variants.length === 0) {
+    const roles = family === "whisper" ? "encoder and decoder" : "encoder, decoder and joiner";
     throw new Error(
-      "Could not find a complete transducer in this repository — encoder, decoder and joiner " +
-        `never share a precision (${samplePaths(onnx)}). Earheart can only run sherpa-onnx ` +
-        "transducer bundles"
+      `Could not assemble a complete model from this repository — ${roles} never share a ` +
+        `precision (${samplePaths(onnx)})`
     );
   }
   // Best-first by precision rank, then smallest download, so variants[0] is the

--- a/main/services/hf-models.js
+++ b/main/services/hf-models.js
@@ -328,12 +328,31 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
         "not single-file ONNX models"
     );
   }
+  // Which of the three roles the repo has at all, before worrying about
+  // precisions or the symbol table. A repo missing one outright is a different
+  // kind of model, and saying so beats complaining about a missing tokens.txt.
+  const missing = ["encoder", "decoder", "joiner"].filter(
+    (part) => !onnx.some((f) => componentOf(f.name) === part)
+  );
+  if (missing.length) {
+    // Encoder and decoder but no joiner is the encoder-decoder (seq2seq) shape
+    // — Whisper and its distillations — which sherpa runs from a different
+    // model config than the transducer one the engine wires up.
+    const seq2seq = missing.length === 1 && missing[0] === "joiner";
+    throw new Error(
+      `Found ${onnx.length} .onnx file${onnx.length === 1 ? "" : "s"} ` +
+        `(${samplePaths(onnx)}), but no ${missing.join(" or ")} — ` +
+        (seq2seq ? "this looks like an encoder-decoder model (Whisper and similar), " +
+          "not a transducer. " : "") +
+        "Earheart can only run sherpa-onnx transducer bundles (encoder, decoder and joiner " +
+        ".onnx plus tokens.txt)"
+    );
+  }
   const tokens = byDepth.find((f) => f.name === "tokens.txt");
   if (!tokens) {
     throw new Error(
-      `Found ${onnx.length} transducer .onnx file${onnx.length === 1 ? "" : "s"} ` +
-        `(${samplePaths(onnx)}), but no tokens.txt — sherpa-onnx needs the bundle's symbol ` +
-        "table, so this doesn't look like a sherpa-onnx model repo"
+      "Found the encoder, decoder and joiner .onnx files, but no tokens.txt — sherpa-onnx " +
+        "needs the bundle's symbol table, so this doesn't look like a sherpa-onnx model repo"
     );
   }
 
@@ -396,18 +415,14 @@ async function listSttVariants({ owner, repo, ref }, fetchImpl, { signal } = {})
       },
     });
   }
+  // All three roles are present by here, so the only way to reach this is a
+  // precision that never lines up (e.g. an fp16 encoder whose joiner ships
+  // int8-only, with no fp32 of either to fall back to).
   if (variants.length === 0) {
-    const missing = ["encoder", "decoder", "joiner"].filter(
-      (part) => !onnx.some((f) => componentOf(f.name) === part)
-    );
-    // With all three roles present this can only be a precision that never
-    // lines up (e.g. an fp16 encoder whose joiner ships int8-only).
-    const why = missing.length
-      ? `no ${missing.join(" or ")} alongside ${samplePaths(onnx)}`
-      : `encoder, decoder and joiner never share a precision (${samplePaths(onnx)})`;
     throw new Error(
-      `Could not find a complete transducer in this repository — ${why}. Earheart can only ` +
-        "run sherpa-onnx transducer bundles"
+      "Could not find a complete transducer in this repository — encoder, decoder and joiner " +
+        `never share a precision (${samplePaths(onnx)}). Earheart can only run sherpa-onnx ` +
+        "transducer bundles"
     );
   }
   // Best-first by precision rank, then smallest download, so variants[0] is the

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -170,8 +170,10 @@
               </div>
               <p class="hint">
                 Paste a Hugging Face URL or owner/model of a sherpa-onnx transducer
-                bundle (encoder, decoder, joiner + tokens.txt). Custom models aren't
-                checksum-verified.
+                bundle (encoder, decoder, joiner + tokens.txt) or Whisper export
+                (encoder, decoder + tokens.txt), such as
+                <code>csukuangfj/sherpa-onnx-whisper-turbo</code>. Custom models
+                aren't checksum-verified.
               </p>
             </div>
           </div>

--- a/test/hf-models.test.js
+++ b/test/hf-models.test.js
@@ -348,17 +348,96 @@ test("listSttVariants rejects repos that are not transducer bundles", async () =
     ] }],
     ["/api/models/", { body: { sha: "c" } }],
   ]);
-  await assert.rejects(
-    listSttVariants({ owner: "u", repo: "r" }, incomplete),
-    /no decoder or joiner/
-  );
+  await assert.rejects(listSttVariants({ owner: "u", repo: "r" }, incomplete), /no decoder/);
 });
 
-test("listSttVariants names the encoder-decoder shape instead of blaming tokens.txt", async () => {
-  // distil-whisper/distil-large-v3: a real speech-to-text model, but seq2seq —
-  // encoder + decoder, no joiner, and its vocabulary lives in tokenizer.json.
-  // The missing joiner is the reason it can't run, so lead with that rather
-  // than the missing tokens.txt the user would hit first.
+/* ---------------- STT: sherpa-onnx Whisper exports ---------------- */
+
+test("listSttVariants finds a Whisper export and omits the joiner", async () => {
+  // csukuangfj/sherpa-onnx-whisper-tiny.en: encoder + decoder, no joiner, and
+  // every file prefixed with the model name — including the symbol table.
+  const fetchImpl = stubFetch([
+    ["/tree/", { body: [
+      { type: "file", path: "tiny.en-encoder.int8.onnx", size: 12_937_772 },
+      { type: "file", path: "tiny.en-encoder.onnx", size: 37_647_080 },
+      { type: "file", path: "tiny.en-decoder.int8.onnx", size: 89_853_865 },
+      { type: "file", path: "tiny.en-decoder.onnx", size: 114_504_265 },
+      { type: "file", path: "tiny.en-tokens.txt", size: 835_554 },
+      { type: "file", path: "test_wavs/0.wav", size: 212_044 },
+    ] }],
+    ["/api/models/", { body: { sha: "whispercommit" } }],
+  ]);
+
+  const out = await listSttVariants(
+    { owner: "csukuangfj", repo: "sherpa-onnx-whisper-tiny.en" },
+    fetchImpl
+  );
+  assert.deepStrictEqual(out.variants.map((v) => v.label), ["int8", "fp32"]);
+  assert.strictEqual(out.recommended, "int8");
+  const int8 = out.variants[0];
+  assert.deepStrictEqual(int8.files.map((f) => f.name), [
+    "tiny.en-encoder.int8.onnx", "tiny.en-decoder.int8.onnx", "tiny.en-tokens.txt",
+  ]);
+  // No joiner key at all: its absence is what selects the whisper model config.
+  assert.deepStrictEqual(int8.sherpa, {
+    encoder: "tiny.en-encoder.int8.onnx",
+    decoder: "tiny.en-decoder.int8.onnx",
+    tokens: "tiny.en-tokens.txt",
+    modelType: "whisper",
+  });
+  assert.strictEqual("joiner" in int8.sherpa, false);
+});
+
+test("listSttVariants pairs a prefixed tokens file with its own bundle", async () => {
+  // A repo carrying two exports side by side: each variant must take the
+  // symbol table sharing its prefix, not whichever sorted first.
+  const fetchImpl = stubFetch([
+    ["/tree/", { body: [
+      { type: "file", path: "base.en-encoder.onnx", size: 95 },
+      { type: "file", path: "base.en-decoder.onnx", size: 196 },
+      { type: "file", path: "base.en-tokens.txt", size: 8 },
+      { type: "file", path: "small.en-encoder.int8.onnx", size: 112 },
+      { type: "file", path: "small.en-decoder.int8.onnx", size: 262 },
+      { type: "file", path: "small.en-tokens.txt", size: 9 },
+    ] }],
+    ["/api/models/", { body: { sha: "c" } }],
+  ]);
+
+  const out = await listSttVariants({ owner: "u", repo: "sherpa-onnx-whisper-pair" }, fetchImpl);
+  const byLabel = Object.fromEntries(out.variants.map((v) => [v.label, v.sherpa]));
+  assert.strictEqual(byLabel.int8.tokens, "small.en-tokens.txt");
+  assert.strictEqual(byLabel.fp32.tokens, "base.en-tokens.txt");
+});
+
+test("listSttVariants keeps Whisper external-data weights with the fp32 variant", async () => {
+  // csukuangfj/sherpa-onnx-whisper-turbo: a 735 KB fp32 encoder whose weights
+  // live in a 2.6 GB sidecar, next to a self-contained int8 encoder.
+  const fetchImpl = stubFetch([
+    ["/tree/", { body: [
+      { type: "file", path: "turbo-encoder.onnx", size: 735_920 },
+      { type: "file", path: "turbo-encoder.weights", size: 2_600_325_120 },
+      { type: "file", path: "turbo-encoder.int8.onnx", size: 674_716_297 },
+      { type: "file", path: "turbo-decoder.onnx", size: 636_209_532 },
+      { type: "file", path: "turbo-decoder.int8.onnx", size: 361_080_764 },
+      { type: "file", path: "turbo-tokens.txt", size: 816_730 },
+    ] }],
+    ["/api/models/", { body: { sha: "c" } }],
+  ]);
+
+  const out = await listSttVariants({ owner: "csukuangfj", repo: "sherpa-onnx-whisper-turbo" }, fetchImpl);
+  const [int8, fp32] = out.variants;
+  assert.deepStrictEqual(int8.files.map((f) => f.name), [
+    "turbo-encoder.int8.onnx", "turbo-decoder.int8.onnx", "turbo-tokens.txt",
+  ]);
+  assert.deepStrictEqual(fp32.files.map((f) => f.name), [
+    "turbo-encoder.onnx", "turbo-decoder.onnx", "turbo-encoder.weights", "turbo-tokens.txt",
+  ]);
+});
+
+test("listSttVariants points optimum ONNX exports at a sherpa conversion", async () => {
+  // distil-whisper/distil-large-v3 is a real STT model in the right family, but
+  // the Hugging Face export keeps its vocabulary in tokenizer.json, so the
+  // missing symbol table — not the missing joiner — is what blocks it.
   const fetchImpl = stubFetch([
     ["/tree/", { body: [
       { type: "file", path: "onnx/encoder_model.onnx", size: 646_473 },
@@ -373,12 +452,9 @@ test("listSttVariants names the encoder-decoder shape instead of blaming tokens.
   await assert.rejects(
     listSttVariants({ owner: "distil-whisper", repo: "distil-large-v3" }, fetchImpl),
     (err) => {
-      assert.match(err.message, /no joiner/);
-      assert.match(err.message, /encoder-decoder model/);
-      assert.doesNotMatch(err.message, /tokens\.txt — /); // not diagnosed as a missing symbol table
-      // The .onnx_data external-data file isn't itself an .onnx, so it doesn't
-      // inflate the count.
-      assert.match(err.message, /Found 3 \.onnx files/);
+      assert.match(err.message, /encoder and decoder \.onnx files, but no tokens\.txt/);
+      assert.match(err.message, /tokenizer\.json/);
+      assert.match(err.message, /sherpa-onnx-…/); // names the way out
       return true;
     }
   );

--- a/test/hf-models.test.js
+++ b/test/hf-models.test.js
@@ -350,7 +350,37 @@ test("listSttVariants rejects repos that are not transducer bundles", async () =
   ]);
   await assert.rejects(
     listSttVariants({ owner: "u", repo: "r" }, incomplete),
-    /complete transducer/
+    /no decoder or joiner/
+  );
+});
+
+test("listSttVariants names the encoder-decoder shape instead of blaming tokens.txt", async () => {
+  // distil-whisper/distil-large-v3: a real speech-to-text model, but seq2seq —
+  // encoder + decoder, no joiner, and its vocabulary lives in tokenizer.json.
+  // The missing joiner is the reason it can't run, so lead with that rather
+  // than the missing tokens.txt the user would hit first.
+  const fetchImpl = stubFetch([
+    ["/tree/", { body: [
+      { type: "file", path: "onnx/encoder_model.onnx", size: 646_473 },
+      { type: "file", path: "onnx/encoder_model.onnx_data", size: 2_547_875_840 },
+      { type: "file", path: "onnx/decoder_model.onnx", size: 477_847_873 },
+      { type: "file", path: "onnx/decoder_model_merged.onnx", size: 477_928_888 },
+      { type: "file", path: "tokenizer.json", size: 2_480_617 },
+    ] }],
+    ["/api/models/", { body: { sha: "c" } }],
+  ]);
+
+  await assert.rejects(
+    listSttVariants({ owner: "distil-whisper", repo: "distil-large-v3" }, fetchImpl),
+    (err) => {
+      assert.match(err.message, /no joiner/);
+      assert.match(err.message, /encoder-decoder model/);
+      assert.doesNotMatch(err.message, /tokens\.txt — /); // not diagnosed as a missing symbol table
+      // The .onnx_data external-data file isn't itself an .onnx, so it doesn't
+      // inflate the count.
+      assert.match(err.message, /Found 3 \.onnx files/);
+      return true;
+    }
   );
 });
 


### PR DESCRIPTION
Whisper repos are the obvious thing to paste into **Speech-to-text → Add a model from Hugging Face**, and none of them worked. Whisper is encoder-decoder; `loadStt` only ever built a `transducer` config, so every Whisper repo was turned away — including sherpa-onnx's own conversions, which are otherwise ready to run.

## Which repos work now

Any `csukuangfj/sherpa-onnx-whisper-*` export. Verified live against the API:

| Repo | Recommended | int8 | fp32 |
| --- | --- | --- | --- |
| `csukuangfj/sherpa-onnx-whisper-tiny.en` | int8 | 104 MB | 153 MB |
| `csukuangfj/sherpa-onnx-whisper-turbo` | int8 | 1.0 GB | 3.2 GB |
| `csukuangfj/sherpa-onnx-whisper-large-v3` | int8 | 1.8 GB | 6.2 GB |

…alongside `base.en`, `small.en`, `medium.en`, `distil-medium.en` and the rest of that family.

## How it hangs together

`sherpa-onnx-node` already exposes an `OfflineWhisperModelConfig`, so the engine only has to pick the right sub-config. **A missing joiner is what distinguishes the two families**, and that carries end to end: discovery omits the `joiner` key for Whisper bundles, and `loadStt` reads its absence and passes `{ whisper: { encoder, decoder } }` instead of `{ transducer: … }`. No new flag, no second code path through the download manager or registry.

Discovery had to learn one more thing: sherpa's Whisper exports prefix **every** file with the model name, symbol table included (`tiny.en-encoder.onnx`, `tiny.en-tokens.txt`), so tokens can't be found by looking for a file literally named `tokens.txt`. Each encoder now takes the tokens file sharing its prefix, falling back to an unprefixed one.

## Better dead ends

`distil-whisper/distil-large-v3` is the right family but keeps its vocabulary in `tokenizer.json`, so it still can't load. It now says why and where to go instead:

> Found the encoder and decoder .onnx files, but no tokens.txt — sherpa-onnx needs the bundle's symbol table. Hugging Face / optimum ONNX exports keep the vocabulary in tokenizer.json instead; look for a sherpa-onnx conversion of the same model (csukuangfj/sherpa-onnx-…)

## Verification

Verified for real rather than by shape. Downloaded `sherpa-onnx-whisper-tiny.en` int8 **through the discovery output**, then decoded `test_wavs/0.wav` through `loadStt`'s exact config:

```
whisper     "After early nightfall, the yellow lamps would light up here and
             there the squalid quarter of the brothels."      405ms load, 264ms decode
transducer  "After early nightfall the yellow lamps would light up here and
             there the squalid quarter of the brothers."      Parakeet int8, regression check
```

Both families load and transcribe through the one refactored path. (The brothels/brothers split is a model difference, not a bug.)

`npm test` — 169 pass, 0 fail (1 pre-existing skip), 4 new cases: Whisper discovery omitting the joiner, prefixed-tokens pairing across two bundles in one repo, Whisper external-data weights staying with fp32 only, and the optimum-export dead end. `make smoke` / engine smoke pass under xvfb.

## Note

This also carries commit `fe8e688` from #58 — the encoder-decoder diagnosis fixup, which was pushed after you merged that PR, so it never landed. Its message is adapted here, since "no joiner means not a transducer" is no longer a rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGBVpW9JAF2yXZJ9vpaQEW
