### PR TITLE
feat: clearer settings hints, paged history, reliable error-log button

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,6 +1,8 @@
 // IPC handlers backing the settings window and the setup wizard.
 
 const { ipcMain, app, shell } = require("electron");
+const fs = require("node:fs");
+const path = require("node:path");
 const settings = require("./settings");
 const logger = require("./util/logger");
 const deliver = require("./output/deliver");
@@ -109,13 +111,30 @@ function init({ applyHotkeys, onSettingsChanged }) {
   });
 
   // Settings → About: open the error log in the OS default handler so the user
-  // can read or attach it when something goes wrong. Returns the path (or an
-  // error) so the UI can show where it lives even if opening fails.
+  // can read or attach it when something goes wrong. openPath needs a default
+  // app for .log files, which Windows often lacks — it then resolves with an
+  // error string and nothing opens. Fall back to selecting the file in the OS
+  // file manager, which needs no file association; `action` tells the UI which
+  // outcome to describe. Returns the path either way so the UI can show where
+  // the file lives even if everything fails.
   ipcMain.handle("logs:open", async () => {
     const logPath = logger.getLogPath();
     if (!logPath) return { ok: false, error: "No log file yet." };
-    const error = await shell.openPath(logPath); // "" on success
-    return error ? { ok: false, error, path: logPath } : { ok: true, path: logPath };
+    if (!fs.existsSync(logPath)) {
+      // Nothing logged yet: the file doesn't exist, so open its folder.
+      const error = await shell.openPath(path.dirname(logPath)); // "" on success
+      return error
+        ? { ok: false, error, path: logPath }
+        : { ok: true, path: logPath, action: "folder" };
+    }
+    const error = await shell.openPath(logPath);
+    if (!error) return { ok: true, path: logPath, action: "opened" };
+    try {
+      shell.showItemInFolder(logPath);
+      return { ok: true, path: logPath, action: "revealed" };
+    } catch {
+      return { ok: false, error, path: logPath };
+    }
   });
 
   // Settings → Advanced: re-run the setup wizard on demand. The wizard

--- a/renderer/settings.css
+++ b/renderer/settings.css
@@ -366,9 +366,11 @@ select {
   gap: 12px;
 }
 
-/* The custom fields are .field inside a .grid-2 whose own gap should be the
-   only spacing; grid margins aren't absorbed by gap. */
-#cleanup-custom-fields > .field {
+/* The custom sampling and Performance fields are .field inside a .grid-2
+   whose own gap should be the only spacing; grid margins aren't absorbed by
+   gap. */
+#cleanup-custom-fields > .field,
+#tab-advanced .grid-2 > .field {
   margin-bottom: 0;
 }
 
@@ -937,6 +939,19 @@ input[type="range"]:focus-visible {
   letter-spacing: normal;
 }
 
+/* Newer / range / Older, aligned with the list's width. The range readout is
+   a machine numeral like the timestamps above it. */
+#history-pager {
+  max-width: 620px;
+  margin-top: 12px;
+}
+
+#history-range {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
 /* Visually hidden, still read by AT (terminal download announcements — the
    per-row status spans get rebuilt, so they can't be live regions). */
 .sr-only {
@@ -988,7 +1003,7 @@ footer {
    Rule). */
 .dl-bar {
   height: 6px;
-  border-radius: 3px;
+  border-radius: 2px;
   background: rgba(255, 255, 255, 0.12);
   overflow: hidden;
   margin-bottom: 11px;
@@ -997,7 +1012,7 @@ footer {
 .dl-fill {
   height: 100%;
   width: 0;
-  border-radius: 3px;
+  border-radius: 2px;
   background: var(--text);
   /* The world's documented progress motion (overlay #progress-fill). */
   transition: width 0.15s linear;

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -337,27 +337,50 @@
 
               <div id="cleanup-style-custom">
                 <p class="hint">
-                  Lower values keep the model closer to the most likely wording;
-                  higher values let it vary more. <code>top-k</code> and
-                  <code>min-p</code> apply to the built-in engine only — external
-                  services receive temperature and <code>top-p</code>.
+                  Direct control of sampling — how the model picks each next
+                  word. Unlike a preset, no editing instruction is added to the
+                  prompt: the system prompt below runs exactly as written, so if
+                  you want a particular editing style (keep every word, polish
+                  freely), state it there. <code>top-k</code> and
+                  <code>min-p</code> reach the built-in engine only — external
+                  services receive just temperature and <code>top-p</code>.
                 </p>
                 <div class="grid-2" id="cleanup-custom-fields">
                   <div class="field">
                     <label for="cleanup-temperature">Temperature <span class="muted">(0–2)</span></label>
                     <input id="cleanup-temperature" type="number" min="0" max="2" step="0.05" />
+                    <p class="hint">
+                      How adventurous each word choice is. 0 always takes the
+                      most likely word — same input, same output; higher values
+                      vary more. The presets stay between 0 and 0.4.
+                    </p>
                   </div>
                   <div class="field">
                     <label for="cleanup-top-p">top-p <span class="muted">(0–1)</span></label>
                     <input id="cleanup-top-p" type="number" min="0" max="1" step="0.05" />
+                    <p class="hint">
+                      Considers only the most likely words whose chances add up
+                      to this share. 1 = no limit; 0.9 cuts off the unlikely
+                      tail. Lower is stricter.
+                    </p>
                   </div>
                   <div class="field">
                     <label for="cleanup-top-k">top-k <span class="muted">(0 = off)</span></label>
                     <input id="cleanup-top-k" type="number" min="0" max="200" step="1" />
+                    <p class="hint">
+                      Considers only the K most likely words at each step — 40
+                      means choose among the top 40. Lower is stricter.
+                    </p>
                   </div>
                   <div class="field">
                     <label for="cleanup-min-p">min-p <span class="muted">(0 = off)</span></label>
                     <input id="cleanup-min-p" type="number" min="0" max="1" step="0.01" />
+                    <p class="hint">
+                      Drops words less likely than this fraction of the single
+                      best word — 0.05 discards anything under 5% as likely as
+                      the favorite. Unlike the others, <em>higher</em> is
+                      stricter.
+                    </p>
                   </div>
                 </div>
               </div>
@@ -410,6 +433,11 @@
           <button id="history-clear" class="ghost danger">Clear history</button>
         </div>
         <ul id="history-list"></ul>
+        <div class="row space-between" id="history-pager" hidden>
+          <button id="history-newer" class="ghost" type="button">Newer</button>
+          <span id="history-range" class="muted" aria-live="polite"></span>
+          <button id="history-older" class="ghost" type="button">Older</button>
+        </div>
       </section>
 
       <!-- Advanced -->
@@ -421,17 +449,22 @@
             <div class="field">
               <label for="max-seconds">Max dictation length (s)</label>
               <input id="max-seconds" type="number" min="10" max="3600" step="10" />
+              <p class="hint">
+                Safety stop: a take that runs this long ends and transcribes on
+                its own, in case the stop key never comes.
+              </p>
             </div>
             <div class="field">
               <label for="idle-unload">Unload models after idle (min)</label>
               <input id="idle-unload" type="number" min="0" max="240" step="1" />
+              <p class="hint">
+                Built-in models stay in memory for fast repeat dictations, then
+                unload after this many idle minutes to free ~1.5 GB or more.
+                0 keeps them loaded for the whole session. External services
+                aren't affected.
+              </p>
             </div>
           </div>
-          <p class="hint">
-            Built-in models stay in memory for fast repeat dictations, then unload after this
-            many idle minutes to free memory (~1.5 GB or more). Set to 0 to keep them loaded
-            for the whole session. Only affects in-app models, not external services.
-          </p>
         </div>
 
         <div class="card" id="accessibility-field" hidden>

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -817,17 +817,43 @@ bindAddCustomModel("cleanup");
 
 /* ---------- history ---------- */
 
+// History can hold up to 100 entries; rendering them all would stretch the
+// settings page out of proportion. Show one page at a time, newest first,
+// with Newer/Older controls that only appear once there is a second page.
+const HISTORY_PAGE_SIZE = 10;
+let historyItems = [];
+let historyPage = 0; // 0 = the newest page
+
 async function renderHistory() {
-  const items = await earheart.invoke("history:list");
+  historyItems = await earheart.invoke("history:list");
+  renderHistoryPage();
+}
+
+function renderHistoryPage() {
   const list = $("history-list");
+  const pages = Math.max(1, Math.ceil(historyItems.length / HISTORY_PAGE_SIZE));
+  // New entries arriving (or Clear) can shrink the list under the current
+  // page; clamp instead of showing an empty page.
+  historyPage = Math.min(historyPage, pages - 1);
+  const start = historyPage * HISTORY_PAGE_SIZE;
+  const end = Math.min(start + HISTORY_PAGE_SIZE, historyItems.length);
+
+  const pager = $("history-pager");
+  pager.hidden = pages <= 1;
+  $("history-newer").disabled = historyPage === 0;
+  $("history-older").disabled = historyPage >= pages - 1;
+  $("history-range").textContent = pager.hidden
+    ? ""
+    : `${start + 1}–${end} of ${historyItems.length}`;
+
   list.replaceChildren();
-  if (items.length === 0) {
+  if (historyItems.length === 0) {
     const li = document.createElement("li");
     li.innerHTML = '<span class="muted">No transcriptions yet.</span>';
     list.appendChild(li);
     return;
   }
-  for (const item of items) {
+  for (const item of historyItems.slice(start, end)) {
     const li = document.createElement("li");
     const text = document.createElement("div");
     text.className = "text";
@@ -849,6 +875,15 @@ async function renderHistory() {
     list.appendChild(li);
   }
 }
+
+$("history-newer").addEventListener("click", () => {
+  historyPage = Math.max(0, historyPage - 1);
+  renderHistoryPage();
+});
+$("history-older").addEventListener("click", () => {
+  historyPage += 1;
+  renderHistoryPage();
+});
 
 $("history-clear").addEventListener("click", async () => {
   // Unlike a removed model, cleared history is gone for good — gate it the
@@ -873,10 +908,18 @@ $("open-logs").addEventListener("click", async () => {
   const el = $("open-logs-result");
   const result = await earheart.invoke("logs:open");
   if (result.ok) {
-    el.textContent = result.path;
+    // Main falls back when the OS has no app for .log files (common on
+    // Windows): "revealed" = file selected in the file manager, "folder" =
+    // opened the logs directory because no log exists yet.
+    el.textContent =
+      result.action === "revealed"
+        ? "Opened its folder — no app is set up for .log files"
+        : result.action === "folder"
+          ? "Nothing logged yet — opened the logs folder"
+          : result.path;
     el.className = "status";
   } else {
-    // Opening can fail (no default handler for .log); still show where it is.
+    // Everything failed; at least show where the file lives.
     el.textContent = result.path ? `Couldn't open it — find it at ${result.path}` : result.error;
     el.className = "status err";
   }


### PR DESCRIPTION
## Summary

- **Cleanup → Custom values**: each sampling field now explains itself — temperature (how adventurous word choice is), top-p (keeps the most likely words summing to this share), top-k (considers only the K most likely words), min-p (drops words below this fraction of the best candidate, explicitly noting that *higher* is stricter, unlike the others). The intro hint also states that custom mode adds no editing directive to the prompt, so the editing style belongs in the system prompt.
- **History**: the list renders 10 entries per page with Newer/Older controls and a "1–10 of N" range readout, so a full 100-entry history no longer stretches the settings page. The pager hides with a single page, buttons disable at the ends, and live updates clamp the current page.
- **Error log**: `shell.openPath` fails silently when no app is associated with `.log` files (common on Windows). The handler now falls back to revealing the file in the OS file manager, or opens the logs folder when nothing has been logged yet; the status text says which outcome happened.
- **Advanced → Performance**: per-field hints, adding the previously missing explanation of max dictation length (a safety stop for a forgotten take).
- Aligned the download bar radius with the documented 2px progress-track scale (was 3px, out of step with DESIGN.md and the overlay).

## Test plan

- `npm test` — 169/170 pass (1 skipped), including the settings-contract tests that pin every renderer id referenced by settings.js to the markup (covers the new pager ids and per-field hints).
- Manual: open Settings → Cleanup → Custom values to read the new hints; dictate >10 entries and page through History; on a Windows machine without a `.log` association, click "Open error log" and confirm Explorer opens with the file selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGBVpW9JAF2yXZJ9vpaQEW