### PR TITLE
fix: settle the three settings residuals from #83

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,6 +1,8 @@
 // IPC handlers backing the settings window and the setup wizard.
 
 const { ipcMain, app, shell } = require("electron");
+const fs = require("node:fs");
+const path = require("node:path");
 const settings = require("./settings");
 const logger = require("./util/logger");
 const deliver = require("./output/deliver");
@@ -115,17 +117,31 @@ function init({ applyHotkeys, onSettingsChanged }) {
   });
 
   // Settings → About: open the error log in the OS default handler so the user
-  // can read or attach it when something goes wrong. Returns the path (or an
-  // error) so the UI can show where it lives even if opening fails.
+  // can read or attach it when something goes wrong. `action` names which of
+  // the three outcomes happened so the UI can describe it; the path comes back
+  // either way, so even total failure still tells the user where to look.
   ipcMain.handle("logs:open", async () => {
     const logPath = logger.getLogPath();
     if (!logPath) return { ok: false, error: "No log file yet." };
-    const error = await shell.openPath(logPath); // "" on success
-    if (!error) return { ok: true, path: logPath };
+    // The logger resolves the path at startup but only creates the file on the
+    // first write, so a clean install that has never faulted has no file to
+    // open or reveal — open the logs folder instead.
+    if (!fs.existsSync(logPath)) {
+      const error = await shell.openPath(path.dirname(logPath)); // "" on success
+      return error
+        ? { ok: false, error, path: logPath }
+        : { ok: true, path: logPath, action: "folder" };
+    }
+    const error = await shell.openPath(logPath);
+    if (!error) return { ok: true, path: logPath, action: "opened" };
     // Opening fails when .log has no default app (common on Windows); reveal
     // the file in the OS file manager instead, which needs no association.
-    shell.showItemInFolder(logPath);
-    return { ok: true, path: logPath, revealed: true };
+    try {
+      shell.showItemInFolder(logPath);
+      return { ok: true, path: logPath, action: "revealed" };
+    } catch {
+      return { ok: false, error, path: logPath };
+    }
   });
 
   // Settings → Advanced: re-run the setup wizard on demand. The wizard

--- a/renderer/settings.css
+++ b/renderer/settings.css
@@ -374,9 +374,11 @@ select {
   gap: 12px;
 }
 
-/* The custom fields are .field inside a .grid-2 whose own gap should be the
-   only spacing; grid margins aren't absorbed by gap. */
-#cleanup-custom-fields > .field {
+/* The custom sampling and Performance fields are .field inside a .grid-2
+   whose own gap should be the only spacing; grid margins aren't absorbed by
+   gap, so the non-last field would push its row taller than its neighbour. */
+#cleanup-custom-fields > .field,
+#tab-advanced .grid-2 > .field {
   margin-bottom: 0;
 }
 
@@ -1028,7 +1030,9 @@ footer {
    Rule). */
 .dl-bar {
   height: 6px;
-  border-radius: 3px;
+  /* The 2px hairline round the radius scale reserves for progress tracks
+     (DESIGN.md § Shapes), same as the overlay's #progress and #update-bar. */
+  border-radius: 2px;
   background: var(--track);
   overflow: hidden;
   margin-bottom: 11px;
@@ -1037,7 +1041,7 @@ footer {
 .dl-fill {
   height: 100%;
   width: 0;
-  border-radius: 3px;
+  border-radius: 2px;
   background: var(--text);
   /* The world's documented progress motion (overlay #progress-fill). */
   transition: width 0.15s linear;

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -938,7 +938,15 @@ $("open-logs").addEventListener("click", async () => {
   try {
     const result = await earheart.invoke("logs:open");
     if (result.ok) {
-      el.textContent = result.revealed ? `Opened its folder — ${result.path}` : result.path;
+      // Main falls back when the OS has no app for .log files (common on
+      // Windows): "revealed" = the file selected in the file manager,
+      // "folder" = the logs directory, because nothing has faulted yet.
+      el.textContent =
+        result.action === "revealed"
+          ? "Opened its folder — no app is set up for .log files"
+          : result.action === "folder"
+            ? "Nothing logged yet — opened the logs folder"
+            : result.path;
       el.className = "status";
     } else {
       // Opening can fail (no default handler for .log); still show where it is.

--- a/test/ipc-contract.test.js
+++ b/test/ipc-contract.test.js
@@ -79,6 +79,24 @@ test("every channel the renderers listen on is in the preload LISTEN allowlist",
   assert.deepStrictEqual(missing, [], `preload LISTEN is missing: ${missing.join(", ")}`);
 });
 
+// logs:open answers with an `action` naming which of its three fallbacks ran,
+// and the renderer switches on that string to phrase the status line. The two
+// sides are joined by nothing but the literal, so renaming one silently drops
+// the other back to its default branch. `action:` appears nowhere else in
+// main, so a file-wide scan is the whole set.
+test("every logs:open action the renderer branches on is one main can return", () => {
+  const emitted = channels(main, /action:\s*"([a-z]+)"/g);
+  assert.deepStrictEqual(
+    [...emitted].sort(),
+    ["folder", "opened", "revealed"],
+    "logs:open should return exactly the three documented outcomes",
+  );
+  // "opened" needs no branch — it falls through to printing the bare path.
+  const compared = channels(renderer, /result\.action\s*===\s*"([a-z]+)"/g);
+  const unknown = [...compared].filter((a) => !emitted.has(a)).sort();
+  assert.deepStrictEqual(unknown, [], `renderer tests actions main never sends: ${unknown.join(", ")}`);
+});
+
 test("every channel the renderers send is in SEND and has an ipcMain.on", () => {
   const sent = channels(renderer, /earheart\.send\(\s*"([a-z:-]+)"/g);
   assert.ok(sent.size > 5, `expected many sent channels, got ${sent.size}`);


### PR DESCRIPTION
## Summary

#83 opened against `700ea51`, and while it sat, main solved the same three problems independently in `5472045`, `10945b5`, and `6ae4c55` (shipped in v0.24.0) — generally with more than the PR had: a "Start from preset" seed button, `aria-valuetext` on the style slider, a blank-field-falls-back-to-saved fix in `collectCleanupStyle`, a 3-line history clamp with Show more, and a renderer-side try/catch around the log invoke. Rebasing #83 would have reverted the `--track` token, the 16px/650 `.legend`, and `button.ghost:disabled` along the way.

This picks out the three things in it that main genuinely still lacks. #83 is superseded and can be closed.

- **`logs:open` on a clean install.** `logger.js` resolves the log path at startup but only creates the file on the first write, so an install that has never faulted has a path with no file behind it. `openPath` failed on it and `showItemInFolder` was then handed a path that doesn't exist. Now that case opens the logs folder, and the reveal is guarded so a throw there reports the original `openPath` error instead of escaping the handler. The reply names its outcome (`action: "opened" | "revealed" | "folder"`) rather than a `revealed` boolean, since there are three, and the status line says which one happened.
- **A contract test for that string.** The `action` literal is the only thing joining the handler to the renderer's branch — the same class of unlinked-string gap that shipped this button dead once already (see the file's header comment). The test pins the set main emits and checks the renderer never branches on one it doesn't.
- **`.dl-bar` / `.dl-fill` radius.** 3px is off the scale; DESIGN.md § Shapes reserves the 2px hairline round for progress tracks, and the overlay's `#progress` / `#update-bar` are already 2px.
- **Advanced → Performance grid.** Its `.field`s still carry `.field`'s 16px bottom margin, so the first one pushes its row taller than its neighbour. Scoped the existing reset to cover them, as `#cleanup-custom-fields` already does.

## Test plan

- `npm test` — 181 tests, 180 pass, 1 skipped (baseline was 180/179/1; the new contract test is the addition).
- Verified the new test actually bites: renaming `result.action === "revealed"` in the renderer to a value main never sends fails it.
- Not exercised on a real Windows box — the no-association `showItemInFolder` fallback is unchanged from what's already on main, and the new branch above it is the `!fs.existsSync` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)