### PR TITLE
feat: review before send — edit a long prompt before it reaches the agent

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,54 +1,292 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-31T00:00:00Z",
+  "generatedAt": "2026-08-06T00:00:00Z",
   "title": "Design System: Earheart",
   "extensions": {
     "colorMeta": {
-      "bar-ink": { "role": "neutral", "displayName": "Bar Ink", "canonical": "#18181b", "tonalRamp": ["oklch(15% 0.006 286)", "oklch(25% 0.006 286)", "oklch(37% 0.006 286)", "oklch(49% 0.006 286)", "oklch(61% 0.006 286)", "oklch(73% 0.006 286)", "oklch(85% 0.006 286)", "oklch(95% 0.006 286)"] },
-      "coral-voice": { "role": "primary", "displayName": "Coral Voice", "canonical": "#fb4d5c", "tonalRamp": ["oklch(15% 0.19 18)", "oklch(27% 0.19 18)", "oklch(39% 0.19 18)", "oklch(51% 0.19 18)", "oklch(63% 0.19 18)", "oklch(75% 0.15 18)", "oklch(86% 0.09 18)", "oklch(95% 0.04 18)"] },
-      "text-primary": { "role": "neutral", "displayName": "Primary Text", "canonical": "#f4f4f5", "tonalRamp": ["oklch(15% 0.002 286)", "oklch(27% 0.002 286)", "oklch(39% 0.002 286)", "oklch(51% 0.002 286)", "oklch(63% 0.002 286)", "oklch(75% 0.002 286)", "oklch(87% 0.002 286)", "oklch(96% 0.002 286)"] },
-      "text-status": { "role": "neutral", "displayName": "Status Text", "canonical": "#d4d4d8", "tonalRamp": ["oklch(15% 0.005 286)", "oklch(27% 0.005 286)", "oklch(39% 0.005 286)", "oklch(51% 0.005 286)", "oklch(63% 0.005 286)", "oklch(75% 0.005 286)", "oklch(87% 0.005 286)", "oklch(95% 0.005 286)"] },
-      "text-dim": { "role": "neutral", "displayName": "Dim Text", "canonical": "#a1a1aa", "tonalRamp": ["oklch(15% 0.01 286)", "oklch(27% 0.01 286)", "oklch(39% 0.01 286)", "oklch(51% 0.01 286)", "oklch(63% 0.01 286)", "oklch(75% 0.01 286)", "oklch(87% 0.01 286)", "oklch(95% 0.01 286)"] },
-      "text-faint": { "role": "neutral", "displayName": "Faint Text", "canonical": "rgba(255, 255, 255, 0.28)" },
-      "hairline-edge": { "role": "neutral", "displayName": "Hairline Edge", "canonical": "rgba(255, 255, 255, 0.1)" },
-      "seam": { "role": "neutral", "displayName": "Seam", "canonical": "rgba(255, 255, 255, 0.08)" },
-      "hover-wash": { "role": "neutral", "displayName": "Hover Wash", "canonical": "rgba(255, 255, 255, 0.08)" },
-      "wash-faint": { "role": "neutral", "displayName": "Faint Wash", "canonical": "rgba(255, 255, 255, 0.04)" },
-      "track": { "role": "neutral", "displayName": "Track", "canonical": "rgba(255, 255, 255, 0.12)" },
-      "field": { "role": "neutral", "displayName": "Field", "canonical": "#101013", "tonalRamp": ["oklch(13% 0.008 286)", "oklch(24% 0.008 286)", "oklch(36% 0.008 286)", "oklch(48% 0.008 286)", "oklch(60% 0.008 286)", "oklch(72% 0.008 286)", "oklch(84% 0.008 286)", "oklch(95% 0.008 286)"] },
-      "field-edge": { "role": "neutral", "displayName": "Field Edge", "canonical": "#6b6b74", "tonalRamp": ["oklch(15% 0.012 286)", "oklch(27% 0.012 286)", "oklch(39% 0.012 286)", "oklch(51% 0.012 286)", "oklch(63% 0.012 286)", "oklch(75% 0.012 286)", "oklch(87% 0.012 286)", "oklch(95% 0.012 286)"] },
-      "tray": { "role": "neutral", "displayName": "Tray", "canonical": "rgba(0, 0, 0, 0.25)" },
-      "delivered-green": { "role": "tertiary", "displayName": "Delivered Green", "canonical": "#34d399", "tonalRamp": ["oklch(15% 0.11 163)", "oklch(27% 0.11 163)", "oklch(39% 0.11 163)", "oklch(51% 0.11 163)", "oklch(63% 0.11 163)", "oklch(75% 0.11 163)", "oklch(87% 0.09 163)", "oklch(95% 0.05 163)"] },
-      "failed-red": { "role": "tertiary", "displayName": "Failed Red", "canonical": "#f87171", "tonalRamp": ["oklch(15% 0.12 22)", "oklch(27% 0.12 22)", "oklch(39% 0.12 22)", "oklch(51% 0.12 22)", "oklch(63% 0.12 22)", "oklch(75% 0.12 22)", "oklch(87% 0.08 22)", "oklch(95% 0.04 22)"] },
-      "idle-gray": { "role": "neutral", "displayName": "Idle Gray", "canonical": "#71717a", "tonalRamp": ["oklch(15% 0.01 286)", "oklch(27% 0.01 286)", "oklch(39% 0.01 286)", "oklch(51% 0.01 286)", "oklch(63% 0.01 286)", "oklch(75% 0.01 286)", "oklch(87% 0.01 286)", "oklch(95% 0.01 286)"] }
+      "bar-ink": {
+        "role": "neutral",
+        "displayName": "Bar Ink",
+        "canonical": "#18181b",
+        "tonalRamp": [
+          "oklch(15% 0.006 286)",
+          "oklch(25% 0.006 286)",
+          "oklch(37% 0.006 286)",
+          "oklch(49% 0.006 286)",
+          "oklch(61% 0.006 286)",
+          "oklch(73% 0.006 286)",
+          "oklch(85% 0.006 286)",
+          "oklch(95% 0.006 286)"
+        ]
+      },
+      "coral-voice": {
+        "role": "primary",
+        "displayName": "Coral Voice",
+        "canonical": "#fb4d5c",
+        "tonalRamp": [
+          "oklch(15% 0.19 18)",
+          "oklch(27% 0.19 18)",
+          "oklch(39% 0.19 18)",
+          "oklch(51% 0.19 18)",
+          "oklch(63% 0.19 18)",
+          "oklch(75% 0.15 18)",
+          "oklch(86% 0.09 18)",
+          "oklch(95% 0.04 18)"
+        ]
+      },
+      "text-primary": {
+        "role": "neutral",
+        "displayName": "Primary Text",
+        "canonical": "#f4f4f5",
+        "tonalRamp": [
+          "oklch(15% 0.002 286)",
+          "oklch(27% 0.002 286)",
+          "oklch(39% 0.002 286)",
+          "oklch(51% 0.002 286)",
+          "oklch(63% 0.002 286)",
+          "oklch(75% 0.002 286)",
+          "oklch(87% 0.002 286)",
+          "oklch(96% 0.002 286)"
+        ]
+      },
+      "text-status": {
+        "role": "neutral",
+        "displayName": "Status Text",
+        "canonical": "#d4d4d8",
+        "tonalRamp": [
+          "oklch(15% 0.005 286)",
+          "oklch(27% 0.005 286)",
+          "oklch(39% 0.005 286)",
+          "oklch(51% 0.005 286)",
+          "oklch(63% 0.005 286)",
+          "oklch(75% 0.005 286)",
+          "oklch(87% 0.005 286)",
+          "oklch(95% 0.005 286)"
+        ]
+      },
+      "text-dim": {
+        "role": "neutral",
+        "displayName": "Dim Text",
+        "canonical": "#a1a1aa",
+        "tonalRamp": [
+          "oklch(15% 0.01 286)",
+          "oklch(27% 0.01 286)",
+          "oklch(39% 0.01 286)",
+          "oklch(51% 0.01 286)",
+          "oklch(63% 0.01 286)",
+          "oklch(75% 0.01 286)",
+          "oklch(87% 0.01 286)",
+          "oklch(95% 0.01 286)"
+        ]
+      },
+      "text-faint": {
+        "role": "neutral",
+        "displayName": "Faint Text",
+        "canonical": "rgba(255, 255, 255, 0.28)"
+      },
+      "hairline-edge": {
+        "role": "neutral",
+        "displayName": "Hairline Edge",
+        "canonical": "rgba(255, 255, 255, 0.1)"
+      },
+      "seam": {
+        "role": "neutral",
+        "displayName": "Seam",
+        "canonical": "rgba(255, 255, 255, 0.08)"
+      },
+      "hover-wash": {
+        "role": "neutral",
+        "displayName": "Hover Wash",
+        "canonical": "rgba(255, 255, 255, 0.08)"
+      },
+      "wash-faint": {
+        "role": "neutral",
+        "displayName": "Faint Wash",
+        "canonical": "rgba(255, 255, 255, 0.04)"
+      },
+      "track": {
+        "role": "neutral",
+        "displayName": "Track",
+        "canonical": "rgba(255, 255, 255, 0.12)"
+      },
+      "field": {
+        "role": "neutral",
+        "displayName": "Field",
+        "canonical": "#101013",
+        "tonalRamp": [
+          "oklch(13% 0.008 286)",
+          "oklch(24% 0.008 286)",
+          "oklch(36% 0.008 286)",
+          "oklch(48% 0.008 286)",
+          "oklch(60% 0.008 286)",
+          "oklch(72% 0.008 286)",
+          "oklch(84% 0.008 286)",
+          "oklch(95% 0.008 286)"
+        ]
+      },
+      "field-edge": {
+        "role": "neutral",
+        "displayName": "Field Edge",
+        "canonical": "#6b6b74",
+        "tonalRamp": [
+          "oklch(15% 0.012 286)",
+          "oklch(27% 0.012 286)",
+          "oklch(39% 0.012 286)",
+          "oklch(51% 0.012 286)",
+          "oklch(63% 0.012 286)",
+          "oklch(75% 0.012 286)",
+          "oklch(87% 0.012 286)",
+          "oklch(95% 0.012 286)"
+        ]
+      },
+      "tray": {
+        "role": "neutral",
+        "displayName": "Tray",
+        "canonical": "rgba(0, 0, 0, 0.25)"
+      },
+      "delivered-green": {
+        "role": "tertiary",
+        "displayName": "Delivered Green",
+        "canonical": "#34d399",
+        "tonalRamp": [
+          "oklch(15% 0.11 163)",
+          "oklch(27% 0.11 163)",
+          "oklch(39% 0.11 163)",
+          "oklch(51% 0.11 163)",
+          "oklch(63% 0.11 163)",
+          "oklch(75% 0.11 163)",
+          "oklch(87% 0.09 163)",
+          "oklch(95% 0.05 163)"
+        ]
+      },
+      "failed-red": {
+        "role": "tertiary",
+        "displayName": "Failed Red",
+        "canonical": "#f87171",
+        "tonalRamp": [
+          "oklch(15% 0.12 22)",
+          "oklch(27% 0.12 22)",
+          "oklch(39% 0.12 22)",
+          "oklch(51% 0.12 22)",
+          "oklch(63% 0.12 22)",
+          "oklch(75% 0.12 22)",
+          "oklch(87% 0.08 22)",
+          "oklch(95% 0.04 22)"
+        ]
+      },
+      "idle-gray": {
+        "role": "neutral",
+        "displayName": "Idle Gray",
+        "canonical": "#71717a",
+        "tonalRamp": [
+          "oklch(15% 0.01 286)",
+          "oklch(27% 0.01 286)",
+          "oklch(39% 0.01 286)",
+          "oklch(51% 0.01 286)",
+          "oklch(63% 0.01 286)",
+          "oklch(75% 0.01 286)",
+          "oklch(87% 0.01 286)",
+          "oklch(95% 0.01 286)"
+        ]
+      }
     },
     "typographyMeta": {
-      "body": { "displayName": "Transcript Body", "purpose": "The live transcript — the largest type in the system; the words are the interface." },
-      "window-title": { "displayName": "Window Title", "purpose": "Settings header h1, wizard step h2, and settings section legends — the framed windows' largest chrome text." },
-      "settings-body": { "displayName": "Settings Body", "purpose": "The settings/wizard base text: leads, option copy, running prose at a ~62ch measure." },
-      "title": { "displayName": "Section Title", "purpose": "The update prompt's headline and settings card titles — sentence case." },
-      "label": { "displayName": "Status Label", "purpose": "The overlay's one-word status; settings field labels at 13px/550; pill labels at 12-13px." },
-      "hint": { "displayName": "Hint", "purpose": "Settings hints, descriptions, and muted text in Dim Text." },
-      "caption": { "displayName": "Detail Caption", "purpose": "Single-line overlay detail (paste preview, error, hint) and the update note; ellipsized." },
-      "mono-value": { "displayName": "Machine Value Mono", "purpose": "Accelerators, prompt/dictionary textareas, the tabular version numeral — machine notation only, never prose." },
-      "timer": { "displayName": "Timer Mono", "purpose": "Captured-audio time in tabular figures so digits never jitter." },
-      "history-meta": { "displayName": "History Meta Mono", "purpose": "Timestamp rows under history entries, tabular-nums." }
+      "body": {
+        "displayName": "Transcript Body",
+        "purpose": "The live transcript — the largest type in the system; the words are the interface."
+      },
+      "window-title": {
+        "displayName": "Window Title",
+        "purpose": "Settings header h1, wizard step h2, and settings section legends — the framed windows' largest chrome text."
+      },
+      "settings-body": {
+        "displayName": "Settings Body",
+        "purpose": "The settings/wizard base text: leads, option copy, running prose at a ~62ch measure."
+      },
+      "title": {
+        "displayName": "Section Title",
+        "purpose": "The update prompt's headline and settings card titles — sentence case."
+      },
+      "label": {
+        "displayName": "Status Label",
+        "purpose": "The overlay's one-word status; settings field labels at 13px/550; pill labels at 12-13px."
+      },
+      "hint": {
+        "displayName": "Hint",
+        "purpose": "Settings hints, descriptions, and muted text in Dim Text."
+      },
+      "caption": {
+        "displayName": "Detail Caption",
+        "purpose": "Single-line overlay detail (paste preview, error, hint) and the update note; ellipsized."
+      },
+      "mono-value": {
+        "displayName": "Machine Value Mono",
+        "purpose": "Accelerators, prompt/dictionary textareas, the tabular version numeral — machine notation only, never prose."
+      },
+      "timer": {
+        "displayName": "Timer Mono",
+        "purpose": "Captured-audio time in tabular figures so digits never jitter."
+      },
+      "history-meta": {
+        "displayName": "History Meta Mono",
+        "purpose": "Timestamp rows under history entries, tabular-nums."
+      }
     },
     "shadows": [
-      { "name": "capture-bloom", "value": "0 0 6px rgba(251, 77, 92, 0.45)", "purpose": "The recording dot's coral bloom, so the capture dot reads lit, not printed. Its wizard-demo miniature is 0 0 5px rgba(251, 77, 92, 0.5). Never surface elevation." },
-      { "name": "focus-ring", "value": "0 0 0 3px rgba(255, 255, 255, 0.1)", "purpose": "Input focus ring — a 0-blur spread that is an outline-equivalent, not elevation; paired with the border brightening to white." },
-      { "name": "capture-ring", "value": "0 0 0 3px rgba(251, 77, 92, 0.16)", "purpose": "The hotkey field's mid-capture coral ring (The Capture Exception) — 0-blur, outline-equivalent, sanctioned." }
+      {
+        "name": "capture-bloom",
+        "value": "0 0 6px rgba(251, 77, 92, 0.45)",
+        "purpose": "The recording dot's coral bloom, so the capture dot reads lit, not printed. Its wizard-demo miniature is 0 0 5px rgba(251, 77, 92, 0.5). Never surface elevation."
+      },
+      {
+        "name": "focus-ring",
+        "value": "0 0 0 3px rgba(255, 255, 255, 0.1)",
+        "purpose": "Input focus ring — a 0-blur spread that is an outline-equivalent, not elevation; paired with the border brightening to white."
+      },
+      {
+        "name": "capture-ring",
+        "value": "0 0 0 3px rgba(251, 77, 92, 0.16)",
+        "purpose": "The hotkey field's mid-capture coral ring (The Capture Exception) — 0-blur, outline-equivalent, sanctioned."
+      }
     ],
     "motion": [
-      { "name": "card-enter", "value": "opacity 0.2s ease, transform 0.2s ease", "purpose": "Overlay card fade/rise-in from translateY(8px) scale(0.98)." },
-      { "name": "card-height", "value": "height 0.18s ease", "purpose": "The overlay card eases its own height so the transcript slides into new space instead of popping." },
-      { "name": "state-change", "value": "background 0.12s ease, color 0.12s ease, border-color 0.12s ease", "purpose": "The universal state transition: keys, pills, tabs, inputs, options. Switches use 0.16s; active presses 0.08s (scale 0.92 keys / 0.97 pills)." },
-      { "name": "progress-fill", "value": "width 0.15s linear", "purpose": "All progress and download fills ease width linearly, driven from JS (incumbent shipped mechanism)." },
-      { "name": "pulse", "value": "opacity 1 → 0.45 keyframes; 2s recording / 1.2s working / 1s warming", "purpose": "Status-dot breathing (the wizard mini-dot matches 2s); goes still under prefers-reduced-motion." },
-      { "name": "scroll-glide", "value": "scroll-behavior: smooth", "purpose": "Settings index clicks glide the page; becomes a jump under prefers-reduced-motion. Reduced motion also collapses all settings/wizard transitions to 0.01ms and forces infinite demo animations to one iteration." }
+      {
+        "name": "card-enter",
+        "value": "opacity 0.2s ease, transform 0.2s ease",
+        "purpose": "Overlay card fade/rise-in from translateY(8px) scale(0.98)."
+      },
+      {
+        "name": "card-height",
+        "value": "height 0.18s ease",
+        "purpose": "The overlay card eases its own height so the transcript slides into new space instead of popping."
+      },
+      {
+        "name": "state-change",
+        "value": "background 0.12s ease, color 0.12s ease, border-color 0.12s ease",
+        "purpose": "The universal state transition: keys, pills, tabs, inputs, options. Switches use 0.16s; active presses 0.08s (scale 0.92 keys / 0.97 pills)."
+      },
+      {
+        "name": "progress-fill",
+        "value": "width 0.15s linear",
+        "purpose": "All progress and download fills ease width linearly, driven from JS (incumbent shipped mechanism)."
+      },
+      {
+        "name": "pulse",
+        "value": "opacity 1 → 0.45 keyframes; 2s recording / 1.2s working / 1s warming",
+        "purpose": "Status-dot breathing (the wizard mini-dot matches 2s); goes still under prefers-reduced-motion."
+      },
+      {
+        "name": "scroll-glide",
+        "value": "scroll-behavior: smooth",
+        "purpose": "Settings index clicks glide the page; becomes a jump under prefers-reduced-motion. Reduced motion also collapses all settings/wizard transitions to 0.01ms and forces infinite demo animations to one iteration."
+      }
     ],
     "breakpoints": [
-      { "name": "compact", "value": "600px", "purpose": "Below this the settings index docks horizontally above the page and the wizard demo stacks vertically." }
+      {
+        "name": "compact",
+        "value": "600px",
+        "purpose": "Below this the settings index docks horizontally above the page and the wizard demo stacks vertically."
+      }
     ]
   },
   "components": [
@@ -147,11 +385,19 @@
       "description": "The quiet in-card note the app uses to talk about itself — entirely neutral-white grammar, no coral; the same grammar as the settings banner. Carries the what's-new list: Caption-weight bullets in Text Dim with Text Faint markers, closed by a markerless Text Faint line counting what didn't fit.",
       "html": "<div class=\"ds-update\"><div class=\"ds-update-head\"><span class=\"ds-update-title\">Earheart 0.23.0 is available</span></div><div class=\"ds-update-note\">You're on 0.22.0. It takes a few seconds.</div><ul class=\"ds-update-notes\"><li>Paginate the settings history list</li><li>Revive the dead Open error log button</li><li class=\"more\">and 2 more changes — see Settings</li></ul><div class=\"ds-update-actions\"><button class=\"ds-update-primary\">Update now</button><button class=\"ds-update-quiet\">Skip this version</button></div></div>",
       "css": ".ds-update { display: flex; flex-direction: column; gap: 6px; padding: 10px 12px; border-radius: 12px; border: 1px solid rgba(255, 255, 255, 0.1); background: #1f1f23; max-width: 320px; } .ds-update-title { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 13px; font-weight: 600; color: #f4f4f5; } .ds-update-note { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 11.5px; color: #a1a1aa; } .ds-update-notes { display: flex; flex-direction: column; gap: 3px; margin: 0; padding: 0; list-style: none; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 11.5px; color: #a1a1aa; } .ds-update-notes li { display: flex; gap: 6px; } .ds-update-notes li::before { content: \"•\"; color: #71717a; flex: none; } .ds-update-notes li.more { color: #71717a; } .ds-update-notes li.more::before { content: \"\"; } .ds-update-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 2px; } .ds-update-primary { height: 26px; padding: 0 11px; border: none; border-radius: 13px; background: #f4f4f5; color: #18181b; font-family: inherit; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.12s ease; } .ds-update-primary:hover { background: #ffffff; } .ds-update-quiet { height: 26px; padding: 0 11px; border: none; border-radius: 13px; background: transparent; color: #a1a1aa; font-family: inherit; font-size: 12px; font-weight: 500; cursor: pointer; transition: background 0.12s ease, color 0.12s ease; } .ds-update-quiet:hover { background: rgba(255, 255, 255, 0.08); color: #f4f4f5; }"
+    },
+    {
+      "name": "Review Panel",
+      "kind": "card",
+      "refersTo": "review-panel",
+      "description": "The review-before-send stop: the update panel's quiet neutral grammar with a real editable field on darker ground. Head row (600/13px title, tabular Caption char count in Text Faint, quiet Raw pill), the textarea with the universal 2px focus ring, filled white Send beside quiet Copy/Discard, and the key map taught on the panel itself in Text Faint. The overlay's one sanctioned focus borrow, always repaid.",
+      "html": "<div class=\"ds-review\"><div class=\"ds-review-head\"><span class=\"ds-review-title\">Review before send</span><span class=\"ds-review-count\">412 chars</span><button class=\"ds-review-raw\">Raw</button></div><textarea class=\"ds-review-text\" rows=\"3\">Fix the bug in main/pipeline.js where the session id is not invalidated on cancel.</textarea><div class=\"ds-review-actions\"><button class=\"ds-review-send\">Send</button><button class=\"ds-review-quiet\">Copy</button><button class=\"ds-review-quiet\">Discard</button></div><div class=\"ds-review-keys\">ctrl+↵ send · ctrl+shift+C copy · ctrl+R raw · esc discard</div></div>",
+      "css": ".ds-review { display: flex; flex-direction: column; gap: 6px; padding: 10px 12px; border-radius: 12px; border: 1px solid rgba(255, 255, 255, 0.1); background: #1f1f23; max-width: 340px; font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; } .ds-review-head { display: flex; align-items: center; gap: 8px; } .ds-review-title { flex: 1; font-size: 13px; font-weight: 600; color: #f4f4f5; } .ds-review-count { font-size: 11px; color: #71717a; font-variant-numeric: tabular-nums; } .ds-review-raw { height: 26px; padding: 0 11px; border: none; border-radius: 13px; background: transparent; color: #a1a1aa; font-family: inherit; font-size: 12px; font-weight: 500; cursor: pointer; transition: background 0.12s ease, color 0.12s ease; } .ds-review-raw:hover { background: rgba(255, 255, 255, 0.08); color: #f4f4f5; } .ds-review-text { width: 100%; min-height: 60px; padding: 8px 10px; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 8px; background: rgba(0, 0, 0, 0.28); color: #f4f4f5; font-family: inherit; font-size: 13px; line-height: 1.5; resize: none; } .ds-review-text:focus-visible { outline: 2px solid #f4f4f5; outline-offset: 2px; } .ds-review-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 2px; } .ds-review-send { height: 26px; padding: 0 11px; border: none; border-radius: 13px; background: #f4f4f5; color: #18181b; font-family: inherit; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.12s ease; } .ds-review-send:hover { background: #ffffff; } .ds-review-quiet { height: 26px; padding: 0 11px; border: none; border-radius: 13px; background: transparent; color: #a1a1aa; font-family: inherit; font-size: 12px; font-weight: 500; cursor: pointer; transition: background 0.12s ease, color 0.12s ease; } .ds-review-quiet:hover { background: rgba(255, 255, 255, 0.08); color: #f4f4f5; } .ds-review-keys { font-size: 10.5px; color: #71717a; letter-spacing: 0.02em; }"
     }
   ],
   "narrative": {
     "northStar": "The Quiet Transcription Bar",
-    "overview": "Earheart is a clean minimal dictation bar played straight — the category canon of Wispr Flow and superwhisper, held to craft-bar standard. The live words ARE the interface: a solid near-black strip pinned low on the screen, hairline-edged, with the transcript growing upward above a single control row. Every control is a glyph the whole world already reads (pause, check, X); nothing on the bar needs a manual, a legend, or a label.\n\nOne color speaks: a coral accent lifted from the app icon's waveform-heart, and it means exactly one thing — \"Earheart is working with your voice.\" The capture dot, the live waveform, and the dictation progress fill wear it; beyond the bar it appears only in two sanctioned capture moments (see The Capture Exception). Everything else is white and gray on near-black, with green and red confined to miniature status signals. The world explicitly refuses the hardware metaphor: no tape, no lamps, no legends, no eject. The previous \"Tape Transport\" service-panel system and the earlier violet/rose \"On-Air Lamp\" system are both fully retired; neither may resurface.\n\nScope note: the world now covers every surface. The overlay (renderer/overlay.*), the settings window (renderer/settings.*), and the setup wizard (renderer/wizard.*, which layers on settings.css) all speak this language; the framed windows extend the bar's grammar with white-wash cards, solid inputs, and pill buttons. The main process paints framed windows in Bar Ink before load (INK_COLOR in main/windows.js), which must stay in sync with --ink \u2014 the one name the value carries in both overlay.css and settings.css. The retired Tape Transport and On-Air Lamp systems survive only as historical notes.",
+    "overview": "Earheart is a clean minimal dictation bar played straight — the category canon of Wispr Flow and superwhisper, held to craft-bar standard. The live words ARE the interface: a solid near-black strip pinned low on the screen, hairline-edged, with the transcript growing upward above a single control row. Every control is a glyph the whole world already reads (pause, check, X); nothing on the bar needs a manual, a legend, or a label.\n\nOne color speaks: a coral accent lifted from the app icon's waveform-heart, and it means exactly one thing — \"Earheart is working with your voice.\" The capture dot, the live waveform, and the dictation progress fill wear it; beyond the bar it appears only in two sanctioned capture moments (see The Capture Exception). Everything else is white and gray on near-black, with green and red confined to miniature status signals. The world explicitly refuses the hardware metaphor: no tape, no lamps, no legends, no eject. The previous \"Tape Transport\" service-panel system and the earlier violet/rose \"On-Air Lamp\" system are both fully retired; neither may resurface.\n\nScope note: the world now covers every surface. The overlay (renderer/overlay.*), the settings window (renderer/settings.*), and the setup wizard (renderer/wizard.*, which layers on settings.css) all speak this language; the framed windows extend the bar's grammar with white-wash cards, solid inputs, and pill buttons. The main process paints framed windows in Bar Ink before load (INK_COLOR in main/windows.js), which must stay in sync with --ink — the one name the value carries in both overlay.css and settings.css. The retired Tape Transport and On-Air Lamp systems survive only as historical notes.",
     "keyCharacteristics": [
       "Solid neutral near-black surfaces; nothing translucent under text",
       "One coral accent, reserved exclusively for the voice being heard or captured",
@@ -161,15 +407,56 @@
       "The live transcript is the hero; chrome stays quiet around it"
     ],
     "rules": [
-      { "name": "The One Voice Rule", "body": "Coral is spent only on the dictation itself — the capture dot, the waveform, the dictation progress fill. When the app talks about itself (the update prompt, model downloads), it uses the neutral white grammar: filled white primary pill, white download-bar fill. Never spend coral on non-voice surfaces.", "section": "colors" },
-      { "name": "The Capture Exception", "body": "On the settings window coral appears exactly once: a hotkey field mid-capture (.capturing — coral border rgba(251, 77, 92, 0.55), coral wash rgba(251, 77, 92, 0.07), 0-blur coral ring rgba(251, 77, 92, 0.16)), because the field is literally capturing the user's key press. The wizard's mini-bar demo is the only other sanctioned non-overlay coral: it is a depiction of the real bar, not a new use. No third use exists.", "section": "colors" },
-      { "name": "The Tiny Dot Rule", "body": "Green and red stay miniature: 8px status dots on the overlay, single lines of 13px status text on settings/wizard (.status.ok / .status.err) — never fills, washes, or large surfaces. One deliberate carve-out: the Destructive Hover Exception. Destructive controls (the overlay's discard key, button.danger pills) are gray at rest and take Failed Red text plus a red wash (rgba(248, 113, 113, 0.12), pills add a rgba(248, 113, 113, 0.4) border) on hover only — red names the consequence at the moment of intent, never at rest.", "section": "colors" },
-      { "name": "The Pending Text Rule", "body": "Streaming, not-yet-settled words render in Dim Text and brighten to Primary Text when cleanup settles them — the universal \"pending\" signal, done with color alone, no italics or spinners.", "section": "typography" },
-      { "name": "The Machine Values Rule", "body": "Monospace is for machine notation only: accelerators, timestamps, the version numeral, dictionary and prompt textareas, code and kbd. Prose is never mono — the hotkey fields' prose placeholders (\"Click, then press…\") explicitly render in the body face even though the field itself is mono.", "section": "typography" },
-      { "name": "The No Surface Shadow Rule", "body": "No blurred or offset box-shadow on any surface, card, key, or pill — ever. Two device classes are explicitly not elevation and are sanctioned: (1) the recording dot's coral bloom (box-shadow: 0 0 6px rgba(251, 77, 92, 0.45); its wizard-demo miniature uses 0 0 5px rgba(251, 77, 92, 0.5)) — a light-emission cue on a tiny dot; and (2) 0-blur box-shadow spreads used as rings — the input focus ring (0 0 0 3px rgba(255, 255, 255, 0.1)) and the hotkey capture ring (0 0 0 3px rgba(251, 77, 92, 0.16)). Zero-blur spreads are outline-equivalents that hug the border; they cast nothing. True drop shadows remain banned everywhere.", "section": "elevation" },
-      { "name": "The Solid Ground Rule", "body": "Text never sits on translucency over the desktop. The bar is solid Bar Ink; framed windows are painted Bar Ink before load; in-window washes are safe because the solid ink is beneath them.", "section": "elevation" },
-      { "name": "The Keys Keep Their Slots Rule", "body": "Keys disable and fade but never leave the row; the row never reflows and no key ever jumps under the cursor.", "section": "components" },
-      { "name": "The Filled Dot Contract", "body": "The filled pulsing coral dot + moving waveform + running timer together mean \"audio is captured right now.\" Mic warm-up is a pulsing hollow coral ring; paused is a steady hollow coral ring. Never show the filled dot before samples actually flow. Under prefers-reduced-motion the warming ring dims to 55% opacity instead of pulsing \u2014 dimmer = not capturing yet, full = paused.", "section": "components" }
+      {
+        "name": "The One Voice Rule",
+        "body": "Coral is spent only on the dictation itself — the capture dot, the waveform, the dictation progress fill. When the app talks about itself (the update prompt, model downloads), it uses the neutral white grammar: filled white primary pill, white download-bar fill. Never spend coral on non-voice surfaces.",
+        "section": "colors"
+      },
+      {
+        "name": "The Capture Exception",
+        "body": "On the settings window coral appears exactly once: a hotkey field mid-capture (.capturing — coral border rgba(251, 77, 92, 0.55), coral wash rgba(251, 77, 92, 0.07), 0-blur coral ring rgba(251, 77, 92, 0.16)), because the field is literally capturing the user's key press. The wizard's mini-bar demo is the only other sanctioned non-overlay coral: it is a depiction of the real bar, not a new use. No third use exists.",
+        "section": "colors"
+      },
+      {
+        "name": "The Tiny Dot Rule",
+        "body": "Green and red stay miniature: 8px status dots on the overlay, single lines of 13px status text on settings/wizard (.status.ok / .status.err) — never fills, washes, or large surfaces. One deliberate carve-out: the Destructive Hover Exception. Destructive controls (the overlay's discard key, button.danger pills) are gray at rest and take Failed Red text plus a red wash (rgba(248, 113, 113, 0.12), pills add a rgba(248, 113, 113, 0.4) border) on hover only — red names the consequence at the moment of intent, never at rest.",
+        "section": "colors"
+      },
+      {
+        "name": "The Pending Text Rule",
+        "body": "Streaming, not-yet-settled words render in Dim Text and brighten to Primary Text when cleanup settles them — the universal \"pending\" signal, done with color alone, no italics or spinners.",
+        "section": "typography"
+      },
+      {
+        "name": "The Machine Values Rule",
+        "body": "Monospace is for machine notation only: accelerators, timestamps, the version numeral, dictionary and prompt textareas, code and kbd. Prose is never mono — the hotkey fields' prose placeholders (\"Click, then press…\") explicitly render in the body face even though the field itself is mono.",
+        "section": "typography"
+      },
+      {
+        "name": "The No Surface Shadow Rule",
+        "body": "No blurred or offset box-shadow on any surface, card, key, or pill — ever. Two device classes are explicitly not elevation and are sanctioned: (1) the recording dot's coral bloom (box-shadow: 0 0 6px rgba(251, 77, 92, 0.45); its wizard-demo miniature uses 0 0 5px rgba(251, 77, 92, 0.5)) — a light-emission cue on a tiny dot; and (2) 0-blur box-shadow spreads used as rings — the input focus ring (0 0 0 3px rgba(255, 255, 255, 0.1)) and the hotkey capture ring (0 0 0 3px rgba(251, 77, 92, 0.16)). Zero-blur spreads are outline-equivalents that hug the border; they cast nothing. True drop shadows remain banned everywhere.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Solid Ground Rule",
+        "body": "Text never sits on translucency over the desktop. The bar is solid Bar Ink; framed windows are painted Bar Ink before load; in-window washes are safe because the solid ink is beneath them.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Keys Keep Their Slots Rule",
+        "body": "Keys disable and fade but never leave the row; the row never reflows and no key ever jumps under the cursor.",
+        "section": "components"
+      },
+      {
+        "name": "The Filled Dot Contract",
+        "body": "The filled pulsing coral dot + moving waveform + running timer together mean \"audio is captured right now.\" Mic warm-up is a pulsing hollow coral ring; paused is a steady hollow coral ring. Never show the filled dot before samples actually flow. Under prefers-reduced-motion the warming ring dims to 55% opacity instead of pulsing — dimmer = not capturing yet, full = paused.",
+        "section": "components"
+      },
+      {
+        "name": "The Focus Borrow Rule",
+        "body": "The review panel is the overlay's one sanctioned focus borrow: capture the target window before taking focus, repay it on every exit (send, copy, discard, cancel) so the paste lands in the app the user came from.",
+        "section": "components"
+      }
     ],
     "dos": [
       "Do keep every surface under text solid; every window is opaque Bar Ink (#18181b) — the overlay by its own paint, framed windows via INK_COLOR in main/windows.js, kept in sync with --ink.",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -576,6 +576,33 @@ corners anywhere.
   line is the only news left. Settings mirrors it in full, one quiet 600/12px
   version heading per release.
 
+### Review panel (overlay)
+- The update panel's grammar, reused wholesale: 12px radius, white 0.05-alpha
+  fill, hairline edge, 10px 12px padding, entirely neutral-white — no coral
+  (the accent stays reserved for the dictation itself). Always solo: the
+  control row hides and the panel is the whole card.
+- **The editable field:** the cleaned transcript in a real textarea on a
+  darker ground (black 0.28, hairline edge, 8px radius) so the editable
+  surface reads apart from the panel; 13px/1.5 text; the universal focus
+  treatment (2px Primary Text outline, 2px offset). It grows with its content
+  and caps at 40% of the screen, scrolling inside past that.
+- **The raw view:** same box, dashed hairline and Dim Text — the ground
+  truth as reference, not a second draft. Flipping back always returns to
+  the (possibly edited) cleaned text.
+- **Head row:** 600/13px title, a tabular Caption char count in Text Faint,
+  and the quiet Raw pill (aria-pressed carries its state).
+- **Actions:** filled white Send (the one key action, same grammar as Done
+  and Update now), quiet Copy and Discard pills.
+- **The key line:** the four chords (send / copy / raw / discard) taught on
+  the panel itself in 10.5px Text Faint — keyboard-first means the surface
+  is its own manual.
+- **Focus contract:** the panel is the overlay's one sanctioned focus borrow.
+  Main captures the target window before focusing and repays on every exit —
+  send, copy, discard, cancel — so "paste to the app you came from" survives
+  even a mid-review click elsewhere. The Keys-Keep-Their-Slots rule is
+  satisfied the way the update prompt satisfies it: solo mode removes the
+  control row wholesale; nothing reflows under a cursor.
+
 ### Wizard step dots
 - 7px circles, white 0.35 at rest (clearing the 3:1 UI bar on the ink), solid
   white when active; centered in the footer with an sr-only spoken

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -74,16 +74,21 @@ Supporting truths (real, but not the lead):
 **Not claimed (yet):** Earheart does not submit the prompt for you, does not
 speak the agent's replies, and has no MCP or agent-side integration. These are
 tracked as roadmap issues under the `agents` label — never describe them as
-shipped.
+shipped. Also not claimed: on Wayland, focus returning to the target window
+after review-before-send depends on the compositor; when it doesn't, delivery
+falls back to the clipboard with a note.
 
 ## Operating Context
 
 - Lives in the system tray. UI surfaces: a low always-on-top overlay strip at
   the bottom of the screen (status dot, live waveform, live transcript,
-  progress — never steals focus), a settings window, a first-run wizard, and
-  the tray menu.
+  progress — never steals focus during dictation), a settings window, a
+  first-run wizard, and the tray menu.
 - Used mid-task inside other applications; the overlay must never interrupt or
-  take focus from the app being dictated into.
+  take focus from the app being dictated into. The opt-in review-before-send
+  panel is the sole, deliberate exception: it borrows focus to make the
+  transcript editable and gives it back to the captured target window on
+  every exit.
 - Global hotkey (default `Ctrl/Cmd+Shift+Space`) starts and stops dictation.
   On GNOME/KDE Wayland, users bind a system shortcut to `earheart --toggle`
   (single-instance).
@@ -161,7 +166,9 @@ shipped.
 2. **Never lose the user's words.** Every failure path still delivers the raw
    transcript; history catches mis-aimed pastes.
 3. **Stay out of the way.** Dictation happens inside someone else's app —
-   never steal focus, never interrupt, never demand attention mid-flow.
+   never steal focus, never interrupt, never demand attention mid-flow. The
+   opt-in review step is the one sanctioned focus borrow, and it must always
+   repay it: capture the target before taking focus, restore it on exit.
 4. **Zero setup before power.** Defaults work with nothing installed or
    configured; depth (endpoints, prompts, models, servers) stays available
    underneath, one Settings field away.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ OpenAI-compatible HTTP clients**, so you can choose where your voice goes:
 - **Auto-paste, clipboard, or both** — paste straight into the focused app
   (with clipboard restore), paste *and* keep the transcript on the clipboard,
   or clipboard-only if you prefer to paste yourself.
+- **Review before send (opt-in)** — hold long dictations on the overlay for a
+  keyboard-driven edit pass — fix a mis-heard identifier, peek at the raw
+  transcript — before anything reaches the app. Off by default; turn it on
+  for every dictation or only past a length threshold (Settings → General).
 - **Start on login (optional)** — have Earheart launch into the tray
   automatically when you sign in, so the hotkey is always ready. Off by
   default; toggle it under Settings → General. Works on Windows, macOS and
@@ -261,7 +265,9 @@ OpenAI).
 1. Put your cursor wherever you want text — an email, an editor, a chat box.
 2. Press the hotkey (default `Ctrl/Cmd+Shift+Space`). A slim bar appears at
    the bottom of the screen — a status dot and word, your voice drawn live,
-   and a timer; it never steals focus.
+   and a timer; it never steals focus. (The one exception is the opt-in
+   review-before-send step, which borrows focus so you can edit the
+   transcript, then hands it back to the app you came from when you send.)
 3. Speak, then press the hotkey again (or the bar's ✓ key). Earheart
    transcribes, optionally cleans up, and pastes the result right where you
    were typing. The ✕ key discards the dictation — nothing is typed.
@@ -291,7 +297,7 @@ collide with your editor — live in **[docs/agents.md](docs/agents.md)**.
 | --- | --- |
 | **Claude Code / Codex CLI** (terminal) | Paste lands in the TUI input like any paste. On Linux, auto-paste needs `xdotool`/`wtype` — see [Platform notes](#linux). |
 | **Cursor, VS Code, JetBrains chat** | Nothing special — click the chat box and dictate. |
-| **claude.ai, ChatGPT, agent web UIs** | Same. The overlay never steals focus, so the composer keeps it. |
+| **claude.ai, ChatGPT, agent web UIs** | Same. The overlay never steals focus, so the composer keeps it. With review-before-send on, the overlay borrows focus for the edit pass and returns it on send. |
 | **Anywhere via a shortcut** | Bind a system shortcut, mouse button or foot pedal to `earheart --toggle` instead of using the built-in hotkey. |
 
 Three settings are worth a minute for agent work:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -54,7 +54,8 @@ Settings → Cleanup, three fields, and every recipe below gets better:
 ## Terminal agents — Claude Code, Codex CLI, Aider, Gemini CLI
 
 1. Click the terminal so the TUI input has focus, and leave it there — the
-   overlay never steals focus.
+   overlay never steals focus (unless you've turned on review-before-send,
+   which borrows it for the edit pass and restores it when you send).
 2. Press the hotkey, say the whole prompt, press it again. The transcript
    pastes into the input like any other paste.
 3. Press Enter yourself. Earheart pastes; it does not submit.
@@ -113,10 +114,34 @@ awkwardly; this is where dictating a full paragraph pays off most.
 ## Desktop and web chats — Claude, ChatGPT, agent web UIs
 
 Nothing special, which is worth saying: click the composer, press the hotkey,
-speak, press again. The overlay never steals focus, so the composer keeps the
-caret and the text lands where you were typing.
+speak, press again. The overlay never steals focus (review-before-send, if
+you've enabled it, borrows focus and gives it back on send), so the composer
+keeps the caret and the text lands where you were typing.
 
 The one thing to remember is the same everywhere — you press Enter.
+
+## Reviewing long prompts
+
+A two-minute prompt is full of identifiers — exactly the words speech-to-text
+gets wrong — and the agent will *act* on it. **Review before send** (Settings
+→ General) holds the cleaned transcript on the overlay in an editable panel
+before anything is pasted. The setting worth using for agent work is **Only
+long dictations**: quick chat-sized dictations keep the zero-friction flow,
+long prompts get a look first.
+
+On the panel:
+
+- `Ctrl/Cmd+Enter` (or the record hotkey again) **sends** — the text pastes
+  into the window you dictated from, even if you clicked elsewhere while
+  reviewing.
+- `Ctrl/Cmd+R` flips to the **raw** transcript — the ground truth when
+  cleanup "fixed" a technical term into a real word — and back.
+- `Ctrl/Cmd+Shift+C` copies instead of pasting; `Esc` discards. Either way
+  the transcript is kept in History, so the words are never lost.
+
+On Wayland there is no way to re-focus the target window explicitly; Earheart
+relies on the compositor returning focus when the panel closes, and falls back
+to leaving the text on the clipboard if the paste can't land.
 
 ## When something doesn't land
 

--- a/main/main.js
+++ b/main/main.js
@@ -127,6 +127,8 @@ function main() {
   // every window to close and the overlay refuses; electron#5891). Destroy
   // it first so quitting from the tray actually exits.
   app.on("before-quit", () => {
+    // Quitting mid-review must not lose the words: park them in history.
+    pipeline.flushReview();
     windows.destroyOverlay();
   });
 

--- a/main/output/deliver.js
+++ b/main/output/deliver.js
@@ -14,8 +14,7 @@
 //             tools exist we degrade to clipboard-only and tell the caller.
 
 const { clipboard, systemPreferences, shell } = require("electron");
-const { execFile } = require("node:child_process");
-const fs = require("node:fs");
+const { execFileAsync, commandExists, isWayland } = require("../util/exec");
 
 // Deep link to System Settings ▸ Privacy & Security ▸ Accessibility. The URL is
 // unchanged across the old System Preferences and the new System Settings, so it
@@ -23,35 +22,8 @@ const fs = require("node:fs");
 const ACCESSIBILITY_PANE_URL =
   "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
 
-function execFileAsync(cmd, args, options = {}) {
-  return new Promise((resolve, reject) => {
-    execFile(cmd, args, { timeout: 10000, ...options }, (err, stdout, stderr) => {
-      if (err) reject(new Error(stderr?.trim() || err.message));
-      else resolve(stdout);
-    });
-  });
-}
-
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function commandExists(cmd) {
-  const dirs = (process.env.PATH || "").split(":");
-  return dirs.some((dir) => {
-    try {
-      fs.accessSync(`${dir}/${cmd}`, fs.constants.X_OK);
-      return true;
-    } catch {
-      return false;
-    }
-  });
-}
-
-function isWayland() {
-  return (
-    process.env.XDG_SESSION_TYPE === "wayland" || !!process.env.WAYLAND_DISPLAY
-  );
 }
 
 async function simulatePasteLinux() {

--- a/main/output/focus.js
+++ b/main/output/focus.js
@@ -1,0 +1,178 @@
+// Target-window capture and restore for the review-before-send flow.
+//
+// The paste in deliver.js lands in whatever window has keyboard focus, which
+// works because the overlay never takes it. The review step is the one
+// deliberate exception: the overlay borrows focus so the transcript can be
+// edited, so before it does we remember which window the user dictated into
+// (captureTarget), and give it back right before pasting (restoreTarget).
+//
+// Every failure degrades softly: a null token or a failed restore just means
+// send behaves like today's paste-into-whatever-is-focused, and deliver()
+// already falls back to clipboard-with-note when the paste itself fails.
+// Nothing in here may ever block or fail a dictation.
+//
+// captureSpec/restoreSpec build the platform commands as data so tests can
+// cover every platform's argument shapes without a display server.
+
+const { execFileAsync, commandExists, isWayland } = require("../util/exec");
+const logger = require("../util/logger");
+
+// macOS goes through System Events for both capture and restore on purpose:
+// activating the target directly (`tell application id … to activate`) sends
+// that app an Apple Event and triggers a per-target-app Automation consent
+// prompt, while System Events is the exact permission surface the auto-paste
+// keystroke already needs — no new prompts for existing users.
+const DARWIN_CAPTURE_SCRIPT =
+  'tell application "System Events" to get (unix id of first application process whose frontmost is true) & "\\n" & (name of first application process whose frontmost is true)';
+
+function darwinRestoreScript(token) {
+  // Prefer the pid; fall back to the name if the process was relaunched.
+  const pid = Number(token.pid);
+  const name = String(token.name || "").replace(/[\\"]/g, "");
+  if (Number.isFinite(pid) && pid > 0) {
+    return (
+      'tell application "System Events"\n' +
+      `if exists (first application process whose unix id is ${pid}) then\n` +
+      `set frontmost of (first application process whose unix id is ${pid}) to true\n` +
+      (name ? `else\nset frontmost of application process "${name}" to true\n` : "") +
+      "end if\nend tell"
+    );
+  }
+  return `tell application "System Events" to set frontmost of application process "${name}" to true`;
+}
+
+// Windows: GetForegroundWindow gives the HWND of the window the user was
+// dictating into. Restoring is the delicate half — SetForegroundWindow is
+// called from a PowerShell child that is not the foreground process, so
+// Windows' foreground lock may reduce it to a taskbar flash. Tapping the Alt
+// key (keybd_event VK_MENU) first is the long-standing release of that lock.
+// If this proves flaky in the field, the escalation is AttachThreadInput.
+const WIN_CAPTURE_SCRIPT =
+  "Add-Type 'using System;using System.Runtime.InteropServices;public class FG{[DllImport(\"user32.dll\")]public static extern IntPtr GetForegroundWindow();}';" +
+  "[FG]::GetForegroundWindow().ToInt64()";
+
+function winRestoreScript(hwnd) {
+  const id = String(hwnd).replace(/[^0-9]/g, "");
+  return (
+    "Add-Type 'using System;using System.Runtime.InteropServices;public class FG{" +
+    '[DllImport("user32.dll")]public static extern bool SetForegroundWindow(IntPtr h);' +
+    '[DllImport("user32.dll")]public static extern bool IsWindow(IntPtr h);' +
+    '[DllImport("user32.dll")]public static extern void keybd_event(byte k,byte s,uint f,UIntPtr e);}\';' +
+    `$h=[IntPtr]${id};` +
+    "if(-not [FG]::IsWindow($h)){exit 1};" +
+    // Alt down/up releases the foreground lock for the SetForegroundWindow call.
+    "[FG]::keybd_event(0x12,0,0,[UIntPtr]::Zero);" +
+    "[FG]::SetForegroundWindow($h)|Out-Null;" +
+    "[FG]::keybd_event(0x12,0,2,[UIntPtr]::Zero)"
+  );
+}
+
+// Build the capture command for a platform, or null when capture is not
+// possible there (Wayland has no way to ask which surface is focused).
+// parse() turns the command's stdout into the token payload, or null.
+function captureSpec(platform, wayland) {
+  if (platform === "darwin") {
+    return {
+      cmd: "osascript",
+      args: ["-e", DARWIN_CAPTURE_SCRIPT],
+      parse: (out) => {
+        const [pid, ...name] = String(out).trim().split("\n");
+        const parsed = { kind: "darwin", pid: Number(pid), name: name.join("\n").trim() };
+        return Number.isFinite(parsed.pid) && parsed.pid > 0 ? parsed : null;
+      },
+    };
+  }
+  if (platform === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: ["-NoProfile", "-NonInteractive", "-Command", WIN_CAPTURE_SCRIPT],
+      parse: (out) => {
+        const hwnd = String(out).trim();
+        return /^[0-9]+$/.test(hwnd) && hwnd !== "0"
+          ? { kind: "win32", hwnd }
+          : null;
+      },
+    };
+  }
+  // Linux: only X11 can be queried. On Wayland the token still records the
+  // situation so restoreTarget can explain itself in its note.
+  if (wayland) return null;
+  return {
+    cmd: "xdotool",
+    args: ["getactivewindow"],
+    parse: (out) => {
+      const id = String(out).trim();
+      return /^[0-9]+$/.test(id) ? { kind: "x11", windowId: id } : null;
+    },
+  };
+}
+
+// Build the restore command for a token, or null when there is nothing to run
+// (Wayland, missing/degenerate token).
+function restoreSpec(token) {
+  if (!token) return null;
+  if (token.kind === "darwin") {
+    return { cmd: "osascript", args: ["-e", darwinRestoreScript(token)] };
+  }
+  if (token.kind === "win32") {
+    return {
+      cmd: "powershell.exe",
+      args: ["-NoProfile", "-NonInteractive", "-Command", winRestoreScript(token.hwnd)],
+    };
+  }
+  if (token.kind === "x11") {
+    return {
+      cmd: "xdotool",
+      args: ["windowactivate", "--sync", String(token.windowId)],
+    };
+  }
+  return null; // wayland or unknown
+}
+
+// Remember the window the user is dictating into. Must be called while that
+// window still has focus — i.e. BEFORE the overlay is made focusable.
+async function captureTarget() {
+  try {
+    if (process.platform === "linux" && isWayland()) {
+      // No Wayland protocol exposes the focused surface; the review flow
+      // instead relies on the compositor returning focus to the previous
+      // surface once the overlay stops being focusable.
+      return { kind: "wayland" };
+    }
+    const spec = captureSpec(process.platform, false);
+    if (!spec || (process.platform === "linux" && !commandExists(spec.cmd))) {
+      return null;
+    }
+    return spec.parse(await execFileAsync(spec.cmd, spec.args));
+  } catch (err) {
+    logger.warn("focus capture failed:", err.message);
+    return null;
+  }
+}
+
+// Give focus back to the captured window. Never throws; the caller pastes
+// regardless and deliver() handles the paste's own failure modes.
+async function restoreTarget(token) {
+  try {
+    const spec = restoreSpec(token);
+    if (!spec) {
+      return {
+        ok: false,
+        note:
+          token?.kind === "wayland"
+            ? "Wayland cannot re-focus the target window; relying on the compositor"
+            : "no captured target window",
+      };
+    }
+    if (process.platform === "linux" && !commandExists(spec.cmd)) {
+      return { ok: false, note: `${spec.cmd} not found` };
+    }
+    await execFileAsync(spec.cmd, spec.args);
+    return { ok: true };
+  } catch (err) {
+    logger.warn("focus restore failed:", err.message);
+    return { ok: false, note: err.message };
+  }
+}
+
+module.exports = { captureTarget, restoreTarget, captureSpec, restoreSpec };

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -2,8 +2,15 @@
 //
 // State machine:
 //   idle ──hotkey──▶ recording ──hotkey──▶ processing ──▶ idle
+//                        │                     │  ▲
+//                        │              (gate) ▼  │ (send/copy)
+//                        │                  reviewing
 //                        │                     │
-//                        └──cancel──▶ idle ◀───┘ (error/cancel)
+//                        └──cancel──▶ idle ◀───┘ (error/cancel/discard)
+//
+// The reviewing state is the opt-in review-before-send stop: the cleaned
+// transcript parks on the overlay for a keyboard edit pass, then a send/copy
+// re-enters processing to deliver, or a discard drops back to idle.
 //
 // Recording happens in the overlay renderer (it owns the microphone); the
 // captured WAV arrives here over IPC and the rest runs in the main process.
@@ -12,22 +19,29 @@
 // messages. Events from a torn-down session (late cancels, slow renderers)
 // are ignored instead of corrupting the current one.
 
-const { app, ipcMain, Notification } = require("electron");
+const { app, clipboard, ipcMain, Notification } = require("electron");
 const path = require("node:path");
 const windows = require("./windows");
 const settings = require("./settings");
 const route = require("./services/route");
 const engines = require("./engines");
 const { deliver } = require("./output/deliver");
+const { captureTarget, restoreTarget } = require("./output/focus");
+const { needsReview } = require("./util/review");
 const history = require("./history");
 const { createLivePreview } = require("./live-preview");
 const { createPersistedRtfEstimator } = require("./util/rtf");
 const { wavDurationSec, wavSliceFromFrame } = require("./util/wav");
 const logger = require("./util/logger");
 
-let state = "idle"; // idle | recording | processing
+let state = "idle"; // idle | recording | processing | reviewing
 let session = 0; // current dictation session id
 let abortController = null;
+// The dictation parked on the overlay for review. `target` is the focus
+// token of the window the user dictated into (see main/output/focus.js);
+// `text` is the cleaned transcript as it was offered, so history can record
+// whether the user edited it before sending.
+let pendingReview = null; // { sid, raw, text, cleaned, target }
 const stateListeners = new Set();
 
 // Live preview (the streaming partial transcript shown while recording) lives in
@@ -231,6 +245,12 @@ function toggle() {
     startRecording();
   } else if (state === "recording") {
     stopRecording();
+  } else if (state === "reviewing") {
+    // The hotkey's grammar is "advance the pipeline", and during review the
+    // next step is sending. It is also the only key that still works after
+    // the user clicked away to another app mid-review. The renderer owns the
+    // edited text, so ask it to send rather than sending main's stale copy.
+    windows.sendToOverlay("review:request-send", { sid: session });
   }
   // While processing, the hotkey is ignored; cancel is available on the
   // overlay and in the tray menu.
@@ -310,8 +330,137 @@ function cancel() {
     // The abort only mutes the reply; the cleanup worker would keep generating
     // for nothing (and delay the next dictation's clean). Stop it too.
     engines.cancelClean();
+  } else if (state === "reviewing") {
+    // Tray/CLI cancel can't see the renderer's edits, so the parked (main-
+    // side) text is what history keeps; the focus borrow is repaid so the
+    // user lands back where they were dictating.
+    flushReview();
+    windows.leaveReviewFocus();
+    if (pendingReviewTarget) restoreTarget(pendingReviewTarget);
+    pendingReviewTarget = null;
   }
   setState("idle");
+  windows.hideOverlay();
+}
+
+// Write a parked review to history as discarded and clear it. Called from
+// cancel() and from before-quit — a two-minute dictation must survive both.
+// Remembers the focus token aside so cancel() can still repay the borrow.
+let pendingReviewTarget = null;
+function flushReview() {
+  if (!pendingReview) return;
+  const review = pendingReview;
+  pendingReview = null;
+  pendingReviewTarget = review.target;
+  windows.setReviewPinned(false);
+  const cfg = settings.get();
+  if (cfg.history.enabled) {
+    history.add(
+      {
+        raw: review.raw,
+        text: review.text,
+        cleaned: review.cleaned,
+        reviewed: true,
+        edited: false,
+        delivered: "discarded",
+      },
+      cfg.history
+    );
+    windows.sendToSettings("history:changed");
+  }
+}
+
+// Send or copy the reviewed text: leave the borrowed focus, give the captured
+// target window its focus back, and only then deliver — in that order, so the
+// simulated paste keystroke cannot land in our own (now unfocusable) window.
+async function finishReview(sid, finalText, mode) {
+  if (sid !== session || state !== "reviewing" || !pendingReview) return;
+  const review = pendingReview;
+  pendingReview = null;
+  windows.setReviewPinned(false);
+  setState("processing");
+  const cfg = settings.get();
+  const text = finalText || review.text;
+  const edited = text !== review.text;
+  try {
+    await windows.leaveReviewFocus();
+    let result;
+    if (mode === "send") {
+      await restoreTarget(review.target);
+      overlayStatus("delivering");
+      // Wayland can't re-activate the target explicitly; give the compositor
+      // a longer beat to return focus on its own before the keystroke fires.
+      const output =
+        review.target?.kind === "wayland"
+          ? { ...cfg.output, pasteDelayMs: Math.max(cfg.output.pasteDelayMs ?? 150, 300) }
+          : cfg.output;
+      result = await deliver(text, output);
+    } else {
+      // Copy: the user keeps the text and pastes it themselves; still hand
+      // focus back so they land where they were working.
+      clipboard.writeText(text);
+      restoreTarget(review.target);
+      result = { method: "clipboard" };
+    }
+    if (sid !== session) return;
+    if (cfg.history.enabled) {
+      history.add(
+        {
+          raw: review.raw,
+          text,
+          cleaned: review.cleaned,
+          reviewed: true,
+          edited,
+          delivered: result.method,
+        },
+        cfg.history
+      );
+      windows.sendToSettings("history:changed");
+    }
+    overlayStatus("done", {
+      preview: text.length > 120 ? `${text.slice(0, 120)}…` : text,
+      method: result.method,
+      note: result.note,
+    });
+    hideOverlaySoon(sid, result.note ? 4000 : 1600);
+  } catch (err) {
+    if (sid !== session) return;
+    logger.error("review delivery failed:", err);
+    overlayStatus("error", { message: String(err.message).slice(0, 200) });
+    hideOverlaySoon(sid, 5000);
+  } finally {
+    if (session === sid) setState("idle");
+  }
+}
+
+// Esc from the review panel: nothing is pasted, but the words are kept
+// (history's whole purpose is that a transcript is never lost) — with the
+// renderer's edits, which travel with the discard message.
+async function discardReview(sid, editedText) {
+  if (sid !== session || state !== "reviewing" || !pendingReview) return;
+  const review = pendingReview;
+  pendingReview = null;
+  windows.setReviewPinned(false);
+  const cfg = settings.get();
+  const text = editedText || review.text;
+  if (cfg.history.enabled) {
+    history.add(
+      {
+        raw: review.raw,
+        text,
+        cleaned: review.cleaned,
+        reviewed: true,
+        edited: text !== review.text,
+        delivered: "discarded",
+      },
+      cfg.history
+    );
+    windows.sendToSettings("history:changed");
+  }
+  await windows.leaveReviewFocus();
+  // Esc means "back to work": return focus to where the user was dictating.
+  restoreTarget(review.target);
+  if (session === sid) setState("idle");
   windows.hideOverlay();
 }
 
@@ -332,6 +481,9 @@ async function process(sid, wavArrayBuffer) {
   const { signal } = controller;
   const wav = Buffer.from(wavArrayBuffer);
   const stale = () => session !== sid || signal.aborted;
+  // Set when this dictation parks on the review panel: the finally below must
+  // then leave the reviewing state alone instead of clobbering it to idle.
+  let enteredReview = false;
 
   const builtinCleanup = cfg.cleanup.enabled && cfg.cleanup.engine === "builtin";
   if (builtinCleanup) {
@@ -378,6 +530,20 @@ async function process(sid, wavArrayBuffer) {
       if (stale()) return;
     }
 
+    if (needsReview(cfg.review, text)) {
+      // Remember the window the user dictated into BEFORE the overlay borrows
+      // focus — from here on, "the focused app" would be us.
+      const target = await captureTarget();
+      if (stale()) return;
+      pendingReview = { sid, raw, text, cleaned, target };
+      enteredReview = true;
+      setState("reviewing");
+      windows.setReviewPinned(true); // auto-hide must not take the panel down
+      windows.enterReviewFocus();
+      overlayStatus("review", { sid, text, raw });
+      return; // review:send / review:discard IPC picks the session back up
+    }
+
     overlayStatus("delivering");
     const result = await deliver(text, cfg.output, signal);
     if (stale()) return;
@@ -399,7 +565,7 @@ async function process(sid, wavArrayBuffer) {
     hideOverlaySoon(sid, 5000);
   } finally {
     if (abortController === controller) abortController = null;
-    if (session === sid) setState("idle");
+    if (session === sid && !enteredReview) setState("idle");
   }
 }
 
@@ -429,6 +595,18 @@ function init() {
   });
 
   ipcMain.on("pipeline:cancel", () => cancel());
+
+  // Review panel exits. The renderer sends its (possibly edited) textarea
+  // content with each one; the sid guards inside drop stale sessions.
+  ipcMain.on("review:send", (event, { sid, text } = {}) => {
+    finishReview(sid, String(text ?? ""), "send");
+  });
+  ipcMain.on("review:copy", (event, { sid, text } = {}) => {
+    finishReview(sid, String(text ?? ""), "copy");
+  });
+  ipcMain.on("review:discard", (event, { sid, text } = {}) => {
+    discardReview(sid, String(text ?? ""));
+  });
 }
 
 // Re-arm the idle-unload timer with the latest setting (e.g. the user changed
@@ -446,4 +624,5 @@ module.exports = {
   getState,
   onStateChange,
   onSettingsChanged,
+  flushReview,
 };

--- a/main/settings.js
+++ b/main/settings.js
@@ -68,6 +68,16 @@ const DEFAULTS = {
     restoreClipboard: true, // after pasting in "paste" mode, restore clipboard
     pasteDelayMs: 150, // wait before simulating the paste keystroke
   },
+  review: {
+    // Review before send: hold the cleaned transcript on the overlay for a
+    // keyboard-driven edit pass before it is pasted. "off" preserves the
+    // zero-friction default; "always" reviews every dictation; "length" only
+    // reviews dictations of at least `minChars` characters (long agent
+    // prompts are where a mis-heard identifier costs real work). `minChars`
+    // is kept across mode switches so toggling modes doesn't lose it.
+    mode: "off", // "off" | "always" | "length"
+    minChars: 400,
+  },
   stt: {
     // "builtin" = run Parakeet in-process (no setup, default for new users),
     // "remote"  = any OpenAI-compatible transcription endpoint.

--- a/main/tray.js
+++ b/main/tray.js
@@ -29,8 +29,12 @@ function buildMenu(app) {
           ? "Stop & transcribe"
           : state === "processing"
             ? "Processing…"
-            : "Start dictation",
+            : state === "reviewing"
+              ? "Send to app"
+              : "Start dictation",
       enabled: state !== "processing",
+      // During review, toggle() routes to send — same "advance the pipeline"
+      // grammar as the record hotkey.
       click: () => pipeline.toggle(),
     },
     {
@@ -121,7 +125,9 @@ function refresh(app = appRef) {
       ? "Earheart — recording"
       : state === "processing"
         ? "Earheart — processing"
-        : "Earheart — ready"
+        : state === "reviewing"
+          ? "Earheart — reviewing"
+          : "Earheart — ready"
   );
   tray.setContextMenu(buildMenu(app));
 }

--- a/main/util/exec.js
+++ b/main/util/exec.js
@@ -1,0 +1,35 @@
+// Small child-process helpers shared by the modules that shell out to
+// platform tools (output delivery, focus capture/restore). Pure Node — no
+// Electron imports — so the modules built on top stay unit-testable.
+
+const { execFile } = require("node:child_process");
+const fs = require("node:fs");
+
+function execFileAsync(cmd, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout: 10000, ...options }, (err, stdout, stderr) => {
+      if (err) reject(new Error(stderr?.trim() || err.message));
+      else resolve(stdout);
+    });
+  });
+}
+
+function commandExists(cmd) {
+  const dirs = (process.env.PATH || "").split(":");
+  return dirs.some((dir) => {
+    try {
+      fs.accessSync(`${dir}/${cmd}`, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function isWayland() {
+  return (
+    process.env.XDG_SESSION_TYPE === "wayland" || !!process.env.WAYLAND_DISPLAY
+  );
+}
+
+module.exports = { execFileAsync, commandExists, isWayland };

--- a/main/util/review.js
+++ b/main/util/review.js
@@ -1,0 +1,14 @@
+// The review-before-send gate: should this dictation stop on the overlay for
+// an edit pass instead of being pasted immediately? Pure so the truth table
+// is unit-testable; the pipeline owns everything that happens next.
+
+function needsReview(reviewCfg, text) {
+  if (!reviewCfg || !text) return false;
+  if (reviewCfg.mode === "always") return true;
+  if (reviewCfg.mode === "length") {
+    return text.length >= (reviewCfg.minChars ?? 400);
+  }
+  return false; // "off" and unknown values paste straight through
+}
+
+module.exports = { needsReview };

--- a/main/windows.js
+++ b/main/windows.js
@@ -1,7 +1,7 @@
 // Window management: the recording overlay (a small always-on-top card that
 // also owns the microphone) and the settings window.
 
-const { BrowserWindow, ipcMain, screen } = require("electron");
+const { app, BrowserWindow, ipcMain, screen } = require("electron");
 const path = require("node:path");
 const settings = require("./settings");
 const logger = require("./util/logger");
@@ -33,6 +33,7 @@ let overlayCustomPosition = null; // set when the user drags the card
 let overlayDragOrigin = null; // { winX, winY, pointerX, pointerY }
 let overlayHideTimer = null;
 let overlayPinned = false; // update prompt holds the card on screen
+let reviewPinned = false; // review-before-send holds the card on screen
 
 // Clamp a top-left position so the window stays on-screen. The height matters
 // for the bottom bound: a transcript-grown overlay is taller than OVERLAY_HEIGHT,
@@ -272,6 +273,41 @@ function setOverlayPinned(pinned) {
   overlayPinned = Boolean(pinned);
 }
 
+// A second, independent pin for the review-before-send panel: the update
+// prompt's unpin (updates.js) must not take down a live review, and vice
+// versa. Whoever unpins is responsible for hiding when appropriate.
+function setReviewPinned(pinned) {
+  reviewPinned = Boolean(pinned);
+}
+
+// The one deliberate exception to "the overlay never steals focus": the
+// review-before-send panel needs real keyboard focus for its textarea. The
+// caller has already captured the target window (main/output/focus.js), so
+// this borrow is repaid by leaveReviewFocus + restoreTarget on the way out.
+function enterReviewFocus() {
+  const win = getOverlay();
+  if (!win) return;
+  win.setFocusable(true);
+  // A tray app has no active window on macOS, so focusing the overlay alone
+  // doesn't make Earheart the active application — the keystrokes would still
+  // land in the previous app.
+  if (process.platform === "darwin") app.focus({ steal: true });
+  win.focus();
+  raiseWithinTopmostBand(win);
+}
+
+// Give focus up again, in an order that guarantees the upcoming simulated
+// paste cannot land in our own window: release key focus, then make the
+// window unfocusable so nothing hands focus back, then let the OS settle
+// before the caller re-activates the captured target.
+async function leaveReviewFocus() {
+  const win = getOverlay();
+  if (!win) return;
+  win.blur();
+  win.setFocusable(false);
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
 // "Visible" for the update prompt's purposes: a card mid fade-out counts as
 // hidden, so a prompt arriving during the fade re-shows the window cleanly
 // instead of attaching to a disappearing card.
@@ -281,7 +317,7 @@ function isOverlayVisible() {
 }
 
 function hideOverlay() {
-  if (overlayPinned) return;
+  if (overlayPinned || reviewPinned) return;
   const win = getOverlay();
   if (!win || !win.isVisible() || overlayHideTimer) return;
   // Let the card fade out before the window actually disappears.
@@ -400,6 +436,9 @@ module.exports = {
   showOverlay,
   hideOverlay,
   setOverlayPinned,
+  setReviewPinned,
+  enterReviewFocus,
+  leaveReviewFocus,
   isOverlayVisible,
   sendToOverlay,
   openSettings,

--- a/preload.js
+++ b/preload.js
@@ -16,6 +16,7 @@ const LISTEN = new Set([
   "models:progress",
   "updates:state",
   "updates:prompt",
+  "review:request-send",
 ]);
 
 const SEND = new Set([
@@ -28,6 +29,9 @@ const SEND = new Set([
   "overlay:drag",
   "overlay:drag-end",
   "overlay:resize",
+  "review:send",
+  "review:copy",
+  "review:discard",
 ]);
 
 const INVOKE = new Set([

--- a/renderer/overlay.css
+++ b/renderer/overlay.css
@@ -261,6 +261,105 @@ body {
   border-radius: 50%;
 }
 
+/* Review before send: the same quiet panel grammar as the update prompt —
+   neutral white on hairline, the accent stays reserved for dictation. The
+   card is solo while reviewing: the control row has nothing to say. */
+#review {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 2px 12px 6px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--edge);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+#card[data-review="solo"] #controls {
+  display: none;
+}
+
+#review-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#review-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+#review-count {
+  font-size: 11px;
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The editable transcript. A real field on the quiet panel: darker ground so
+   the editable surface reads as one, the universal focus treatment on top. */
+#review-text {
+  width: 100%;
+  min-height: 72px;
+  padding: 8px 10px;
+  border: 1px solid var(--edge);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.28);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: none;
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+}
+
+#review-text:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+}
+
+/* The raw transcript, read-only: same box as the textarea so the flip reads
+   as the same surface showing its ground truth, dimmed because it is a
+   reference, not the draft. */
+#review-rawview {
+  width: 100%;
+  min-height: 72px;
+  max-height: 40vh;
+  padding: 8px 10px;
+  border: 1px dashed var(--edge);
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.28);
+  color: var(--text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+#review-rawview:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+}
+
+#review-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+/* The key map teaches itself, one step quieter than the actions. */
+#review-keys {
+  font-size: 10.5px;
+  color: var(--text-faint);
+  letter-spacing: 0.02em;
+}
+
 /* Live transcript: fills the top of the card and grows freely (no clip, no
    scroll, no mask). Two layers inline: the settled cleaned text and the
    still-streaming raw tail — fresh words dimmed, brightening as they settle. */

--- a/renderer/overlay.html
+++ b/renderer/overlay.html
@@ -73,6 +73,40 @@
           </div>
         </div>
       </div>
+      <!-- Review before send (opt-in): the cleaned transcript parks here for a
+           keyboard edit pass before anything is pasted. The one moment the
+           overlay borrows keyboard focus — main captured the target window
+           first and hands focus back on every exit. Solo like the update
+           prompt: the control row has nothing to say while reviewing. -->
+      <div id="review" hidden>
+        <div id="review-head">
+          <span id="review-title">Review before send</span>
+          <span id="review-count" aria-hidden="true"></span>
+          <!-- Raw is the ground truth: cleanup occasionally "fixes" a
+               technical term into a real word. Toggles a read-only view of
+               the uncleaned transcript. -->
+          <button id="review-raw-toggle" class="pill quiet" aria-pressed="false">
+            Raw
+          </button>
+        </div>
+        <textarea
+          id="review-text"
+          spellcheck="false"
+          rows="4"
+          aria-label="Transcript to review before sending"
+        ></textarea>
+        <div id="review-rawview" tabindex="-1" hidden></div>
+        <div id="review-actions">
+          <button id="review-send" class="pill primary" title="Paste into the app you dictated from">
+            Send
+          </button>
+          <button id="review-copy" class="pill quiet">Copy</button>
+          <button id="review-discard" class="pill quiet">Discard</button>
+        </div>
+        <!-- The key map, visible: keyboard-first means the keys are taught on
+             the surface itself, not in a manual. Filled in per-platform. -->
+        <div id="review-keys" aria-hidden="true"></div>
+      </div>
       <!-- Live transcript: shown while recording when live preview is on. The
            cleaned text is the settled line; the still-streaming raw tail trails
            it dimmed — fresh words brighten to white as cleanup settles them.

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -28,6 +28,15 @@ const updateOuts = document.getElementById("update-outs");
 const updateSkip = document.getElementById("update-skip");
 const updateNever = document.getElementById("update-never");
 const updateClose = document.getElementById("update-close");
+const reviewEl = document.getElementById("review");
+const reviewText = document.getElementById("review-text");
+const reviewRawView = document.getElementById("review-rawview");
+const reviewCount = document.getElementById("review-count");
+const reviewRawToggle = document.getElementById("review-raw-toggle");
+const reviewSend = document.getElementById("review-send");
+const reviewCopy = document.getElementById("review-copy");
+const reviewDiscard = document.getElementById("review-discard");
+const reviewKeys = document.getElementById("review-keys");
 
 let recording = null; // { sid, stream, source, recorder, chunks, startedAt, timerId, maxTimerId, partialTimerId }
 let generation = 0; // bumped on every start/teardown to invalidate stale awaits
@@ -856,7 +865,13 @@ earheart.on("pipeline:status", ({ status, detail }) => {
   // reports a post-recording status, retire the transcript so it doesn't linger
   // alongside the control row's own status/preview.
   clearTranscript();
+  // Any status that isn't the review offer takes the review panel down — the
+  // pipeline has moved on (delivering after a send, or a new dictation).
+  if (status !== "review") exitReview();
   switch (status) {
+    case "review":
+      startReview(detail);
+      break;
     case "transcribing":
       setStatus("transcribing", "Transcribing…");
       break;
@@ -884,6 +899,127 @@ earheart.on("pipeline:status", ({ status, detail }) => {
       setStatus("error", "Failed", detail?.message);
       break;
   }
+});
+
+/* ---------- review before send ---------- */
+
+// The review panel: the pipeline parks the cleaned transcript here (status
+// "review") instead of pasting, the user edits it in a real textarea — the
+// one moment this window holds keyboard focus — and one of three exits sends
+// the result back over IPC. Main owns everything after that.
+let review = null; // { sid, raw, showingRaw } while the panel is up
+
+// The overlay has no menu, so these chords are ours alone. Shown on the
+// panel itself (keyboard-first means the surface teaches its own keys).
+const REVIEW_KEY_HINTS =
+  navigator.platform.toUpperCase().includes("MAC")
+    ? "⌘↵ send · ⌘⇧C copy · ⌘R raw · esc discard"
+    : "ctrl+↵ send · ctrl+shift+C copy · ctrl+R raw · esc discard";
+
+function startReview({ sid, text, raw } = {}) {
+  review = { sid, raw: raw || "", showingRaw: false };
+  setStatus("review", "Review");
+  reviewText.value = text || "";
+  reviewRawView.textContent = "";
+  reviewRawView.hidden = true;
+  reviewText.hidden = false;
+  reviewRawToggle.setAttribute("aria-pressed", "false");
+  reviewKeys.textContent = REVIEW_KEY_HINTS;
+  syncReviewCount();
+  card.dataset.review = "solo"; // hides the control row, like the update prompt
+  reviewEl.hidden = false;
+  autoGrowReviewText();
+  syncOverlayHeight();
+  reviewText.focus();
+  // Caret at the end: the likely edit is near where dictation trailed off,
+  // and select-all would make the first keystroke destroy the transcript.
+  reviewText.setSelectionRange(reviewText.value.length, reviewText.value.length);
+}
+
+function exitReview() {
+  if (!review) return;
+  review = null;
+  reviewEl.hidden = true;
+  card.removeAttribute("data-review");
+  syncOverlayHeight();
+}
+
+function syncReviewCount() {
+  reviewCount.textContent = `${reviewText.value.length} chars`;
+}
+
+// The textarea grows with its content (capped so a huge prompt scrolls inside
+// instead of filling the screen); the window then grows upward around the
+// card via the existing overlay:resize path.
+function autoGrowReviewText() {
+  reviewText.style.height = "";
+  const cap = Math.round(window.screen.availHeight * 0.4);
+  reviewText.style.height = `${Math.min(reviewText.scrollHeight, cap)}px`;
+}
+
+function doReviewSend() {
+  if (!review) return;
+  earheart.send("review:send", { sid: review.sid, text: reviewText.value });
+}
+
+function doReviewCopy() {
+  if (!review) return;
+  earheart.send("review:copy", { sid: review.sid, text: reviewText.value });
+}
+
+function doReviewDiscard() {
+  if (!review) return;
+  earheart.send("review:discard", { sid: review.sid, text: reviewText.value });
+}
+
+// Raw is a read-only peek, not an alternate draft: flipping back always
+// returns to the (possibly edited) cleaned text in the textarea.
+function toggleReviewRaw() {
+  if (!review) return;
+  review.showingRaw = !review.showingRaw;
+  reviewRawToggle.setAttribute("aria-pressed", String(review.showingRaw));
+  reviewRawView.textContent = review.raw;
+  reviewRawView.hidden = !review.showingRaw;
+  reviewText.hidden = review.showingRaw;
+  syncOverlayHeight();
+  (review.showingRaw ? reviewRawView : reviewText).focus();
+}
+
+// One listener catches the chords whether focus sits in the textarea or on
+// the raw view. Plain Enter stays a newline; plain Ctrl/Cmd+C stays native
+// copy-selection.
+reviewEl.addEventListener("keydown", (event) => {
+  const mod = event.metaKey || event.ctrlKey;
+  if (event.key === "Enter" && mod) {
+    event.preventDefault();
+    doReviewSend();
+  } else if (event.key === "Escape") {
+    event.preventDefault();
+    doReviewDiscard();
+  } else if (mod && event.shiftKey && event.code === "KeyC") {
+    event.preventDefault();
+    doReviewCopy();
+  } else if (mod && !event.shiftKey && event.code === "KeyR") {
+    event.preventDefault();
+    toggleReviewRaw();
+  }
+});
+
+reviewText.addEventListener("input", () => {
+  syncReviewCount();
+  autoGrowReviewText();
+  syncOverlayHeight();
+});
+
+reviewSend.addEventListener("click", doReviewSend);
+reviewCopy.addEventListener("click", doReviewCopy);
+reviewDiscard.addEventListener("click", doReviewDiscard);
+reviewRawToggle.addEventListener("click", toggleReviewRaw);
+
+// The global record hotkey during review means send — main asks (it can't
+// read the textarea), the renderer answers with the edited text.
+earheart.on("review:request-send", ({ sid } = {}) => {
+  if (review?.sid === sid) doReviewSend();
 });
 
 // The update prompt. The main process decides WHEN it appears (never over a

--- a/renderer/settings.css
+++ b/renderer/settings.css
@@ -866,11 +866,17 @@ ul.notes li::before {
   line-height: 1.5;
 }
 
-/* ---------- disabled cleanup blocks ---------- */
+/* ---------- disabled field blocks ---------- */
 
-#cleanup-fields.disabled {
+#cleanup-fields.disabled,
+#review-threshold-field.disabled {
   opacity: 0.42;
   pointer-events: none;
+}
+
+/* The threshold input is a short number, not a full-width URL. */
+#review-min-chars {
+  width: 110px;
 }
 
 /* ---------- cleanup style: preset slider vs custom sampling ---------- */

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -128,6 +128,39 @@
         </div>
 
         <div class="card">
+          <div class="card-title">Review before send</div>
+          <div class="field">
+            <div class="options">
+              <label class="option">
+                <input type="radio" name="review-mode" value="off" />
+                <span class="option-text">Off — paste immediately</span>
+              </label>
+              <label class="option">
+                <input type="radio" name="review-mode" value="always" />
+                <span class="option-text">Always review</span>
+              </label>
+              <label class="option">
+                <input type="radio" name="review-mode" value="length" />
+                <span class="option-text">Only long dictations</span>
+              </label>
+            </div>
+            <div id="review-threshold-field" class="field">
+              <label for="review-min-chars">Review from</label>
+              <div class="row">
+                <input id="review-min-chars" type="number" min="0" step="50" />
+                <span class="hint">characters</span>
+              </div>
+            </div>
+            <p class="hint">
+              Holds the cleaned transcript on the overlay so you can fix a word
+              or check the raw take before it reaches the app — useful for long
+              agent prompts. The overlay briefly borrows keyboard focus and
+              hands it back when you send.
+            </p>
+          </div>
+        </div>
+
+        <div class="card">
           <label class="toggle">
             <span class="toggle-text">
               <span class="t">Start Earheart when I log in</span>

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -229,6 +229,14 @@ function populate() {
   syncEngine("stt");
   syncEngine("cleanup");
 
+  const reviewMode = current.review?.mode || "off";
+  (
+    document.querySelector(`input[name="review-mode"][value="${reviewMode}"]`) ||
+    document.querySelector('input[name="review-mode"][value="off"]')
+  ).checked = true;
+  $("review-min-chars").value = current.review?.minChars ?? 400;
+  syncReviewMode();
+
   $("start-on-boot").checked = !!current.startOnBoot;
 
   $("history-enabled").checked = current.history.enabled;
@@ -261,6 +269,15 @@ function collect() {
       // that was the only way to keep the transcript on the clipboard; the
       // explicit paste-copy mode replaces it, so plain paste always restores.
       restoreClipboard: true,
+    },
+    review: {
+      ...current.review,
+      mode:
+        document.querySelector('input[name="review-mode"]:checked')?.value ||
+        "off",
+      // Preserved even while the mode is "off"/"always" so flipping back to
+      // "length" keeps the user's threshold.
+      minChars: Math.max(0, parseInt($("review-min-chars").value, 10) || 400),
     },
     stt: {
       ...current.stt,
@@ -322,6 +339,20 @@ function syncCleanupEnabled() {
   fields.inert = !on;
 }
 $("cleanup-enabled").addEventListener("change", syncCleanupEnabled);
+
+// The character threshold only means something in "length" mode; same
+// dim+inert treatment as the cleanup fields so keyboard focus matches.
+function syncReviewMode() {
+  const mode =
+    document.querySelector('input[name="review-mode"]:checked')?.value || "off";
+  const field = $("review-threshold-field");
+  const on = mode === "length";
+  field.classList.toggle("disabled", !on);
+  field.inert = !on;
+}
+for (const radio of document.querySelectorAll('input[name="review-mode"]')) {
+  radio.addEventListener("change", syncReviewMode);
+}
 
 /* ---------- cleanup style: preset slider vs custom sampling ---------- */
 

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -902,7 +902,9 @@ async function renderHistory() {
     const meta = document.createElement("div");
     meta.className = "meta";
     const when = document.createElement("span");
-    when.textContent = `${new Date(item.at).toLocaleString()}${item.cleaned ? " · cleaned" : ""}`;
+    // "discarded" marks a reviewed transcript the user chose not to send —
+    // kept anyway, because history's promise is that words are never lost.
+    when.textContent = `${new Date(item.at).toLocaleString()}${item.cleaned ? " · cleaned" : ""}${item.delivered === "discarded" ? " · discarded" : ""}`;
     const actions = document.createElement("span");
     actions.className = "actions";
     const copy = document.createElement("button");

--- a/test/review.test.js
+++ b/test/review.test.js
@@ -1,0 +1,89 @@
+// Tests for the review-before-send plumbing: the platform command specs of
+// focus capture/restore. Pure command-building — no display server needed.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { captureSpec, restoreSpec } = require("../main/output/focus");
+
+test("captureSpec darwin queries the frontmost process via System Events", () => {
+  const spec = captureSpec("darwin", false);
+  assert.strictEqual(spec.cmd, "osascript");
+  assert.match(spec.args.join(" "), /System Events/);
+  assert.match(spec.args.join(" "), /frontmost/);
+  assert.deepStrictEqual(spec.parse("742\nTerminal\n"), {
+    kind: "darwin",
+    pid: 742,
+    name: "Terminal",
+  });
+  assert.strictEqual(spec.parse("garbage"), null);
+  assert.strictEqual(spec.parse(""), null);
+});
+
+test("captureSpec win32 reads the foreground HWND", () => {
+  const spec = captureSpec("win32", false);
+  assert.strictEqual(spec.cmd, "powershell.exe");
+  assert.match(spec.args.join(" "), /GetForegroundWindow/);
+  assert.deepStrictEqual(spec.parse("132456\r\n"), {
+    kind: "win32",
+    hwnd: "132456",
+  });
+  assert.strictEqual(spec.parse("0"), null); // no foreground window
+  assert.strictEqual(spec.parse("not-a-number"), null);
+});
+
+test("captureSpec linux/X11 uses xdotool; Wayland has no capture", () => {
+  const spec = captureSpec("linux", false);
+  assert.strictEqual(spec.cmd, "xdotool");
+  assert.deepStrictEqual(spec.args, ["getactivewindow"]);
+  assert.deepStrictEqual(spec.parse("6291463\n"), {
+    kind: "x11",
+    windowId: "6291463",
+  });
+  assert.strictEqual(spec.parse("xdotool: no active window"), null);
+  assert.strictEqual(captureSpec("linux", true), null);
+});
+
+test("restoreSpec darwin prefers the pid and falls back to the name", () => {
+  const spec = restoreSpec({ kind: "darwin", pid: 742, name: "Terminal" });
+  assert.strictEqual(spec.cmd, "osascript");
+  const script = spec.args.join(" ");
+  assert.match(script, /unix id is 742/);
+  assert.match(script, /"Terminal"/);
+  // A dead pid token still restores by name alone.
+  const byName = restoreSpec({ kind: "darwin", pid: NaN, name: "Terminal" });
+  assert.match(byName.args.join(" "), /application process "Terminal"/);
+});
+
+test("restoreSpec darwin strips quote characters from the app name", () => {
+  const spec = restoreSpec({ kind: "darwin", pid: NaN, name: 'Bad"App\\' });
+  assert.doesNotMatch(spec.args.join(" "), /Bad"App/);
+});
+
+test("restoreSpec win32 guards IsWindow and taps Alt around SetForegroundWindow", () => {
+  const spec = restoreSpec({ kind: "win32", hwnd: "132456" });
+  assert.strictEqual(spec.cmd, "powershell.exe");
+  const script = spec.args.join(" ");
+  assert.match(script, /IsWindow/);
+  assert.match(script, /SetForegroundWindow/);
+  assert.match(script, /keybd_event/);
+  assert.match(script, /\[IntPtr\]132456/);
+});
+
+test("restoreSpec win32 sanitizes a non-numeric hwnd", () => {
+  const spec = restoreSpec({ kind: "win32", hwnd: "12; Remove-Item x" });
+  assert.match(spec.args.join(" "), /\[IntPtr\]12\b/);
+  assert.doesNotMatch(spec.args.join(" "), /Remove-Item/);
+});
+
+test("restoreSpec x11 activates the captured window id", () => {
+  const spec = restoreSpec({ kind: "x11", windowId: "6291463" });
+  assert.strictEqual(spec.cmd, "xdotool");
+  assert.deepStrictEqual(spec.args, ["windowactivate", "--sync", "6291463"]);
+});
+
+test("restoreSpec has nothing to run for wayland/missing tokens", () => {
+  assert.strictEqual(restoreSpec({ kind: "wayland" }), null);
+  assert.strictEqual(restoreSpec(null), null);
+  assert.strictEqual(restoreSpec({ kind: "unknown" }), null);
+});

--- a/test/review.test.js
+++ b/test/review.test.js
@@ -5,6 +5,29 @@ const { test } = require("node:test");
 const assert = require("node:assert");
 
 const { captureSpec, restoreSpec } = require("../main/output/focus");
+const { needsReview } = require("../main/util/review");
+const { deepMerge, DEFAULTS } = require("../main/settings");
+
+test("needsReview truth table", () => {
+  assert.strictEqual(needsReview({ mode: "off" }, "hello"), false);
+  assert.strictEqual(needsReview({ mode: "always" }, "hello"), true);
+  // Boundary: minChars counts as long enough.
+  assert.strictEqual(needsReview({ mode: "length", minChars: 5 }, "1234"), false);
+  assert.strictEqual(needsReview({ mode: "length", minChars: 5 }, "12345"), true);
+  // Missing threshold falls back to the 400 default.
+  assert.strictEqual(needsReview({ mode: "length" }, "x".repeat(399)), false);
+  assert.strictEqual(needsReview({ mode: "length" }, "x".repeat(400)), true);
+  // Degenerate inputs never review.
+  assert.strictEqual(needsReview(undefined, "hello"), false);
+  assert.strictEqual(needsReview({ mode: "banana" }, "hello"), false);
+  assert.strictEqual(needsReview({ mode: "always" }, ""), false);
+});
+
+test("review defaults to off with a 400-char threshold", () => {
+  const cfg = deepMerge(DEFAULTS, {});
+  assert.strictEqual(cfg.review.mode, "off");
+  assert.strictEqual(cfg.review.minChars, 400);
+});
 
 test("captureSpec darwin queries the frontmost process via System Events", () => {
   const spec = captureSpec("darwin", false);


### PR DESCRIPTION
Closes #75.

An **opt-in review step**: instead of pasting immediately, the cleaned transcript parks on the overlay in an editable, fully keyboard-driven panel — fix a word, peek at the raw transcript, then send it on with a key.

## Progress

- [x] Focus plumbing: `main/util/exec.js` extraction, `main/output/focus.js` capture/restore with per-platform command specs + unit tests
- [x] Setting: `DEFAULTS.review` (Off / Always / Only long dictations + threshold), General-tab UI, pure `needsReview` gate + tests
- [x] Feature: pipeline `reviewing` state, windows focus dance, overlay review panel, preload channels, tray, history semantics
- [x] Docs: README, docs/agents.md recipe, PRODUCT.md, DESIGN.md review-panel spec
- [ ] Deferred: macOS-fullscreen Space behavior if manual testing shows Space-switching; Wayland activation protocol if compositors grow support

## How it works

The paste mechanism fires Ctrl/Cmd+V at whatever is focused, and the overlay is deliberately `focusable: false` — so an editable panel is in direct tension with the "never steal focus" promise. The resolution:

1. **Capture** the target window while it still has focus (`main/output/focus.js`): System Events frontmost-process on macOS (same permission surface as auto-paste — no new prompts), `GetForegroundWindow` on Windows, `xdotool getactivewindow` on X11. Wayland has no protocol for this; it relies on the compositor returning focus, with deliver's existing clipboard-with-note degrade as the worst case.
2. **Borrow** focus: `setFocusable(true)` + focus, review panel up, textarea seeded with the cleaned text.
3. **Repay** on every exit: blur + `setFocusable(false)` *before* re-activating the captured window, which happens *before* the paste keystroke — so the paste can never land in Earheart's own window, and "send" pastes into the app you dictated from even after clicking elsewhere mid-review.

Panel keys (taught on the panel itself): `Ctrl/Cmd+Enter` send · `Esc` discard · `Ctrl/Cmd+Shift+C` copy · `Ctrl/Cmd+R` raw transcript. The record hotkey and the tray's "Send to app" also send. Discard still writes history (`delivered: "discarded"`) — words are never lost, including on quit mid-review.

Default is **off**: with the setting untouched, every existing flow is unchanged.

## Testing

- `make test`: 205 pass (new: focus command specs per platform incl. Wayland/dead-token, `needsReview` truth table, defaults merge; contract tests auto-cover the new overlay ids, IPC channels, settings fields)
- `make smoke`, `make overlay-smoke` (29 checks), `make settings-smoke` (11 checks) all green
- Manual pass still needed per platform for the focus dance itself (macOS fullscreen Spaces, Windows foreground lock, Wayland compositor variance) — the risk notes live in the code comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)