### PR TITLE
perf(stt): decode asynchronously to keep the engine worker responsive

### DIFF
--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -30,6 +30,19 @@ const DEFAULT_CLEANUP_TEMPERATURE = 0.2;
 
 let recognizer = null; // sherpa-onnx OfflineRecognizer
 let sttModelId = null;
+// STT decode runs on the single-instance recognizer, so at most one decode may
+// be in flight at a time. The sync decoder used to make that implicit (it froze
+// this worker's event loop for the whole decode); the async decoder yields, so
+// an explicit promise chain holds the same invariant — a second transcribe that
+// lands during an in-flight decode waits for it rather than racing on the
+// recognizer. Mirrors the cleanup side's queuedCleanupOp, minus its abort set
+// (an STT decode can't be cancelled mid-flight).
+let sttQueue = Promise.resolve();
+function runSttSerial(fn) {
+  const run = sttQueue.then(fn);
+  sttQueue = run.catch(() => {});
+  return run;
+}
 
 let llama = null; // node-llama-cpp instance
 let llamaGpuMode; // undefined until first load; null = auto, false = CPU
@@ -83,7 +96,7 @@ async function loadStt({ dir, sherpa, modelId }) {
   const family = sherpa.joiner
     ? { transducer: { encoder, decoder, joiner: path.join(dir, sherpa.joiner) } }
     : { whisper: { encoder, decoder } };
-  recognizer = new sherpaOnnx.OfflineRecognizer({
+  recognizer = await sherpaOnnx.OfflineRecognizer.createAsync({
     featConfig: { sampleRate: SAMPLE_RATE, featureDim: FEATURE_DIM },
     modelConfig: {
       ...family,
@@ -102,21 +115,28 @@ async function loadStt({ dir, sherpa, modelId }) {
 
 async function transcribe({ wav, language }) {
   if (!recognizer) throw new Error("STT model not loaded");
-  const buf = Buffer.isBuffer(wav) ? wav : Buffer.from(wav);
-  const { samples, sampleRate } = wavToFloat32(buf);
-  const stream = recognizer.createStream();
-  stream.acceptWaveform({ sampleRate, samples });
-  // Time the decode here, where nothing else can leak in: measured from the
-  // pipeline it would include model loads and queueing behind an in-flight
-  // live-preview decode on this single-threaded worker — poisoning the
-  // realtime-factor estimate that paces the transcribing bar.
-  const startedAt = Date.now();
-  recognizer.decode(stream);
-  const decodeMs = Date.now() - startedAt;
-  const result = recognizer.getResult(stream);
-  return { text: (result && result.text ? result.text : "").trim(), decodeMs };
-  // `language` is accepted for parity with the HTTP API; Parakeet v3
-  // auto-detects, so it is not forwarded.
+  // Serialized so the async decode can't race a second decode on the
+  // single-instance recognizer (see runSttSerial). decodeAsync runs the
+  // inference on the native thread pool and returns the result directly
+  // (combining decode + getResult into one native call), leaving this worker's
+  // event loop free during inference — a sync decode froze the worker for the
+  // whole decode and blocked every incoming message until it returned.
+  return runSttSerial(async () => {
+    const buf = Buffer.isBuffer(wav) ? wav : Buffer.from(wav);
+    const { samples, sampleRate } = wavToFloat32(buf);
+    const stream = recognizer.createStream();
+    stream.acceptWaveform({ sampleRate, samples });
+    // Time the decode here, where nothing else can leak in: measured from the
+    // pipeline it would include model loads and queueing behind an in-flight
+    // live-preview decode on this worker — poisoning the realtime-factor
+    // estimate that paces the transcribing bar.
+    const startedAt = Date.now();
+    const result = await recognizer.decodeAsync(stream);
+    const decodeMs = Date.now() - startedAt;
+    return { text: (result && result.text ? result.text : "").trim(), decodeMs };
+    // `language` is accepted for parity with the HTTP API; Parakeet v3
+    // auto-detects, so it is not forwarded.
+  });
 }
 
 /* ---------------- cleanup (node-llama-cpp / Gemma) ---------------- */


### PR DESCRIPTION
## What & why

The STT worker used sherpa-onnx's **synchronous** API: the `OfflineRecognizer` constructor blocked during the (multi-second) model load, and `recognizer.decode()` blocked for the whole inference. A synchronous native call freezes the `utilityProcess` worker's entire event loop, so during a decode **no incoming messages could be read, no pings answered, and no follow-up request prepped** until it returned.

This switches to the async equivalents the addon already ships:

- `OfflineRecognizer.createAsync()` — model load no longer freezes the worker.
- `recognizer.decodeAsync(stream)` — inference runs on the native thread pool and returns the result directly, **combining decode + `getResult` into one native call** (one fewer N-API boundary crossing + JSON parse per transcription).

Because the async decode yields where the sync one implicitly serialized, an explicit `runSttSerial()` promise chain holds the existing **"one decode at a time on the single-instance recognizer"** invariant — mirroring the cleanup side's `queuedCleanupOp`, minus its abort set (an STT decode can't be cancelled mid-flight).

## Scope note

The decode **compute** itself is unchanged (same native ONNX inference). The win is **responsiveness**: the worker stops freezing during decodes/loads, and saves a native round-trip per transcription. Raw decode speed is bounded by CPU inference, already well-tuned (int8 model, 8-thread cap, tail-only final decode via the live-preview assembly). A *major* decode speedup would need GPU execution providers (`cuda`/`coreml`/`directml`), but the shipped `sherpa-onnx-*` binaries are CPU-only — a separate, larger project.

## How to test

- [x] `npm test` — 196 pass, 1 skipped (network)
- [x] `xvfb-run -a npx electron scripts/engine-smoke.js --no-sandbox` — worker ping ok, native engines load ok (stt + cleanup)

```bash
npm test
make smoke
npx electron scripts/engine-smoke.js --no-sandbox   # under xvfb-run on Linux
```