### PR TITLE
docs(models): say that the small cleanup model leaves fillers in

### DIFF
--- a/main/engines/registry.js
+++ b/main/engines/registry.js
@@ -143,7 +143,11 @@ const MODELS = {
       kind: "cleanup",
       engine: "llama-gguf",
       default: true,
-      note: "Runs on this computer · ~0.8 GB · best for most laptops",
+      // Honest about where it falls down. Measured on a 150-word dictation:
+      // 1B leaves most "um"/"uh" in place and misses the spoken-code rule
+      // ("src slash main dot pie"), where 4B gets both right. Someone picking a
+      // cleanup model should see that before they pick the small one.
+      note: "Runs on this computer · ~0.8 GB · fastest, but leaves some fillers in",
       files: [
         { name: "gemma-3-1b-it-Q4_K_M.gguf", bytes: 806_058_240,
           sha256: "8ccc5cd1f1b3602548715ae25a66ed73fd5dc68a210412eea643eb20eb75a135",
@@ -156,7 +160,7 @@ const MODELS = {
       label: "Gemma 3 4B (balanced)",
       kind: "cleanup",
       engine: "llama-gguf",
-      note: "Runs on this computer · ~2.6 GB · needs ~6 GB RAM",
+      note: "Runs on this computer · ~2.6 GB · needs ~6 GB RAM · removes fillers reliably",
       files: [
         { name: "gemma-3-4b-it-Q4_K_M.gguf", bytes: 2_489_757_856,
           sha256: "882e8d2db44dc554fb0ea5077cb7e4bc49e7342a1f0da57901c0802ea21a0863",


### PR DESCRIPTION
## Why

The Gemma 3 1B note read **"best for most laptops"**, which steers people toward the model least able to do what cleanup is for. This came out of a report that the default cleanup was leaving `um`/`uh` in the transcript.

## Measured

Same 150-word dictation, the shipped `DEFAULT_CLEANUP_PROMPT` + `resolveCleanup`, assembled exactly as `engine-worker.js` does it, run against the real GGUFs on CPU:

| Model + style | fillers left (of 9) | doubled words | spoken-code rule |
|---|---|---|---|
| 1B / Clean | 6 | 2 | not applied |
| 4B / Clean | 2 | 0 | applied |
| 4B / Polished | 0 | 0 | applied |

"Spoken-code rule" is `"src slash main dot pie"` → `src/main.py`. 1B leaves it as words; 4B gets it right.

Cost of 4B for context: ~20s vs ~7s per dictation on CPU, 2.6 GB, ~6 GB RAM.

## What changes

Copy only — both cleanup model notes now name the quality trade-off, not just size and RAM. No behaviour change, no default change: 1B stays the default, since choosing to spend 2.6 GB and 3x the time is the user's call.

Separately, prompt-level fixes were tried first and did not work — sharpening the directive, promoting filler removal into the rules list, and stating the task up front all left 6-7 fillers. A worked example was actively dangerous (in one run the model emitted the example's answer in place of the dictation), so none of that is in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)