### PR TITLE
fix(cleanup): stop a looping model instead of pasting what it repeated

### DIFF
--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -19,7 +19,12 @@
 
 const path = require("node:path");
 const { wavToFloat32, SAMPLE_RATE } = require("../util/wav");
-const { cleanContextNeed, cleanBudgetMessage } = require("../util/clean-budget");
+const {
+  cleanContextNeed,
+  cleanMaxTokens,
+  cleanBudgetMessage,
+  CLEAN_RUNAWAY_MESSAGE,
+} = require("../util/clean-budget");
 
 const port = process.parentPort;
 
@@ -270,6 +275,17 @@ function assertCleanBudget(userTurn, transcript) {
   if (needed > available) throw new Error(cleanBudgetMessage(needed, available));
 }
 
+// Transcript length in tokens, for the generation cap. Falls back to a
+// deliberately generous character estimate when the tokenizer isn't there: the
+// cap is a guard against a runaway, and a loose guard beats none.
+function transcriptTokens(transcript) {
+  try {
+    return llamaModel.tokenize(transcript).length;
+  } catch {
+    return Math.ceil(transcript.length / 3);
+  }
+}
+
 async function clean({ transcript, systemPrompt, sampling }, emitProgress) {
   if (!llamaContext) throw new Error("Cleanup model not loaded");
   const mod = await import("node-llama-cpp");
@@ -287,15 +303,21 @@ async function clean({ transcript, systemPrompt, sampling }, emitProgress) {
     // out), so generated-chars / transcript-chars is an honest progress ratio.
     const total = Math.max(1, transcript.length);
     let generated = 0;
-    const out = await session.prompt(userTurn, {
+    const { responseText, stopReason } = await session.promptWithMeta(userTurn, {
       ...samplingOptions(sampling),
       signal,
+      maxTokens: cleanMaxTokens(transcriptTokens(transcript)),
       onTextChunk: (text) => {
         generated += text.length;
         if (emitProgress) emitProgress(Math.min(CLEAN_PROGRESS_CAP, generated / total));
       },
     });
-    return (out || "").trim();
+    // Hitting the cap means the model never finished: either it looped, or it
+    // wrote past the output the context was sized for. Both make the text on
+    // screen wrong, and half a cleanup is not worth the user's words — throw,
+    // and the caller delivers the raw transcript instead.
+    if (stopReason === "maxTokens") throw new Error(CLEAN_RUNAWAY_MESSAGE);
+    return (responseText || "").trim();
   });
 }
 

--- a/main/util/clean-budget.js
+++ b/main/util/clean-budget.js
@@ -33,6 +33,28 @@ function cleanContextNeed(promptTokens, transcriptTokens) {
 }
 
 /**
+ * The generation cap for one cleanup turn — exactly the output the context
+ * above was sized to hold, and not a token more.
+ *
+ * Two things make this worth capping. Small models loop: Gemma 1B on a
+ * 150-word dictation re-emitted its last two sentences over and over, and with
+ * nothing to stop it, it ran until the context filled — minutes of compute for
+ * a result that repeats itself. And the generation that overruns is the one
+ * that triggers the context shift this module exists to prevent, silently
+ * costing the user the start of their dictation.
+ *
+ * Deriving the cap from the same numbers as cleanContextNeed makes the overrun
+ * arrive as an explicit stop (the maxTokens stop reason in
+ * main/engines/engine-worker.js clean) rather than as quiet truncation, and the
+ * caller answers it by keeping the raw transcript.
+ * @param {number} transcriptTokens tokens in the transcript alone
+ * @returns {number}
+ */
+function cleanMaxTokens(transcriptTokens) {
+  return transcriptTokens + CLEAN_CONTEXT_SLACK_TOKENS;
+}
+
+/**
  * The message for a turn that doesn't fit. It reaches the user verbatim (the
  * pipeline shows a cleanup-failed notification with the error text), so it says
  * what happened in whole words and carries the two numbers that explain it.
@@ -43,6 +65,11 @@ function cleanContextNeed(promptTokens, transcriptTokens) {
 function cleanBudgetMessage(needed, available) {
   return `Transcript too long to clean up in one pass (needs ~${needed} tokens of context, have ${available})`;
 }
+
+// Reaches the user the same way — the pipeline shows it on the cleanup-failed
+// notification — so it says what happened rather than naming a token count.
+const CLEAN_RUNAWAY_MESSAGE =
+  "Cleanup ran away repeating itself and was stopped; used the raw transcript";
 
 // Sizing the context from the dictation cap. The floor is what an ordinary
 // dictation needs; the ceiling is where the KV cache stops being worth it (a
@@ -79,7 +106,9 @@ module.exports = {
   CLEAN_CONTEXT_SLACK_TOKENS,
   CLEAN_CONTEXT_MIN,
   CLEAN_CONTEXT_MAX,
+  CLEAN_RUNAWAY_MESSAGE,
   cleanContextNeed,
   cleanContextFor,
+  cleanMaxTokens,
   cleanBudgetMessage,
 };

--- a/test/clean-budget.test.js
+++ b/test/clean-budget.test.js
@@ -14,8 +14,10 @@ const {
   CLEAN_CONTEXT_SLACK_TOKENS,
   CLEAN_CONTEXT_MIN,
   CLEAN_CONTEXT_MAX,
+  CLEAN_RUNAWAY_MESSAGE,
   cleanContextNeed,
   cleanContextFor,
+  cleanMaxTokens,
   cleanBudgetMessage,
 } = require("../main/util/clean-budget");
 
@@ -45,6 +47,34 @@ test("clean budget: fits exactly at the context size, not one token past", () =>
   assert.strictEqual(cleanContextNeed(exact, 0), available);
   assert.ok(!(cleanContextNeed(exact, 0) > available), "exact fit must not be refused");
   assert.ok(cleanContextNeed(exact, 1) > available, "one token past must be refused");
+});
+
+test("clean cap: the generation is capped at the output the context reserves", () => {
+  // The whole point of deriving the cap from the same numbers as the budget: a
+  // turn that passed cleanContextNeed can generate right up to its cap and
+  // still fit, so the cap fires on a runaway rather than on an honest cleanup.
+  const transcriptTokens = 400;
+  const promptTokens = 700 + transcriptTokens;
+  const available = cleanContextNeed(promptTokens, transcriptTokens);
+  assert.ok(
+    promptTokens + cleanMaxTokens(transcriptTokens) <= available,
+    "a generation that runs to the cap must still fit the sized context"
+  );
+});
+
+test("clean cap: scales with the transcript and never reaches zero", () => {
+  // A one-word dictation still needs room for punctuation and casing, so the
+  // cap floors at the slack rather than at the transcript's own length.
+  assert.ok(cleanMaxTokens(1000) > cleanMaxTokens(100));
+  assert.strictEqual(cleanMaxTokens(1000) - cleanMaxTokens(100), 900);
+  assert.ok(cleanMaxTokens(0) > 0);
+});
+
+test("clean cap: the runaway message says what happened to the text", () => {
+  // It reaches the user verbatim in the cleanup-failed notification, so it has
+  // to say the raw transcript was kept — not leave them wondering what landed.
+  assert.match(CLEAN_RUNAWAY_MESSAGE, /raw transcript/i);
+  assert.match(CLEAN_RUNAWAY_MESSAGE, /repeat/i);
 });
 
 test("clean budget: the refusal message names both numbers", () => {


### PR DESCRIPTION
## The failure

Small cleanup models loop. Gemma 3 1B on a 150-word dictation re-emitted its last two sentences over and over. With nothing to stop it, the generation ran until the context filled: minutes of compute for a result that repeats itself, then pasted into whatever the user was typing into. Hit repeatedly while investigating a filler-removal report.

The same overrun is what triggers the context shift `clean-budget.js` already exists to prevent — llama.cpp drops the oldest tokens, which is the start of the dictation, and reports nothing.

## The guard

`cleanMaxTokens()` caps generation at exactly the output `cleanContextNeed()` already reserves, and `clean()` reads the stop reason back via `promptWithMeta`.

Deriving both from the same numbers is what makes it safe: a turn that passed the budget check can generate right up to the cap and still fit, so an honest cleanup never trips it. Measured across four runs of the reproduction, honest cleanups generated 620-700 characters against a ~950-character cap.

Hitting the cap means the model never finished. Half a cleanup is not worth the user's words, so it throws and the caller delivers the raw transcript with a notification that says what happened — the same path the existing budget refusal uses.

## Scope

This bounds the worst case; it does not fix mild repetition, and it is not the fix for weak filler removal (that is the model — see #97). Three new tests pin the cap against the budget, its scaling, and the message; 213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)