### PR TITLE
feat: start silently in the tray instead of opening Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ showing a progress bar as it goes. It's a one-time download; everything after
 that is faster than realtime, even on CPU. You can pick a larger, higher-
 quality cleanup model in the wizard or later in Settings → Cleanup.
 
+Every launch after that goes straight to the tray — no window to dismiss — and
+posts a short "ready, press *your hotkey*" notification. Click it to open
+Settings, or ignore it and start dictating. Settings is always in the tray menu.
+
 ### Transcript cleanup
 
 Cleanup is **on by default** and runs the built-in Gemma model in-process: a

--- a/main/main.js
+++ b/main/main.js
@@ -12,6 +12,7 @@ const engines = require("./engines");
 const autostart = require("./autostart");
 const updates = require("./updates");
 const logger = require("./util/logger");
+const { prettyHotkey } = require("./util/hotkey-label");
 
 const isSmokeTest = process.argv.includes("--smoke-test");
 const startHidden = process.argv.includes("--hidden");
@@ -51,17 +52,9 @@ function applyHotkeys(cfg) {
   };
 }
 
-// Render the configured hotkey as something a person reads in a notification:
-// the stored accelerator form ("CommandOrControl+Shift+Space") is what the
-// settings/wizard fields show, but it's ugly to surface verbatim.
-function prettyHotkey(accelerator) {
-  if (!accelerator) return "";
-  const isMac = process.platform === "darwin";
-  return accelerator
-    .replace(/CommandOrControl/g, isMac ? "Cmd" : "Ctrl")
-    .replace(/\bCommand\b/g, "Cmd")
-    .replace(/\bControl\b/g, "Ctrl");
-}
+// Held past show() so the click handler survives: a Notification that only the
+// local scope referenced can be collected before the user gets to it.
+let startupNote = null;
 
 // A returning user launching the app manually lands straight in the tray,
 // ready for the hotkey — no settings window to dismiss. A one-shot
@@ -69,16 +62,23 @@ function prettyHotkey(accelerator) {
 // Settings) and the notification dismisses itself otherwise. Settings stays
 // reachable from the tray menu regardless.
 function announceRunning(cfg) {
+  // No notification service (a Linux session without one, or permission
+  // denied) means show() is a silent no-op — and on a desktop without a tray
+  // area the launch would leave no trace at all. Fall back to the window.
+  if (!Notification.isSupported()) {
+    windows.openSettings();
+    return;
+  }
   try {
     const combo = prettyHotkey(cfg.hotkey);
-    const note = new Notification({
+    startupNote = new Notification({
       title: "Earheart is ready",
       body: combo
         ? `Press ${combo} to dictate.`
         : "Open the tray menu to get started.",
     });
-    note.on("click", () => windows.openSettings());
-    note.show();
+    startupNote.on("click", () => windows.openSettings());
+    startupNote.show();
   } catch (err) {
     logger.warn(`startup notification failed: ${err.message}`);
   }
@@ -139,6 +139,12 @@ function main() {
     if (!startHidden && !isSmokeTest) {
       if (firstRun) {
         windows.openWizard();
+      } else if (!hotkeyResults.hotkey.ok) {
+        // The hotkey didn't register — taken by something else, or a Wayland
+        // desktop blocking global grabs. Announcing "press X to dictate" would
+        // be a lie, and the tray says nothing about why it does nothing, so
+        // show Settings: the hotkey field and the Wayland note live there.
+        windows.openSettings();
       } else {
         // Returning user: stay in the tray and announce, instead of popping a
         // settings window they have to dismiss. Settings is still in the tray

--- a/main/main.js
+++ b/main/main.js
@@ -1,7 +1,7 @@
 // Earheart entry point: app lifecycle, single-instance handling, and wiring
 // between the hotkey, tray, windows and the dictation pipeline.
 
-const { app, session } = require("electron");
+const { app, session, Notification } = require("electron");
 const settings = require("./settings");
 const windows = require("./windows");
 const pipeline = require("./pipeline");
@@ -49,6 +49,39 @@ function applyHotkeys(cfg) {
     hotkey: record.empty ? { ok: false, error: "No hotkey configured" } : record,
     pauseHotkey: pause,
   };
+}
+
+// Render the configured hotkey as something a person reads in a notification:
+// the stored accelerator form ("CommandOrControl+Shift+Space") is what the
+// settings/wizard fields show, but it's ugly to surface verbatim.
+function prettyHotkey(accelerator) {
+  if (!accelerator) return "";
+  const isMac = process.platform === "darwin";
+  return accelerator
+    .replace(/CommandOrControl/g, isMac ? "Cmd" : "Ctrl")
+    .replace(/\bCommand\b/g, "Cmd")
+    .replace(/\bControl\b/g, "Ctrl");
+}
+
+// A returning user launching the app manually lands straight in the tray,
+// ready for the hotkey — no settings window to dismiss. A one-shot
+// notification confirms it started; clicking it is optional (it opens
+// Settings) and the notification dismisses itself otherwise. Settings stays
+// reachable from the tray menu regardless.
+function announceRunning(cfg) {
+  try {
+    const combo = prettyHotkey(cfg.hotkey);
+    const note = new Notification({
+      title: "Earheart is ready",
+      body: combo
+        ? `Press ${combo} to dictate.`
+        : "Open the tray menu to get started.",
+    });
+    note.on("click", () => windows.openSettings());
+    note.show();
+  } catch (err) {
+    logger.warn(`startup notification failed: ${err.message}`);
+  }
 }
 
 function main() {
@@ -107,7 +140,10 @@ function main() {
       if (firstRun) {
         windows.openWizard();
       } else {
-        windows.openSettings();
+        // Returning user: stay in the tray and announce, instead of popping a
+        // settings window they have to dismiss. Settings is still in the tray
+        // menu. (--hidden, used by autostart-at-login, stays fully silent.)
+        announceRunning(cfg);
       }
     }
 

--- a/main/util/hotkey-label.js
+++ b/main/util/hotkey-label.js
@@ -1,0 +1,47 @@
+// Turn a stored Electron accelerator into something a person reads.
+//
+// Settings and the wizard show the accelerator verbatim ("CommandOrControl+
+// Shift+Space") because that is what gets registered, but a notification is
+// prose: it has to name the keys the way the platform's own menus do.
+//
+// Pure string work, kept out of main.js so it can be tested directly —
+// main.js binds Electron at module scope and cannot be required from a test.
+
+// Modifier spellings per platform. Electron accepts several aliases for the
+// same modifier (CommandOrControl/CmdOrCtrl, Command/Cmd, Control/Ctrl,
+// Alt/Option, Super/Meta), so every alias maps here — a hand-edited
+// settings.json is as valid an input as one the capture field wrote.
+const MODIFIERS = {
+  commandorcontrol: { darwin: "Cmd", win32: "Ctrl", linux: "Ctrl" },
+  cmdorctrl: { darwin: "Cmd", win32: "Ctrl", linux: "Ctrl" },
+  command: { darwin: "Cmd", win32: "Cmd", linux: "Cmd" },
+  cmd: { darwin: "Cmd", win32: "Cmd", linux: "Cmd" },
+  control: { darwin: "Control", win32: "Ctrl", linux: "Ctrl" },
+  ctrl: { darwin: "Control", win32: "Ctrl", linux: "Ctrl" },
+  alt: { darwin: "Option", win32: "Alt", linux: "Alt" },
+  option: { darwin: "Option", win32: "Alt", linux: "Alt" },
+  altgr: { darwin: "AltGr", win32: "AltGr", linux: "AltGr" },
+  shift: { darwin: "Shift", win32: "Shift", linux: "Shift" },
+  super: { darwin: "Cmd", win32: "Win", linux: "Super" },
+  meta: { darwin: "Cmd", win32: "Win", linux: "Super" },
+};
+
+/**
+ * Human-readable form of an Electron accelerator.
+ * @param {string} accelerator e.g. "CommandOrControl+Shift+Space"
+ * @param {string} [platform] process.platform value; defaults to this machine
+ * @returns {string} e.g. "Ctrl+Shift+Space" ("" for an unbound hotkey)
+ */
+function prettyHotkey(accelerator, platform = process.platform) {
+  if (!accelerator) return "";
+  // Unknown parts (the key itself: "Space", "K", "Up") pass through as typed.
+  return accelerator
+    .split("+")
+    .map((part) => {
+      const mod = MODIFIERS[part.trim().toLowerCase()];
+      return mod ? mod[platform] || mod.linux : part.trim();
+    })
+    .join("+");
+}
+
+module.exports = { prettyHotkey };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -14,6 +14,7 @@ const autostart = require("../main/autostart");
 const { listRemoteModels } = require("../main/services/models-remote");
 const { reconcileTranscript } = require("../renderer/transcript");
 const { acceleratorFromEvent } = require("../renderer/hotkey-capture");
+const { prettyHotkey } = require("../main/util/hotkey-label");
 
 test("encodeWav produces a valid RIFF header", () => {
   const samples = new Int16Array([0, 1000, -1000, 32767, -32768]);
@@ -702,4 +703,20 @@ test("acceleratorFromEvent maps modifiers per platform and names keys", () => {
   } finally {
     delete global.platform;
   }
+});
+
+test("prettyHotkey names modifiers the way each platform does", () => {
+  assert.strictEqual(prettyHotkey("CommandOrControl+Shift+Space", "linux"), "Ctrl+Shift+Space");
+  assert.strictEqual(prettyHotkey("CommandOrControl+Shift+Space", "win32"), "Ctrl+Shift+Space");
+  assert.strictEqual(prettyHotkey("CommandOrControl+Shift+Space", "darwin"), "Cmd+Shift+Space");
+  // macOS spells the physical Ctrl and Alt keys differently from the rest.
+  assert.strictEqual(prettyHotkey("Control+Alt+P", "darwin"), "Control+Option+P");
+  assert.strictEqual(prettyHotkey("Control+Alt+P", "linux"), "Ctrl+Alt+P");
+  // Aliases a hand-edited settings.json may carry, and the Super/Meta key.
+  assert.strictEqual(prettyHotkey("CmdOrCtrl+K", "win32"), "Ctrl+K");
+  assert.strictEqual(prettyHotkey("Super+K", "win32"), "Win+K");
+  assert.strictEqual(prettyHotkey("Meta+K", "linux"), "Super+K");
+  // The key itself passes through untouched, and unbound stays empty.
+  assert.strictEqual(prettyHotkey("CommandOrControl+Up", "linux"), "Ctrl+Up");
+  assert.strictEqual(prettyHotkey("", "linux"), "");
 });


### PR DESCRIPTION
## What & why

Returning users who launch Earheart manually currently get a Settings window every time — something they have to dismiss before getting on with dictation. The app is hotkey/tray-driven, so the window is noise: Settings is already reachable from the tray menu.

This changes the default returning-launch behavior to **stay in the tray and post a one-shot notification** ("Earheart is ready — press \<hotkey\> to dictate"). No click required; the notification dismisses itself. Clicking it is optional and opens Settings.

## Behavior matrix

| Launch type | Before | After |
| --- | --- | --- |
| First run | setup wizard | setup wizard (unchanged) |
| Returning, manual | Settings window | tray + notification |
| Autostart at login (`--hidden`) | silent in tray | silent in tray (unchanged) |
| Re-launch while running | opens Settings | opens Settings (unchanged) |

The post-update "what's new" prompt is unaffected — it surfaces on the overlay card (`raisePrompt("whatsnew")`), not via the Settings window.

## How I tested

- `npm test` — 210 pass, 0 fail
- `make smoke` (`xvfb-run … --smoke-test`) — boots and exits cleanly

Manual: a returning launch should show the notification and no Settings window; first run still shows the wizard.

release: minor