### PR TITLE
fix: actually free the memory models hold when Earheart sits idle

### DIFF
--- a/docs/live-transcription-plan.md
+++ b/docs/live-transcription-plan.md
@@ -169,15 +169,17 @@ keeps the main line from flickering.
      one instance and cleanup requests to the other.
    - **`main/engines/host.js`** — convert the module-level singleton (`child`,
      `nextId`, `pending`, `exitListeners`) into a `createHost({ serviceName })`
-     factory returning an instance with the same `{ request, stop, onExit }`
+     factory returning an instance with the same `{ request, stop, busy, onExit }`
      surface. Each instance owns its own child and lazily forks on first
      `request` (the existing `spawn()` behavior, unchanged).
    - **`main/engines/index.js`** — hold two host instances, `sttHost` and
-     `cleanupHost`; route `load-stt`/`transcribe`/`unload-stt` to the first and
-     `load-cleanup`/`clean`/`unload-cleanup` to the second. Split `forgetLoaded`,
+     `cleanupHost`; route `load-stt`/`transcribe` to the first and
+     `load-cleanup`/`clean` to the second. Split `forgetLoaded`,
      `unloadIdle`, `stop`, and the `onExit` hook so each worker's lifecycle is
-     independent (e.g. unload the heavy LLM while keeping the STT recognizer
-     warm). **Lazy spawn:** because each host forks on first request, a
+     independent (e.g. evict the heavy LLM while keeping the STT recognizer
+     warm). Idle eviction exits the whole worker (`host.stop()`) rather than
+     sending it an unload request — the engines' native allocators do not give
+     the pages back to the OS while the process lives. **Lazy spawn:** because each host forks on first request, a
      batch-only user who never triggers cleanup never spawns the 2nd worker;
      streaming users get full parallelism.
    - Within each worker, requests are still serialized, so the drop-if-busy rule

--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -350,10 +350,13 @@ async function disposeCleanup() {
   cleanupContextSize = 0;
 }
 
+// Drop the recognizer ahead of loading a different STT model. This does NOT
+// reclaim its memory: sherpa-onnx-node's OfflineRecognizer exposes no explicit
+// free(), so its native memory waits on a finalizer that an idle worker never
+// runs. That is why idle eviction exits the whole worker instead (see
+// unloadIdle in ./index.js); here the replacement model is loaded immediately
+// after, so the process is about to be busy either way.
 async function disposeStt() {
-  // sherpa-onnx-node's OfflineRecognizer exposes no explicit free(); its native
-  // memory is released by a finalizer once the handle is unreachable. So we just
-  // drop the reference and let GC reclaim it — reclamation is not immediate.
   recognizer = null;
   sttModelId = null;
 }
@@ -389,12 +392,10 @@ const HANDLERS = {
   loadcheck,
   "load-stt": loadStt,
   transcribe,
-  "unload-stt": disposeStt,
   "load-cleanup": loadCleanup,
   clean,
   "prime-cleanup": primeCleanup,
   "cancel-clean": cancelClean,
-  "unload-cleanup": disposeCleanup,
 };
 
 port.on("message", (event) => {

--- a/main/engines/host.js
+++ b/main/engines/host.js
@@ -29,15 +29,36 @@ function createHost({ serviceName = "earheart-engines" } = {}) {
     exitListeners.add(fn);
   }
 
+  // Drop every in-flight request and tell callers the worker is gone. Called
+  // both from the child's own "exit" event and synchronously from stop(), so a
+  // deliberate kill resets our state immediately rather than one tick later —
+  // by which time a new request may already have forked a successor.
+  function handleGone() {
+    // Fail anything still in flight so callers fall back instead of hanging.
+    for (const entry of pending.values()) {
+      entry.reject(new Error("engine process exited"));
+    }
+    pending.clear();
+    // A fresh worker has nothing loaded; let callers reset their caches so the
+    // next request re-loads the model instead of assuming it is still resident.
+    for (const fn of exitListeners) fn();
+  }
+
   function spawn() {
     if (child) return child;
     // Required lazily so this module can be loaded in non-Electron unit tests.
     const { utilityProcess } = require("electron");
-    child = utilityProcess.fork(path.join(__dirname, "engine-worker.js"), [], {
+    // Bound to `proc`, not to `child`: stop() (idle eviction) can retire this
+    // worker and a new request can fork its successor before this one's async
+    // "exit" lands. Every handler below checks it is still the current worker,
+    // so a dying process can never clear the successor's state.
+    const proc = utilityProcess.fork(path.join(__dirname, "engine-worker.js"), [], {
       serviceName,
       stdio: "inherit",
     });
-    child.on("message", (msg) => {
+    child = proc;
+    proc.on("message", (msg) => {
+      if (child !== proc) return; // superseded worker: ignore its late messages
       const entry = msg && pending.get(msg.id);
       if (!entry) return; // late progress/reply for a finished request: drop
       if (msg.progress !== undefined) {
@@ -55,18 +76,12 @@ function createHost({ serviceName = "earheart-engines" } = {}) {
       if (msg.ok) entry.resolve(msg.result);
       else entry.reject(new Error(msg.error || "engine error"));
     });
-    child.on("exit", () => {
+    proc.on("exit", () => {
+      if (child !== proc) return; // stop() already handled this one
       child = null;
-      // Fail anything still in flight so callers fall back instead of hanging.
-      for (const entry of pending.values()) {
-        entry.reject(new Error("engine process exited"));
-      }
-      pending.clear();
-      // A fresh worker has nothing loaded; let callers reset their caches so the
-      // next request re-loads the model instead of assuming it is still resident.
-      for (const fn of exitListeners) fn();
+      handleGone();
     });
-    return child;
+    return proc;
   }
 
   /**
@@ -115,18 +130,28 @@ function createHost({ serviceName = "earheart-engines" } = {}) {
     });
   }
 
-  function stop() {
-    if (child) {
-      try {
-        child.kill();
-      } catch {
-        // already gone
-      }
-      child = null;
-    }
+  /** True while any request is in flight, i.e. the worker must not be killed. */
+  function busy() {
+    return pending.size > 0;
   }
 
-  return { request, stop, onExit };
+  // Kill the worker process. This is how memory actually goes back to the OS —
+  // the engines' native allocators hold on to their pages for the life of the
+  // process (see unloadIdle in ../index.js) — so it is used for idle eviction,
+  // not just for quitting. The next request() forks a fresh worker.
+  function stop() {
+    if (!child) return;
+    const proc = child;
+    child = null; // any request from here on forks a successor
+    try {
+      proc.kill();
+    } catch {
+      // already gone
+    }
+    handleGone(); // now, so the async "exit" can't land on the successor
+  }
+
+  return { request, stop, busy, onExit };
 }
 
 module.exports = { createHost };

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -229,11 +229,24 @@ function stop() {
 //
 // A worker with a request in flight is left alone: the pipeline is idle here,
 // but a Settings "test transcribe/cleanup" is not part of that state machine and
-// killing it mid-run would surface as a bare "engine process exited". Its memory
-// is reclaimed by the next idle window instead.
+// killing it mid-run would surface as a bare "engine process exited". Skipping
+// one is reported back rather than swallowed — the caller's idle window has
+// already elapsed, so nothing would re-arm it and that worker would stay
+// resident for the rest of the session.
+//
+// @returns {boolean} true when nothing resident is left, false when a busy
+// worker was skipped and the caller should come back for it.
 function unloadIdle() {
-  if (loadedStt !== null && !sttHost.busy()) sttHost.stop();
-  if (loadedCleanup !== null && !cleanupHost.busy()) cleanupHost.stop();
+  let deferred = false;
+  if (loadedStt !== null) {
+    if (sttHost.busy()) deferred = true;
+    else sttHost.stop();
+  }
+  if (loadedCleanup !== null) {
+    if (cleanupHost.busy()) deferred = true;
+    else cleanupHost.stop();
+  }
+  return !deferred;
 }
 
 // If a worker dies (native crash, or our own stop()), it comes back empty.

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -209,6 +209,14 @@ function stop() {
   cleanupHost.stop();
 }
 
+// Stop one worker unless it has a request in flight. Reports whether that
+// worker is now gone.
+function stopIfIdle(host) {
+  if (host.busy()) return false;
+  host.stop();
+  return true;
+}
+
 // Give an idle dictation's memory back to the OS by exiting the worker that
 // holds it. The next transcribe/clean re-forks it and re-runs
 // ensureStt/ensureCleanup.
@@ -237,16 +245,9 @@ function stop() {
 // @returns {boolean} true when nothing resident is left, false when a busy
 // worker was skipped and the caller should come back for it.
 function unloadIdle() {
-  let deferred = false;
-  if (loadedStt !== null) {
-    if (sttHost.busy()) deferred = true;
-    else sttHost.stop();
-  }
-  if (loadedCleanup !== null) {
-    if (cleanupHost.busy()) deferred = true;
-    else cleanupHost.stop();
-  }
-  return !deferred;
+  const sttClear = loadedStt === null || stopIfIdle(sttHost);
+  const cleanupClear = loadedCleanup === null || stopIfIdle(cleanupHost);
+  return sttClear && cleanupClear;
 }
 
 // If a worker dies (native crash, or our own stop()), it comes back empty.

--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -209,27 +209,31 @@ function stop() {
   cleanupHost.stop();
 }
 
-// Release the loaded models without killing the workers, leaving them ready for
-// a fast re-load; the next transcribe/clean call re-runs ensureStt/ensureCleanup.
-// The cleanup engine frees its memory promptly via dispose(); the STT engine
-// has no explicit free, so its memory is reclaimed by GC rather than at once.
-// Each worker is unloaded independently and only if it had a model resident.
-async function unloadIdle() {
-  const jobs = [];
-  if (loadedStt !== null) {
-    forgetStt();
-    jobs.push(sttHost.request("unload-stt"));
-  }
-  if (loadedCleanup !== null) {
-    forgetCleanup();
-    jobs.push(cleanupHost.request("unload-cleanup"));
-  }
-  if (jobs.length === 0) return;
-  try {
-    await Promise.all(jobs);
-  } catch {
-    // A worker may have exited; the flags are already cleared either way.
-  }
+// Give an idle dictation's memory back to the OS by exiting the worker that
+// holds it. The next transcribe/clean re-forks it and re-runs
+// ensureStt/ensureCleanup.
+//
+// Exiting is the only thing that actually reclaims. Dropping the engine handles
+// in-process does not: sherpa-onnx exposes no free() at all, so the recognizer
+// waits on a V8 finalizer that an idle worker never triggers (measured on
+// Parakeet int8: 1.05 GB resident, unchanged 30s after an in-process unload),
+// and even once the handles are gone the native allocators keep the pages
+// rather than returning them.
+//
+// The cost is a cold re-load (~3-4s for Parakeet int8) — paid off the critical
+// path, because startRecording() warms both engines as recording begins, so it
+// lands under the time the user spends speaking. Each worker is stopped
+// independently and only if it had a model resident, so a transcribe-only user
+// never touches the cleanup worker. Stopping a host notifies its exit listeners,
+// which is what clears the loaded-model flags.
+//
+// A worker with a request in flight is left alone: the pipeline is idle here,
+// but a Settings "test transcribe/cleanup" is not part of that state machine and
+// killing it mid-run would surface as a bare "engine process exited". Its memory
+// is reclaimed by the next idle window instead.
+function unloadIdle() {
+  if (loadedStt !== null && !sttHost.busy()) sttHost.stop();
+  if (loadedCleanup !== null && !cleanupHost.busy()) cleanupHost.stop();
 }
 
 // If a worker dies (native crash, or our own stop()), it comes back empty.

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -52,6 +52,9 @@ const livePreview = createLivePreview({
 // cancels the pending timer (and re-arms it when done), so the models stay
 // resident during active use. 0 minutes means never unload.
 let idleUnloadTimer = null;
+// True while the armed timer is a short retry rather than the full window, so
+// an unrelated re-arm can keep the short delay instead of throwing it away.
+let idleUnloadRetrying = false;
 
 // How soon to re-check a worker that was busy when the idle window elapsed.
 // Short, because the thing holding it is a user-initiated Settings test, not a
@@ -63,6 +66,7 @@ function cancelIdleUnload() {
     clearTimeout(idleUnloadTimer);
     idleUnloadTimer = null;
   }
+  idleUnloadRetrying = false;
 }
 
 // Arm the eviction timer. `delayMs` overrides the configured window for the
@@ -71,8 +75,10 @@ function armIdleUnload(delayMs) {
   cancelIdleUnload();
   const minutes = settings.get().engines?.idleUnloadMinutes ?? 0;
   if (!minutes || minutes <= 0) return; // 0 = keep models resident
+  idleUnloadRetrying = delayMs !== undefined;
   idleUnloadTimer = setTimeout(() => {
     idleUnloadTimer = null;
+    idleUnloadRetrying = false;
     // Only unload if still idle — a dictation in flight will re-arm on finish.
     if (state !== "idle") return;
     // unloadIdle() skips a worker that has a request in flight. That request is
@@ -450,8 +456,14 @@ function init() {
 // Re-arm the idle-unload timer with the latest setting (e.g. the user changed
 // the idle window in Settings). Only matters while idle; an active dictation
 // re-arms from the new value when it finishes.
+//
+// Fires on every save, not just idle-window changes — so a save landing inside
+// a busy-worker retry keeps the retry's short delay rather than pushing that
+// worker back out to the full window. Re-arming still re-reads the setting, so
+// switching to 0 (never unload) cancels either kind of pending timer.
 function onSettingsChanged() {
-  if (state === "idle") armIdleUnload();
+  if (state !== "idle") return;
+  armIdleUnload(idleUnloadRetrying ? IDLE_UNLOAD_RETRY_MS : undefined);
 }
 
 module.exports = {

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -53,6 +53,11 @@ const livePreview = createLivePreview({
 // resident during active use. 0 minutes means never unload.
 let idleUnloadTimer = null;
 
+// How soon to re-check a worker that was busy when the idle window elapsed.
+// Short, because the thing holding it is a user-initiated Settings test, not a
+// long-running job.
+const IDLE_UNLOAD_RETRY_MS = 15000;
+
 function cancelIdleUnload() {
   if (idleUnloadTimer) {
     clearTimeout(idleUnloadTimer);
@@ -60,15 +65,22 @@ function cancelIdleUnload() {
   }
 }
 
-function armIdleUnload() {
+// Arm the eviction timer. `delayMs` overrides the configured window for the
+// retry below; the setting still gates whether we arm at all.
+function armIdleUnload(delayMs) {
   cancelIdleUnload();
   const minutes = settings.get().engines?.idleUnloadMinutes ?? 0;
   if (!minutes || minutes <= 0) return; // 0 = keep models resident
   idleUnloadTimer = setTimeout(() => {
     idleUnloadTimer = null;
     // Only unload if still idle — a dictation in flight will re-arm on finish.
-    if (state === "idle") engines.unloadIdle();
-  }, minutes * 60 * 1000);
+    if (state !== "idle") return;
+    // unloadIdle() skips a worker that has a request in flight. That request is
+    // a Settings "test transcribe/cleanup", which never enters this state
+    // machine and so never re-arms the window — without this retry the model
+    // would stay resident until the next real dictation, or forever.
+    if (!engines.unloadIdle()) armIdleUnload(IDLE_UNLOAD_RETRY_MS);
+  }, delayMs ?? minutes * 60 * 1000);
 }
 
 function setState(next) {

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -483,8 +483,10 @@
           <p class="hint">
             <strong>Unload models after idle</strong> — built-in models stay in memory for
             fast repeat dictations, then unload after this many idle minutes to free memory
-            (~1.5 GB or more); 0 keeps them loaded for the whole session. Only affects
-            in-app models, not external services.
+            (~1.5 GB or more); 0 keeps them loaded for the whole session. The next dictation
+            reloads them, which takes a few seconds — usually hidden under the time you spend
+            speaking, since loading starts as soon as recording does. Only affects in-app
+            models, not external services.
           </p>
         </div>
 

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -484,9 +484,8 @@
             <strong>Unload models after idle</strong> — built-in models stay in memory for
             fast repeat dictations, then unload after this many idle minutes to free memory
             (~1.5 GB or more); 0 keeps them loaded for the whole session. The next dictation
-            reloads them, which takes a few seconds — usually hidden under the time you spend
-            speaking, since loading starts as soon as recording does. Only affects in-app
-            models, not external services.
+            reloads them in a few seconds, usually hidden while you're still speaking. Only
+            affects in-app models, not external services.
           </p>
         </div>
 

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -619,12 +619,18 @@ test("engines facade routes STT and cleanup to separate worker hosts", async () 
           if (type === "load-stt" || type === "load-cleanup") return { ready: true };
           if (type === "transcribe") return "transcribed";
           if (type === "clean") return "cleaned";
-          if (type === "unload-stt" || type === "unload-cleanup") return {};
           throw new Error(`unexpected request: ${type}`);
         },
         stopped: false,
+        inFlight: 0,
+        busy() {
+          return this.inFlight > 0;
+        },
+        // Mirrors the real host: killing the worker notifies exit listeners, so
+        // the facade forgets what that worker had resident.
         stop() {
           this.stopped = true;
+          for (const fn of this.exitFns) fn();
         },
         exitFns: [],
         onExit(fn) {
@@ -660,12 +666,12 @@ test("engines facade routes STT and cleanup to separate worker hosts", async () 
   assert.ok(cleanup.calls.includes("load-cleanup") && cleanup.calls.includes("clean"));
   assert.ok(!cleanup.calls.includes("transcribe") && !cleanup.calls.includes("load-stt"));
 
-  // unloadIdle only unloads hosts that have a model resident, on their own host.
-  await facade.unloadIdle();
-  assert.ok(stt.calls.includes("unload-stt"));
-  assert.ok(cleanup.calls.includes("unload-cleanup"));
+  // Idle eviction exits each worker that has a model resident — that, not an
+  // in-process unload request, is what returns the memory to the OS.
+  facade.unloadIdle();
+  assert.ok(stt.stopped && cleanup.stopped);
 
-  // stop tears down both workers.
+  // stop tears down both workers too (app quit).
   facade.stop();
   assert.ok(stt.stopped && cleanup.stopped);
 });
@@ -686,12 +692,16 @@ function loadTwoHostFacade() {
           if (type === "load-stt" || type === "load-cleanup") return { ready: true };
           if (type === "transcribe") return "transcribed";
           if (type === "clean") return "cleaned";
-          if (type === "unload-stt" || type === "unload-cleanup") return {};
           throw new Error(`unexpected request: ${type}`);
         },
         stopped: false,
+        inFlight: 0,
+        busy() {
+          return this.inFlight > 0;
+        },
         stop() {
           this.stopped = true;
+          for (const fn of this.exitFns) fn();
         },
         exitFns: [],
         onExit(fn) {
@@ -739,22 +749,36 @@ test("an STT worker crash forgets only STT loaded-state, not cleanup", async () 
   assert.strictEqual(count(cleanup, "load-cleanup"), 1, "cleanup must not re-load when only STT died");
 });
 
-test("unloadIdle unloads only the engines that are actually resident", async () => {
-  // A transcribe-only user (never cleaned) must unload STT but never send
-  // unload-cleanup to a cleanup worker that was never loaded.
+test("unloadIdle exits only the workers that are actually resident", async () => {
+  // A transcribe-only user (never cleaned) must have the STT worker exited but
+  // never the cleanup worker, which was never loaded and holds no memory.
   const { facade, hostsBySvc } = loadTwoHostFacade();
   await facade.transcribe(Buffer.from("wav"), STT_CFG);
   const stt = hostsBySvc["earheart-stt"];
   const cleanup = hostsBySvc["earheart-cleanup"];
 
-  await facade.unloadIdle();
-  assert.ok(stt.calls.includes("unload-stt"));
-  assert.ok(!cleanup.calls.includes("unload-cleanup"), "cleanup was never loaded; must not be unloaded");
+  facade.unloadIdle();
+  assert.ok(stt.stopped, "the resident STT worker should be exited");
+  assert.ok(!cleanup.stopped, "cleanup was never loaded; its worker must be left alone");
 
-  // A second unloadIdle with nothing resident is a no-op on both hosts.
-  const before = stt.calls.length + cleanup.calls.length;
-  await facade.unloadIdle();
-  assert.strictEqual(stt.calls.length + cleanup.calls.length, before, "idle unload with nothing loaded is a no-op");
+  // A second unloadIdle with nothing resident touches neither host.
+  stt.stopped = false;
+  facade.unloadIdle();
+  assert.ok(!stt.stopped && !cleanup.stopped, "idle unload with nothing loaded is a no-op");
+
+  // The next dictation re-loads into a fresh worker.
+  await facade.transcribe(Buffer.from("wav"), STT_CFG);
+  assert.strictEqual(count(stt, "load-stt"), 2, "STT should re-load after idle eviction");
+
+  // A worker with a request in flight (e.g. a Settings "test transcribe") is
+  // left alone rather than killed out from under its caller.
+  stt.stopped = false;
+  stt.inFlight = 1;
+  facade.unloadIdle();
+  assert.ok(!stt.stopped, "a busy worker must not be exited");
+  stt.inFlight = 0;
+  facade.unloadIdle();
+  assert.ok(stt.stopped, "once free, the same worker is exited");
 });
 
 test("transcribe/clean reject early on an already-aborted signal without touching the worker", async () => {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -668,7 +668,7 @@ test("engines facade routes STT and cleanup to separate worker hosts", async () 
 
   // Idle eviction exits each worker that has a model resident — that, not an
   // in-process unload request, is what returns the memory to the OS.
-  facade.unloadIdle();
+  assert.strictEqual(facade.unloadIdle(), true);
   assert.ok(stt.stopped && cleanup.stopped);
 
   // stop tears down both workers too (app quit).
@@ -771,14 +771,26 @@ test("unloadIdle exits only the workers that are actually resident", async () =>
   assert.strictEqual(count(stt, "load-stt"), 2, "STT should re-load after idle eviction");
 
   // A worker with a request in flight (e.g. a Settings "test transcribe") is
-  // left alone rather than killed out from under its caller.
+  // left alone rather than killed out from under its caller — and the skip is
+  // reported so the caller can come back for it.
   stt.stopped = false;
   stt.inFlight = 1;
-  facade.unloadIdle();
+  assert.strictEqual(facade.unloadIdle(), false, "a skipped worker must be reported");
   assert.ok(!stt.stopped, "a busy worker must not be exited");
   stt.inFlight = 0;
-  facade.unloadIdle();
+  assert.strictEqual(facade.unloadIdle(), true, "nothing left resident");
   assert.ok(stt.stopped, "once free, the same worker is exited");
+});
+
+test("unloadIdle reports success when there is nothing resident to skip", async () => {
+  const { facade, hostsBySvc } = loadTwoHostFacade();
+  // Nothing loaded at all: trivially complete.
+  assert.strictEqual(facade.unloadIdle(), true, "no models resident is a complete unload");
+
+  await facade.transcribe(Buffer.from("wav"), STT_CFG);
+  const stt = hostsBySvc["earheart-stt"];
+  assert.strictEqual(facade.unloadIdle(), true, "an idle resident worker unloads completely");
+  assert.ok(stt.stopped);
 });
 
 test("transcribe/clean reject early on an already-aborted signal without touching the worker", async () => {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -607,45 +607,7 @@ test("engines facade routes STT and cleanup to separate worker hosts", async () 
   // clean only to the cleanup host, so a crash or load in one engine can't
   // affect the other. We hand the facade a `createHost` factory and assert each
   // host sees only its own request types.
-  const hostsBySvc = {};
-  const hostModule = {
-    createHost({ serviceName }) {
-      const calls = [];
-      const host = {
-        serviceName,
-        calls,
-        request: async (type) => {
-          calls.push(type);
-          if (type === "load-stt" || type === "load-cleanup") return { ready: true };
-          if (type === "transcribe") return "transcribed";
-          if (type === "clean") return "cleaned";
-          throw new Error(`unexpected request: ${type}`);
-        },
-        stopped: false,
-        inFlight: 0,
-        busy() {
-          return this.inFlight > 0;
-        },
-        // Mirrors the real host: killing the worker notifies exit listeners, so
-        // the facade forgets what that worker had resident.
-        stop() {
-          this.stopped = true;
-          for (const fn of this.exitFns) fn();
-        },
-        exitFns: [],
-        onExit(fn) {
-          this.exitFns.push(fn);
-        },
-      };
-      hostsBySvc[serviceName] = host;
-      return host;
-    },
-  };
-  const managerStub = {
-    isInstalled: () => true,
-    modelDir: (base, model) => path.join(base, model.kind, model.id),
-  };
-  const facade = loadFacadeWith({ host: hostModule, manager: managerStub });
+  const { facade, hostsBySvc } = loadTwoHostFacade();
 
   const stt = hostsBySvc["earheart-stt"];
   const cleanup = hostsBySvc["earheart-cleanup"];
@@ -676,9 +638,11 @@ test("engines facade routes STT and cleanup to separate worker hosts", async () 
   assert.ok(stt.stopped && cleanup.stopped);
 });
 
-// Build a two-host facade over fake STT + cleanup workers. Each fake records its
-// calls and its registered onExit listeners, so tests can simulate one worker
-// dying and assert the other is unaffected.
+// Build a two-host facade over fake STT + cleanup workers. Each fake records
+// its calls and its registered onExit listeners, so tests can drive routing,
+// idle eviction, and one worker dying while the other is unaffected. Every
+// test in this section shares it — a second hand-written copy of this fake
+// only meant the same edit had to land twice.
 function loadTwoHostFacade() {
   const hostsBySvc = {};
   const hostModule = {
@@ -699,6 +663,9 @@ function loadTwoHostFacade() {
         busy() {
           return this.inFlight > 0;
         },
+        // Mirrors the real host: killing the worker notifies its exit
+        // listeners, which is what makes the facade forget what that worker
+        // had resident.
         stop() {
           this.stopped = true;
           for (const fn of this.exitFns) fn();

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -749,6 +749,36 @@ test("unloadIdle exits only the workers that are actually resident", async () =>
   assert.ok(stt.stopped, "once free, the same worker is exited");
 });
 
+test("unloadIdle checks each host's own busy state, with both engines resident", async () => {
+  // With only one engine ever loaded, the other's branch never runs — so a
+  // regression asking the wrong host whether it is busy (or bailing out on the
+  // first busy engine and never reaching the second) survives every other test
+  // here. Load both, then make one busy at a time.
+  const { facade, hostsBySvc } = loadTwoHostFacade();
+  await facade.transcribe(Buffer.from("wav"), STT_CFG);
+  await facade.clean("text", CLEANUP_CFG);
+  const stt = hostsBySvc["earheart-stt"];
+  const cleanup = hostsBySvc["earheart-cleanup"];
+
+  // Cleanup busy, STT idle: STT still goes, cleanup is spared, skip reported.
+  cleanup.inFlight = 1;
+  assert.strictEqual(facade.unloadIdle(), false, "the busy cleanup worker was skipped");
+  assert.ok(stt.stopped, "the idle STT worker is still evicted");
+  assert.ok(!cleanup.stopped, "the busy cleanup worker must survive");
+
+  // And the mirror image: STT busy, cleanup idle.
+  const second = loadTwoHostFacade();
+  await second.facade.transcribe(Buffer.from("wav"), STT_CFG);
+  await second.facade.clean("text", CLEANUP_CFG);
+  const stt2 = second.hostsBySvc["earheart-stt"];
+  const cleanup2 = second.hostsBySvc["earheart-cleanup"];
+
+  stt2.inFlight = 1;
+  assert.strictEqual(second.facade.unloadIdle(), false, "the busy STT worker was skipped");
+  assert.ok(!stt2.stopped, "the busy STT worker must survive");
+  assert.ok(cleanup2.stopped, "the idle cleanup worker is still evicted");
+});
+
 test("unloadIdle reports success when there is nothing resident to skip", async () => {
   const { facade, hostsBySvc } = loadTwoHostFacade();
   // Nothing loaded at all: trivially complete.

--- a/test/host.test.js
+++ b/test/host.test.js
@@ -183,3 +183,74 @@ test("host: worker exit rejects in-flight requests", async () => {
   child.emit("exit");
   await assert.rejects(promise, /engine process exited/);
 });
+
+test("host: busy() tracks in-flight requests", async () => {
+  // Idle eviction asks busy() whether the worker can be killed, so an
+  // off-by-one here either kills a worker mid-request or never kills one.
+  const { child, host } = setup();
+
+  assert.strictEqual(host.busy(), false, "nothing requested yet");
+  const promise = host.request("transcribe", {});
+  assert.strictEqual(host.busy(), true, "a request is in flight");
+
+  const { id } = child.sent[0];
+  child.emit("message", { id, ok: true, result: "done" });
+  assert.strictEqual(await promise, "done");
+  assert.strictEqual(host.busy(), false, "a settled request is no longer pending");
+});
+
+test("host: stop() rejects in-flight requests and notifies exit listeners", async () => {
+  // stop() is the idle-eviction path, not just the quit path: index.js clears
+  // its loaded-model flags from the exit listeners, so a stop() that killed the
+  // worker without notifying would leave the facade believing a dead worker
+  // still had a model resident.
+  const { host } = setup();
+  let exits = 0;
+  host.onExit(() => exits++);
+
+  // A short deadline so a stop() that forgot to drain fails the assertion
+  // below rather than hanging this test forever on an unsettled promise.
+  const promise = host.request("transcribe", {}, { timeoutMs: 50 });
+  host.stop();
+
+  await assert.rejects(promise, /engine process exited/);
+  assert.strictEqual(exits, 1, "callers must be told the worker is gone");
+  assert.strictEqual(host.busy(), false, "stop() drains pending");
+
+  // Stopping again with no worker is a no-op, not a second spurious notify.
+  host.stop();
+  assert.strictEqual(exits, 1);
+});
+
+test("host: a retired worker can't clobber its successor", async () => {
+  // The race idle eviction made reachable: stop() kills worker A and a new
+  // request forks successor B before A's async "exit" lands. Without the
+  // `child !== proc` guards, A's late events would reject B's in-flight
+  // request and re-fire the exit listeners, wrongly forgetting a model B just
+  // loaded. Nothing else exercises those guards — engines.test.js stubs this
+  // module out entirely.
+  const { child: a, host } = setup();
+  let exits = 0;
+  host.onExit(() => exits++);
+
+  const first = host.request("transcribe", {});
+  a.emit("message", { id: a.sent[0].id, ok: true, result: "from A" });
+  assert.strictEqual(await first, "from A");
+
+  host.stop(); // idle eviction; the fake kill() leaves `a` able to emit
+  assert.strictEqual(exits, 1);
+
+  const b = (currentChild = createFakeChild());
+  const second = host.request("transcribe", {});
+  assert.strictEqual(b.sent.length, 1, "the request went to the successor");
+
+  a.emit("exit"); // the real OS event, arriving after the successor exists
+  assert.strictEqual(exits, 1, "a retired worker must not re-fire exit listeners");
+  assert.strictEqual(host.busy(), true, "B's request must still be in flight");
+
+  // Ids are host-wide and monotonic, so a real A could never reuse B's id —
+  // forcing the collision here is what pins the message-handler guard.
+  a.emit("message", { id: b.sent[0].id, ok: true, result: "stale from A" });
+  b.emit("message", { id: b.sent[0].id, ok: true, result: "from B" });
+  assert.strictEqual(await second, "from B");
+});

--- a/test/pipeline.test.js
+++ b/test/pipeline.test.js
@@ -1,0 +1,194 @@
+// Tests for the pipeline's idle-unload timer: when models get evicted, and what
+// happens when a worker is busy at the moment the window elapses.
+//
+// main/pipeline.js requires Electron and most of the main process at load, so
+// this uses the same require.cache stubbing that engines.test.js uses for the
+// engines facade — just with a longer list. Nothing in production code changes
+// to make this loadable; the module is simply given fakes for its neighbours.
+//
+// Timers are driven by node:test's mock timers rather than real waits, so the
+// configured window (minutes) and the retry (seconds) can both be stepped
+// through deterministically.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const path = require("node:path");
+const os = require("node:os");
+const Module = require("node:module");
+
+const pipelinePath = require.resolve("../main/pipeline");
+const dir = path.dirname(pipelinePath);
+const resolveFrom = (spec) => require.resolve(spec, { paths: [dir] });
+
+// Load main/pipeline.js against fakes for everything it pulls in. `engines` and
+// `settings` are the two the caller actually drives; the rest exist only so the
+// module can finish loading.
+function loadPipelineWith({ engines, settings }) {
+  const stubs = {
+    [resolveFrom("electron")]: {
+      app: { getPath: () => os.tmpdir() },
+      ipcMain: { on() {} },
+      Notification: class {
+        show() {}
+      },
+    },
+    [resolveFrom("./windows")]: { sendToOverlay() {}, showOverlay() {}, hideOverlay() {} },
+    [resolveFrom("./settings")]: settings,
+    [resolveFrom("./services/route")]: { transcribe: async () => "", clean: async () => "" },
+    [resolveFrom("./engines")]: engines,
+    [resolveFrom("./output/deliver")]: { deliver: async () => ({}) },
+    [resolveFrom("./history")]: { add() {} },
+    [resolveFrom("./live-preview")]: {
+      createLivePreview: () => ({ cancel() {}, handleAudio() {}, snapshotFinal: () => null }),
+    },
+    [resolveFrom("./util/logger")]: { info() {}, warn() {}, error() {} },
+  };
+
+  const saved = {};
+  for (const p of Object.keys(stubs)) {
+    saved[p] = require.cache[p];
+    const m = new Module(p, null);
+    m.filename = p;
+    m.loaded = true;
+    m.exports = stubs[p];
+    require.cache[p] = m;
+  }
+  delete require.cache[pipelinePath];
+  try {
+    return require(pipelinePath);
+  } finally {
+    delete require.cache[pipelinePath];
+    for (const p of Object.keys(stubs)) {
+      if (saved[p]) require.cache[p] = saved[p];
+      else delete require.cache[p];
+    }
+  }
+}
+
+const MINUTES = 2;
+const WINDOW_MS = MINUTES * 60 * 1000;
+const RETRY_MS = 15000; // must match IDLE_UNLOAD_RETRY_MS in main/pipeline.js
+
+// A settings fake whose idle window the test can change mid-run, as a real save
+// would. Everything else is whatever the pipeline happens to read.
+function fakeSettings(minutes = MINUTES) {
+  const value = { engines: { idleUnloadMinutes: minutes } };
+  return {
+    get: () => value,
+    set idleUnloadMinutes(m) {
+      value.engines.idleUnloadMinutes = m;
+    },
+  };
+}
+
+// An engines fake that reports whether the unload completed. `resident` flips
+// to false once a call is allowed to succeed, mirroring a busy worker draining.
+function fakeEngines(results) {
+  const calls = [];
+  return {
+    calls,
+    unloadIdle() {
+      calls.push(true);
+      // Consume one scripted result per call; the last one repeats.
+      return results.length > 1 ? results.shift() : results[0];
+    },
+  };
+}
+
+test("pipeline: idle unload fires once the configured window elapses", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const engines = fakeEngines([true]);
+  const pipeline = loadPipelineWith({ engines, settings: fakeSettings() });
+
+  pipeline.onSettingsChanged(); // arms the window (state is idle at load)
+  t.mock.timers.tick(WINDOW_MS - 1);
+  assert.strictEqual(engines.calls.length, 0, "must not evict before the window");
+
+  t.mock.timers.tick(1);
+  assert.strictEqual(engines.calls.length, 1, "evicts when the window elapses");
+
+  // A completed unload does not schedule anything else.
+  t.mock.timers.tick(WINDOW_MS * 2);
+  assert.strictEqual(engines.calls.length, 1, "a complete unload must not retry");
+});
+
+test("pipeline: a busy worker retries in seconds, not another full window", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  // First call finds a worker busy (a Settings "test transcribe"), then it drains.
+  const engines = fakeEngines([false, true]);
+  const pipeline = loadPipelineWith({ engines, settings: fakeSettings() });
+
+  pipeline.onSettingsChanged();
+  t.mock.timers.tick(WINDOW_MS);
+  assert.strictEqual(engines.calls.length, 1, "the window elapsed and found it busy");
+
+  t.mock.timers.tick(RETRY_MS - 1);
+  assert.strictEqual(engines.calls.length, 1, "the retry has not landed yet");
+
+  t.mock.timers.tick(1);
+  assert.strictEqual(engines.calls.length, 2, "the retry lands seconds later, not minutes");
+
+  // That one succeeded, so nothing further is scheduled.
+  t.mock.timers.tick(WINDOW_MS * 2);
+  assert.strictEqual(engines.calls.length, 2, "a successful retry ends the loop");
+});
+
+test("pipeline: a busy worker keeps retrying until it drains", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const engines = fakeEngines([false, false, false, true]);
+  const pipeline = loadPipelineWith({ engines, settings: fakeSettings() });
+
+  pipeline.onSettingsChanged();
+  t.mock.timers.tick(WINDOW_MS);
+  // Ticked one retry at a time: each retry is armed from inside the previous
+  // timer's callback, so a single large jump would not chain through them.
+  for (let i = 0; i < 3; i++) t.mock.timers.tick(RETRY_MS);
+  assert.strictEqual(engines.calls.length, 4, "one window plus three retries");
+
+  for (let i = 0; i < 5; i++) t.mock.timers.tick(RETRY_MS);
+  assert.strictEqual(engines.calls.length, 4, "stops once the worker is free");
+});
+
+test("pipeline: saving settings mid-retry keeps the short delay", (t) => {
+  // onSettingsChanged fires on every save, not just idle-window changes. It
+  // must not push a deferred worker back out to the full window.
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const engines = fakeEngines([false, true]);
+  const pipeline = loadPipelineWith({ engines, settings: fakeSettings() });
+
+  pipeline.onSettingsChanged();
+  t.mock.timers.tick(WINDOW_MS);
+  assert.strictEqual(engines.calls.length, 1, "found busy, retry armed");
+
+  pipeline.onSettingsChanged(); // an unrelated save lands inside the retry
+  t.mock.timers.tick(RETRY_MS);
+  assert.strictEqual(engines.calls.length, 2, "the retry still ran on the short delay");
+});
+
+test("pipeline: switching the idle window to 0 cancels a pending retry", (t) => {
+  // 0 means "keep models resident for the session" — it must win over a retry
+  // that was already armed.
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const engines = fakeEngines([false, true]);
+  const settings = fakeSettings();
+  const pipeline = loadPipelineWith({ engines, settings });
+
+  pipeline.onSettingsChanged();
+  t.mock.timers.tick(WINDOW_MS);
+  assert.strictEqual(engines.calls.length, 1, "found busy, retry armed");
+
+  settings.idleUnloadMinutes = 0;
+  pipeline.onSettingsChanged();
+  t.mock.timers.tick(WINDOW_MS * 2);
+  assert.strictEqual(engines.calls.length, 1, "0 must cancel the pending retry");
+});
+
+test("pipeline: an idle window of 0 never arms at all", (t) => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const engines = fakeEngines([true]);
+  const pipeline = loadPipelineWith({ engines, settings: fakeSettings(0) });
+
+  pipeline.onSettingsChanged();
+  t.mock.timers.tick(WINDOW_MS * 5);
+  assert.strictEqual(engines.calls.length, 0, "0 keeps models resident");
+});


### PR DESCRIPTION
Unloading the models after the idle window reclaimed **nothing**. Earheart sat on ~1 GB (STT alone) for the rest of the session.

## The bug

`unloadIdle()` sent `unload-stt` to the worker, and `disposeStt()` only nulls a JS reference. sherpa-onnx-node's `OfflineRecognizer` exposes no `free()` — its native memory waits on a V8 finalizer that an idle worker process never triggers.

Measured on Parakeet int8, through the app's exact load path:

```
after require            46 MB
loaded+decoded         1051 MB
t=0 after unload-stt   1051 MB
t=30s idle             1051 MB
```

A forced `global.gc()` gave back only ~300 MB of the 1051, and the cleanup worker's native allocators hold their pages the same way. So the setting promised "free memory (~1.5 GB or more)" and delivered none of it.

## The fix

Exit the worker process. Verified end to end under Electron:

```
STT worker RSS with Parakeet loaded:  786 MB
after idle eviction:                    0 MB   (process gone)
```

The cold re-load (~3–4s for Parakeet int8) is paid off the critical path — `startRecording()` already warms both engines as recording begins, so it lands under the time the user spends speaking.

## Two races this makes reachable

`stop()` previously only ran at quit, so neither mattered before:

- A killed worker's async `exit` could clear the state of the successor a new request had already forked. Every handler is now bound to its own `proc`, and `stop()` settles the pending map synchronously.
- A Settings "test transcribe" runs outside the pipeline's state machine, so the idle timer could kill it mid-request and surface a bare "engine process exited". A host with a request in flight is now skipped; its memory is reclaimed by the next idle window.

## Also

- Dropped the now-dead `unload-stt` / `unload-cleanup` worker handlers.
- The Settings hint now states the reload cost.

## Testing

- `npm test` — 214 pass, 1 skipped (the pre-existing network-gated one).
- `xvfb-run -a npx electron scripts/engine-smoke.js --no-sandbox` — passes, covering the refactored fork/kill path under real Electron.
- Ad-hoc Electron harness measuring the worker's `/proc` RSS across load → `stop()`, quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)