### PR TITLE
fix(live-preview): never cover a chunk that swallowed the words

### DIFF
--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -25,9 +25,9 @@
 // the preview display off (the overlay still commits chunks; nothing is
 // painted). Integrity is tracked per commit — each final chunk must start
 // exactly where decoded coverage ends (`fromSample === decodedSamples`), decode
-// successfully, and come back with text if the overlay heard speech in it
-// (`hasSpeech`), else the snapshot is marked broken and the final pass falls
-// back to the full decode. Never lose the user's words.
+// successfully, and come back with text unless the overlay is sure nobody spoke
+// in it (`hasSpeech === false`), else the snapshot is marked broken and the
+// final pass falls back to the full decode. Never lose the user's words.
 //
 // Dependencies are injected so the module stays free of the pipeline's private
 // session/state and is unit-testable:
@@ -169,7 +169,11 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
         // final transcript for good. Break the snapshot instead — the full
         // decode costs latency, losing the user's words costs the dictation.
         // (A silent chunk decoding to nothing is honest, and stays covered.)
-        const lostWords = !!hasSpeech && !text;
+        //
+        // Only an explicit `false` buys that coverage: a payload that lost the
+        // field on the way, or a renderer too old to send it, arrives as
+        // undefined and must not be read as a promise that nobody spoke.
+        const lostWords = !text && hasSpeech !== false;
         if (!broken && !lostWords && fromSample === decodedSamples && frames > 0) {
           decodedSamples = fromSample + frames;
         } else {

--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -24,9 +24,10 @@
 // audio tail instead of re-decoding the whole recording. That works even with
 // the preview display off (the overlay still commits chunks; nothing is
 // painted). Integrity is tracked per commit — each final chunk must start
-// exactly where decoded coverage ends (`fromSample === decodedSamples`) and
-// decode successfully, else the snapshot is marked broken and the final pass
-// falls back to the full decode. Never lose the user's words.
+// exactly where decoded coverage ends (`fromSample === decodedSamples`), decode
+// successfully, and come back with text if the overlay heard speech in it
+// (`hasSpeech`), else the snapshot is marked broken and the final pass falls
+// back to the full decode. Never lose the user's words.
 //
 // Dependencies are injected so the module stays free of the pipeline's private
 // session/state and is unit-testable:
@@ -128,7 +129,7 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
   // the last send of that chunk (commit it). A growing in-progress chunk arrives
   // as repeated non-final sends with the same seq. `fromSample` is the absolute
   // sample offset the chunk starts at — final assembly's contiguity check.
-  async function handleAudio(sid, { seq, final, fromSample, wav: wavArrayBuffer } = {}) {
+  async function handleAudio(sid, { seq, final, fromSample, hasSpeech, wav: wavArrayBuffer } = {}) {
     if (!isCurrent(sid)) return;
     const cfg = getSettings();
     if (cfg.stt.engine !== "builtin") return;
@@ -162,7 +163,14 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
         // out-of-order commit, an unparseable buffer) breaks the snapshot for
         // final assembly — the preview display above is unaffected.
         const frames = wavSampleFrames(wav);
-        if (!broken && fromSample === decodedSamples && frames > 0) {
+        // A chunk the overlay heard speech in that decodes to nothing is the
+        // same hole by another route: its samples would count as decoded and
+        // never be looked at again, so the words in them would be gone from the
+        // final transcript for good. Break the snapshot instead — the full
+        // decode costs latency, losing the user's words costs the dictation.
+        // (A silent chunk decoding to nothing is honest, and stays covered.)
+        const lostWords = !!hasSpeech && !text;
+        if (!broken && !lostWords && fromSample === decodedSamples && frames > 0) {
           decodedSamples = fromSample + frames;
         } else {
           broken = true;

--- a/main/pipeline.js
+++ b/main/pipeline.js
@@ -412,9 +412,11 @@ function init() {
   // `fromSample` must be forwarded: it is the contiguity check that lets the
   // committed chunk decodes stand in for the final transcript's prefix. Dropping
   // it marks every snapshot broken, so the final pass silently falls back to
-  // decoding the whole recording in one shot.
-  ipcMain.on("audio:partial", (event, { sid, seq, final, fromSample, wav } = {}) => {
-    livePreview.handleAudio(sid, { seq, final, fromSample, wav });
+  // decoding the whole recording in one shot. `hasSpeech` is the other half of
+  // that trust — without it a chunk that decoded to nothing is taken at its
+  // word and the speech inside it is never decoded again.
+  ipcMain.on("audio:partial", (event, { sid, seq, final, fromSample, hasSpeech, wav } = {}) => {
+    livePreview.handleAudio(sid, { seq, final, fromSample, hasSpeech, wav });
   });
 
   ipcMain.on("record:cancelled", (event, { sid } = {}) => {

--- a/renderer/overlay.html
+++ b/renderer/overlay.html
@@ -163,6 +163,7 @@
         </button>
       </div>
     </div>
+    <script src="speech-probe.js"></script>
     <script src="transcript.js"></script>
     <script src="overlay.js"></script>
   </body>

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -404,23 +404,6 @@ function flattenRange(chunks, from, to) {
 const QUIET_WINDOW_SEC = 0.3;
 const QUIET_RMS = 0.012;
 
-// Did anyone speak inside this committed chunk? The same silence test the
-// boundary detector uses, applied window by window across the whole chunk: any
-// window above QUIET_RMS means the chunk carries words. The main process pairs
-// this with the chunk's decode — audible speech that decodes to nothing is a
-// hole in the committed transcript, and those samples must not be marked
-// decoded (see main/live-preview.js).
-function rangeHasSpeech(samples) {
-  const windowSamples = Math.max(1, Math.floor(QUIET_WINDOW_SEC * SAMPLE_RATE));
-  for (let start = 0; start < samples.length; start += windowSamples) {
-    const end = Math.min(samples.length, start + windowSamples);
-    let sum = 0;
-    for (let i = start; i < end; i++) sum += samples[i] * samples[i];
-    if (Math.sqrt(sum / (end - start)) >= QUIET_RMS) return true;
-  }
-  return false;
-}
-
 // RMS of the trailing `windowSamples` recorded samples.
 function trailingRms(chunks, windowSamples) {
   let needed = windowSamples;
@@ -470,9 +453,12 @@ function sendPartial() {
     seq: recording.seq,
     final,
     fromSample: from,
+    // Did the user speak inside this chunk? Paired with the decode on the main
+    // side: speech in, no text out, means the words are still in the audio and
+    // it must be decoded again (see speech-probe.js and main/live-preview.js).
     // Only the committed send is assembled into the final transcript, so only
     // it needs the probe — an in-progress tick is replaceable cosmetics.
-    hasSpeech: final ? rangeHasSpeech(samples) : false,
+    hasSpeech: final ? containsSpeech(samples, SAMPLE_RATE) : false,
     wav: encodeWav([samples]),
   });
 

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -374,10 +374,10 @@ function totalSamples(chunks) {
   return n;
 }
 
-// Encode the recorded samples in [from, to) into a WAV. Walks the chunk list,
-// skipping samples before `from` and stopping at `to`, so we only ever encode
-// the slice the live preview needs — not the whole growing buffer.
-function encodeWavRange(chunks, from, to) {
+// Flatten the recorded samples in [from, to) into one buffer. Walks the chunk
+// list, skipping samples before `from` and stopping at `to`, so we only ever
+// touch the slice the live preview needs — not the whole growing buffer.
+function flattenRange(chunks, from, to) {
   const flat = new Float32Array(to - from);
   let pos = 0; // absolute sample index at the start of the current chunk
   let out = 0;
@@ -391,7 +391,7 @@ function encodeWavRange(chunks, from, to) {
     pos += chunk.length;
     if (pos >= to) break;
   }
-  return encodeWav([flat]);
+  return flat;
 }
 
 // A chunk boundary is only committed when the trailing QUIET_WINDOW_SEC of
@@ -403,6 +403,23 @@ function encodeWavRange(chunks, from, to) {
 // costs a little accuracy on one word rather than unbounded re-decode cost.
 const QUIET_WINDOW_SEC = 0.3;
 const QUIET_RMS = 0.012;
+
+// Did anyone speak inside this committed chunk? The same silence test the
+// boundary detector uses, applied window by window across the whole chunk: any
+// window above QUIET_RMS means the chunk carries words. The main process pairs
+// this with the chunk's decode — audible speech that decodes to nothing is a
+// hole in the committed transcript, and those samples must not be marked
+// decoded (see main/live-preview.js).
+function rangeHasSpeech(samples) {
+  const windowSamples = Math.max(1, Math.floor(QUIET_WINDOW_SEC * SAMPLE_RATE));
+  for (let start = 0; start < samples.length; start += windowSamples) {
+    const end = Math.min(samples.length, start + windowSamples);
+    let sum = 0;
+    for (let i = start; i < end; i++) sum += samples[i] * samples[i];
+    if (Math.sqrt(sum / (end - start)) >= QUIET_RMS) return true;
+  }
+  return false;
+}
 
 // RMS of the trailing `windowSamples` recorded samples.
 function trailingRms(chunks, windowSamples) {
@@ -447,13 +464,16 @@ function sendPartial() {
       trailingRms(recording.chunks, Math.floor(QUIET_WINDOW_SEC * SAMPLE_RATE)) < QUIET_RMS);
   if (!final && !livePreview.display) return;
 
-  const wav = encodeWavRange(recording.chunks, from, total);
+  const samples = flattenRange(recording.chunks, from, total);
   earheart.send("audio:partial", {
     sid: recording.sid,
     seq: recording.seq,
     final,
     fromSample: from,
-    wav,
+    // Only the committed send is assembled into the final transcript, so only
+    // it needs the probe — an in-progress tick is replaceable cosmetics.
+    hasSpeech: final ? rangeHasSpeech(samples) : false,
+    wav: encodeWav([samples]),
   });
 
   if (final) {

--- a/renderer/speech-probe.js
+++ b/renderer/speech-probe.js
@@ -1,0 +1,104 @@
+// Did this committed chunk carry words the decoder should have found?
+//
+// The main process pairs the answer with the chunk's decode: audible speech
+// that decodes to nothing is a hole in the committed transcript, and those
+// samples must not be marked decoded or the words in them are lost for good
+// (see main/live-preview.js). So the probe is deliberately asymmetric —
+// a false "speech" costs one full re-decode at stop, a false "silence" costs
+// the user a sentence. When in doubt, say speech.
+//
+// Two bars, either of which counts, checked window by window across the chunk:
+//
+//   absolute — a window at or above SPEECH_RMS is loud enough to be a voice on
+//     its own terms. This is what catches a normal mic.
+//   relative — a window standing SPEECH_OVER_FLOOR above the chunk's OWN noise
+//     floor is a voice rising out of whatever the room is doing. This is what
+//     catches a low-gain mic whose speech never reaches SPEECH_RMS at all;
+//     without it the probe fails exactly where the decoder is likeliest to
+//     return nothing.
+//
+// Both bars need SPEECH_MIN_SEC of audio to clear them before the chunk counts
+// as speech. A single click, a chair creak or one clipped sample is not a
+// sentence, and used to be enough to force a full re-decode of the recording.
+// Steady room tone clears neither bar: it is below SPEECH_RMS and it IS the
+// floor, so it never stands above itself.
+//
+// Kept in its own file (like transcript.js) so the arithmetic is unit-testable
+// without a DOM; overlay.html loads it as a plain script.
+
+// 0.3 s matches the pause detector's window — long enough to average out a
+// single glottal pulse, short enough that one word fills it.
+const SPEECH_WINDOW_SEC = 0.3;
+// Same value as the overlay's QUIET_RMS, kept separately on purpose: the pause
+// detector answers "may I cut here", this answers "were there words here", and
+// the two are free to move apart.
+const SPEECH_RMS = 0.012;
+// A voice sits about 10 dB over the room it is spoken in.
+const SPEECH_OVER_FLOOR = 3;
+// Below this everything is dither and dead air, whatever the floor computes to
+// — without it, digital silence would make every window "3x the floor".
+const SILENCE_RMS = 0.0015;
+// The shortest thing worth calling speech. A word, not a transient.
+const SPEECH_MIN_SEC = 0.6;
+
+// RMS per fixed-size window, in order. A chunk too short to hold one full
+// window is measured whole rather than skipped: reporting "no speech" because
+// there was no room to look is the one answer that loses words.
+function windowRmsSeries(samples, sampleRate) {
+  const size = Math.max(1, Math.floor(SPEECH_WINDOW_SEC * sampleRate));
+  const out = [];
+  for (let start = 0; start + size <= samples.length; start += size) {
+    let sum = 0;
+    for (let i = start; i < start + size; i++) sum += samples[i] * samples[i];
+    out.push(Math.sqrt(sum / size));
+  }
+  if (!out.length && samples.length) {
+    let sum = 0;
+    for (let i = 0; i < samples.length; i++) sum += samples[i] * samples[i];
+    out.push(Math.sqrt(sum / samples.length));
+  }
+  return out;
+}
+
+// The room, as this chunk shows it: the 10th-percentile window rather than the
+// minimum, so one freak-quiet window can't drag the floor down and turn steady
+// noise into "speech". In a chunk holding any pause at all this lands on the
+// pause; in one that is wall-to-wall speech it lands on speech, and the
+// absolute bar is what carries the verdict there.
+function noiseFloor(rmsSeries) {
+  const sorted = [...rmsSeries].sort((a, b) => a - b);
+  return sorted[Math.floor(0.1 * (sorted.length - 1))];
+}
+
+function containsSpeech(samples, sampleRate) {
+  const series = windowRmsSeries(samples, sampleRate);
+  if (!series.length) return false;
+  // Whichever bar is easier to clear — min() is how "either one counts" is
+  // spelled once the two bars are numbers.
+  const threshold = Math.min(
+    SPEECH_RMS,
+    Math.max(SILENCE_RMS, noiseFloor(series) * SPEECH_OVER_FLOOR)
+  );
+  // Never ask for more windows than the chunk has: a chunk shorter than
+  // SPEECH_MIN_SEC would otherwise be unable to report speech by arithmetic.
+  const needed = Math.max(
+    1,
+    Math.min(series.length, Math.round(SPEECH_MIN_SEC / SPEECH_WINDOW_SEC))
+  );
+  let loud = 0;
+  for (const rms of series) {
+    if (rms >= threshold && ++loud >= needed) return true;
+  }
+  return false;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    containsSpeech,
+    SPEECH_WINDOW_SEC,
+    SPEECH_RMS,
+    SPEECH_OVER_FLOOR,
+    SILENCE_RMS,
+    SPEECH_MIN_SEC,
+  };
+}

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -446,8 +446,9 @@ const wavOf = (frames) => {
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 };
 // A committed-chunk payload carrying its absolute start offset. `hasSpeech` is
-// the overlay's "someone spoke inside this chunk" probe; the default (absent,
-// i.e. silence) keeps the coverage tests below about contiguity alone.
+// the overlay's "someone spoke inside this chunk" probe; leaving it out means
+// no verdict, which is only consulted when a chunk decodes to nothing — so the
+// coverage tests below (which all decode to text) stay about contiguity alone.
 const finalChunk = (seq, fromSample, frames, hasSpeech) => ({
   seq,
   final: true,
@@ -513,6 +514,16 @@ test("a silent committed chunk that decodes to nothing stays covered", async () 
   assert.strictEqual(snap.broken, false, "nothing said, nothing lost");
   assert.strictEqual(snap.decodedSamples, 24000);
   assert.strictEqual(snap.committedRaw, "chunk one");
+});
+
+test("a committed chunk with no speech verdict is not trusted to be silent", async () => {
+  // The field went missing on the way (dropped from the payload, an older
+  // renderer). Absent is not "nobody spoke" — cover those samples on that and
+  // an empty decode silently eats the words again.
+  const h = harness();
+  h.setTranscribe(async () => "");
+  await h.lp.handleAudio(1, finalChunk(0, 0, 16000));
+  assert.strictEqual(h.lp.snapshotFinal().broken, true);
 });
 
 test("a speech-bearing chunk that decodes to whitespace only breaks the snapshot", async () => {

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -445,11 +445,14 @@ const wavOf = (frames) => {
   const buf = encodeWav(new Int16Array(frames));
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 };
-// A committed-chunk payload carrying its absolute start offset.
-const finalChunk = (seq, fromSample, frames) => ({
+// A committed-chunk payload carrying its absolute start offset. `hasSpeech` is
+// the overlay's "someone spoke inside this chunk" probe; the default (absent,
+// i.e. silence) keeps the coverage tests below about contiguity alone.
+const finalChunk = (seq, fromSample, frames, hasSpeech) => ({
   seq,
   final: true,
   fromSample,
+  hasSpeech,
   wav: wavOf(frames),
 });
 
@@ -484,6 +487,38 @@ test("a failed final-chunk decode breaks the snapshot", async () => {
     throw new Error("decode boom");
   });
   await h.lp.handleAudio(1, finalChunk(0, 0, 16000));
+  assert.strictEqual(h.lp.snapshotFinal().broken, true);
+});
+
+test("a committed chunk that heard speech but decoded to nothing breaks the snapshot", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "chunk zero");
+  await h.lp.handleAudio(1, finalChunk(0, 0, 16000, true));
+  // The words are audibly there, the decoder returned nothing: covering those
+  // samples would drop them from the final transcript for good.
+  h.setTranscribe(async () => "");
+  await h.lp.handleAudio(1, finalChunk(1, 16000, 16000, true));
+  const snap = h.lp.snapshotFinal();
+  assert.strictEqual(snap.broken, true, "speech in, no text out, is a hole");
+  assert.strictEqual(snap.decodedSamples, 16000, "the empty chunk is not covered");
+});
+
+test("a silent committed chunk that decodes to nothing stays covered", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "");
+  await h.lp.handleAudio(1, finalChunk(0, 0, 16000, false));
+  h.setTranscribe(async () => "chunk one");
+  await h.lp.handleAudio(1, finalChunk(1, 16000, 8000, true));
+  const snap = h.lp.snapshotFinal();
+  assert.strictEqual(snap.broken, false, "nothing said, nothing lost");
+  assert.strictEqual(snap.decodedSamples, 24000);
+  assert.strictEqual(snap.committedRaw, "chunk one");
+});
+
+test("a speech-bearing chunk that decodes to whitespace only breaks the snapshot", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "   ");
+  await h.lp.handleAudio(1, finalChunk(0, 0, 16000, true));
   assert.strictEqual(h.lp.snapshotFinal().broken, true);
 });
 

--- a/test/overlay-contract.test.js
+++ b/test/overlay-contract.test.js
@@ -33,6 +33,29 @@ test("every id overlay.js references exists in overlay.html", () => {
   assert.deepStrictEqual(missing, [], `overlay.html is missing ids: ${missing.join(", ")}`);
 });
 
+// overlay.js calls into its sibling renderer scripts (transcript.js for the
+// two-layer paint, speech-probe.js for the committed-chunk verdict) as plain
+// globals. A script tag dropped from the markup, or a file renamed, throws a
+// ReferenceError deep inside a commit — the preview goes blank and the final
+// pass quietly falls back to a full decode, with overlay-smoke still green.
+test("overlay.html loads every sibling script overlay.js calls into", () => {
+  const loaded = [...html.matchAll(/<script src="([a-z0-9.-]+)"><\/script>/g)].map((m) => m[1]);
+  assert.ok(loaded.includes("overlay.js"), "overlay.html must load overlay.js");
+
+  for (const src of loaded) {
+    assert.ok(fs.existsSync(path.join(RENDERER, src)), `overlay.html loads a missing ${src}`);
+  }
+  // Globals must be defined before overlay.js runs, so their tags come first.
+  const helpers = loaded.slice(0, loaded.indexOf("overlay.js"));
+  for (const { file, fn } of [
+    { file: "transcript.js", fn: "reconcileTranscript" },
+    { file: "speech-probe.js", fn: "containsSpeech" },
+  ]) {
+    assert.ok(new RegExp(`\\b${fn}\\(`).test(js), `overlay.js should call ${fn}()`);
+    assert.ok(helpers.includes(file), `overlay.html must load ${file} before overlay.js`);
+  }
+});
+
 test("overlay.css keeps the [hidden]-always-wins rule", () => {
   // overlay.js toggles the update prompt, its bar, its action pills and the
   // transcript through the hidden attribute; components that set their own

--- a/test/speech-probe.test.js
+++ b/test/speech-probe.test.js
@@ -1,0 +1,79 @@
+// Tests for the committed-chunk speech probe. Pure arithmetic over a sample
+// buffer (no DOM), so the renderer's "were there words in here" verdict — the
+// one that decides whether an empty decode is believed — can be exercised
+// directly.
+//
+// Every signal below alternates sign at full rate, so a buffer filled with
+// amplitude `a` has RMS exactly `a` and the thresholds can be reasoned about
+// as numbers rather than approximated.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { containsSpeech } = require("../renderer/speech-probe");
+
+const SAMPLE_RATE = 16000;
+
+// A `seconds`-long buffer at a constant RMS.
+function level(seconds, amplitude) {
+  const samples = new Float32Array(Math.floor(seconds * SAMPLE_RATE));
+  for (let i = 0; i < samples.length; i++) samples[i] = i % 2 ? amplitude : -amplitude;
+  return samples;
+}
+
+// Overwrite [fromSec, toSec) with a constant RMS — a sentence dropped into a
+// room, loud or quiet.
+function speakInto(samples, fromSec, toSec, amplitude) {
+  const a = Math.floor(fromSec * SAMPLE_RATE);
+  const b = Math.floor(toSec * SAMPLE_RATE);
+  for (let i = a; i < b; i++) samples[i] = i % 2 ? amplitude : -amplitude;
+  return samples;
+}
+
+test("digital silence carries no speech", () => {
+  assert.strictEqual(containsSpeech(level(12, 0), SAMPLE_RATE), false);
+});
+
+test("steady room tone carries no speech", () => {
+  // 0.007 RMS of air conditioning for the whole chunk: under the absolute bar,
+  // and it IS the floor, so it never stands above itself.
+  assert.strictEqual(containsSpeech(level(12, 0.007), SAMPLE_RATE), false);
+});
+
+test("a sentence at the end of a long silence carries speech", () => {
+  // The shape that broke: 11 s of thinking, then the tail nobody wants to lose.
+  const chunk = speakInto(level(12, 0.0002), 11, 12, 0.05);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), true);
+});
+
+test("a whole chunk of uninterrupted speech carries speech", () => {
+  // No pause anywhere, so the chunk's own floor sits at speech level and only
+  // the absolute bar can answer.
+  assert.strictEqual(containsSpeech(level(12, 0.05), SAMPLE_RATE), true);
+});
+
+test("a low-gain mic's speech carries speech", () => {
+  // 0.008 RMS never reaches the absolute bar — the old probe called this
+  // silence and let the empty decode cover it, losing the words.
+  const chunk = speakInto(level(12, 0.0008), 4, 6, 0.008);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), true);
+});
+
+test("a quiet voice over audible room tone carries speech", () => {
+  const chunk = speakInto(level(12, 0.002), 4, 6, 0.008);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), true);
+});
+
+test("a single loud transient does not carry speech", () => {
+  // 6 ms of keyboard at 0.5, well inside one window. Loud, but not a word —
+  // and calling it one would force a full re-decode of the whole recording.
+  const chunk = level(12, 0);
+  speakInto(chunk, 5.1, 5.106, 0.5);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), false);
+});
+
+test("a chunk too short to hold a window is still measured", () => {
+  // Never answer "no speech" because there was no room to look.
+  assert.strictEqual(containsSpeech(level(0.2, 0.05), SAMPLE_RATE), true);
+  assert.strictEqual(containsSpeech(level(0.2, 0), SAMPLE_RATE), false);
+});


### PR DESCRIPTION
## The bug

A dictation would sometimes come back missing its **last sentence** — and the missing words were absent from the stored `raw` transcript too, so this was never a cleanup problem.

`live-preview.js` marks a committed chunk's samples as decoded as soon as the chunk decodes, **whatever came back**:

```js
const frames = wavSampleFrames(wav);
if (!broken && fromSample === decodedSamples && frames > 0) {
  decodedSamples = fromSample + frames;   // advanced even when text === ""
}
```

When the decoder returned an empty string for a chunk that actually held speech, those 10–20 seconds counted as covered. The final pass then decoded only the audio *after* them, so the words inside were dropped for good. It shows up as a missing ending because the tail is exactly what commits in the pause right before you press stop.

## The fix

The overlay probes each committed chunk and ships the verdict as `hasSpeech` on `audio:partial`. The probe lives in `renderer/speech-probe.js` (following `transcript.js`, so the arithmetic is unit-testable without a DOM) and takes either of two bars, each needing 0.6 s of audio to clear it:

- **absolute** — a 0.3 s window at `SPEECH_RMS` is a voice on its own terms.
- **relative** — a window 3x the chunk's *own* noise floor is a voice rising out of the room. This is what catches a low-gain mic whose speech never reaches `SPEECH_RMS` — precisely where the decoder is likeliest to return nothing.

Steady room tone clears neither: it is below the absolute bar, and it *is* the floor, so it never stands above itself. A single keyboard click clears a bar but not the duration.

- **Speech in, no text out** → the snapshot is marked broken, so the final pass re-decodes the whole recording. Costs latency, keeps the user's words.
- **Silence in, no text out** → honest, stays covered. A thinking pause still keeps the tail-only fast path.

Only an explicit `hasSpeech === false` buys that coverage: a payload that lost the field, or a renderer too old to send it, arrives as `undefined` and is not read as a promise that nobody spoke.

## Verification

- `npm test` — 227 pass, 0 fail, 1 skipped. Four new cases in `test/live-preview.test.js` (speech-in-nothing-out breaks the snapshot, silence-in-nothing-out does not, whitespace-only counts as nothing, a *missing* verdict is not trusted as silence), eight in `test/speech-probe.test.js` over synthetic buffers, and a contract test that `overlay.html` loads the sibling scripts `overlay.js` calls into.
- `make overlay-smoke` — 29/29; the capture path is unchanged apart from `encodeWavRange` → `flattenRange` (the samples now feed both the WAV and the probe).
- The probe was run over real audio: a speech clip → `true`, digital silence → `false`, 0.007-RMS room noise → `false`, and 11 s of silence with a single sentence at the end → `true`.

## Still open (not in this PR)

Measured against the real Parakeet model while tracking this down:

- A tail shorter than ~1 s decodes to garbage — `"of the whole recording"` came back as `"O recarding"`.
- The word straddling a chunk boundary gets mangled when a noisy mic keeps the trailing-quiet test from ever passing, so the 20 s hard cap cuts mid-speech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
