### PR TITLE
fix(overlay): put a forced chunk boundary in the quietest moment

### DIFF
--- a/renderer/chunk-boundary.js
+++ b/renderer/chunk-boundary.js
@@ -1,0 +1,45 @@
+// Where to cut the current in-progress chunk when the hard cap forces a commit.
+//
+// A boundary that lands mid-word costs that word twice over: the committed
+// chunk decodes its start wrong and the next chunk starts inside it, and the
+// committed text is reused verbatim in the FINAL transcript, so the damage is
+// permanent (see main/live-preview.js). Measured against the shipped Parakeet
+// model, a cut through "so the chunk boundary lands" came back as "so the
+// chon." followed by "boundary land somewhere here" — a word lost and another
+// mangled.
+//
+// The soft trigger already waits for a pause, so it cuts in silence. The hard
+// cap fires *through* uninterrupted speech, and used to cut at whatever sample
+// the tick happened to land on. Instead, look back over the last few seconds
+// and cut at the end of the quietest window in there: the calmest moment
+// available, even when nothing in it is quiet enough to count as a pause.
+//
+// Kept in its own file (like transcript.js) so the arithmetic is unit-testable
+// without a DOM; overlay.html loads it as a plain script.
+
+// Offset just past the quietest `windowSamples`-long window of `samples`,
+// scanning every `hopSamples`. Ties go to the LATEST window, so a forced cut
+// stays as late as it can and the least possible audio moves into the next
+// chunk. Returns samples.length when the region is too short to hold a window
+// (nothing to choose from — cut where the caller already was).
+function quietestOffset(samples, windowSamples, hopSamples) {
+  if (!(windowSamples > 0) || !(hopSamples > 0)) return samples.length;
+  if (samples.length < windowSamples) return samples.length;
+  let best = Infinity;
+  let bestEnd = samples.length;
+  for (let start = 0; start + windowSamples <= samples.length; start += hopSamples) {
+    let sum = 0;
+    for (let i = start; i < start + windowSamples; i++) sum += samples[i] * samples[i];
+    const rms = Math.sqrt(sum / windowSamples);
+    // <= so a later window of equal energy wins (digital silence ties at 0).
+    if (rms <= best) {
+      best = rms;
+      bestEnd = start + windowSamples;
+    }
+  }
+  return bestEnd;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { quietestOffset };
+}

--- a/renderer/overlay.html
+++ b/renderer/overlay.html
@@ -163,6 +163,7 @@
         </button>
       </div>
     </div>
+    <script src="chunk-boundary.js"></script>
     <script src="speech-probe.js"></script>
     <script src="transcript.js"></script>
     <script src="overlay.js"></script>

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -403,6 +403,12 @@ function flattenRange(chunks, from, to) {
 // costs a little accuracy on one word rather than unbounded re-decode cost.
 const QUIET_WINDOW_SEC = 0.3;
 const QUIET_RMS = 0.012;
+// How far a forced boundary may move back to find a calmer place to cut, and
+// how finely that range is scanned. Three seconds is long enough to reach the
+// gap between two sentences at speaking pace, short enough that the audio
+// handed to the next chunk stays small.
+const BOUNDARY_SEARCH_SEC = 3;
+const BOUNDARY_HOP_SEC = 0.05;
 
 // RMS of the trailing `windowSamples` recorded samples.
 function trailingRms(chunks, windowSamples) {
@@ -441,13 +447,32 @@ function sendPartial() {
 
   const chunkSamples = (livePreview.chunkSeconds || 10) * SAMPLE_RATE;
   const liveSamples = total - from;
-  const final =
-    liveSamples >= chunkSamples * 2 ||
-    (liveSamples >= chunkSamples &&
-      trailingRms(recording.chunks, Math.floor(QUIET_WINDOW_SEC * SAMPLE_RATE)) < QUIET_RMS);
+  const windowSamples = Math.floor(QUIET_WINDOW_SEC * SAMPLE_RATE);
+  const paused =
+    liveSamples >= chunkSamples &&
+    trailingRms(recording.chunks, windowSamples) < QUIET_RMS;
+  const forced = !paused && liveSamples >= chunkSamples * 2;
+  const final = paused || forced;
   if (!final && !livePreview.display) return;
 
-  const samples = flattenRange(recording.chunks, from, total);
+  // A pause-triggered boundary is already sitting in silence. A forced one is
+  // cutting through speech, so it moves back to the quietest window in the last
+  // BOUNDARY_SEARCH_SEC instead of splitting whatever word is being said right
+  // now (see chunk-boundary.js). Everything after the boundary stays live and
+  // is re-sent with the next chunk, so nothing is skipped either way.
+  let boundary = total;
+  if (forced) {
+    const searchFrom = Math.max(from + chunkSamples, total - BOUNDARY_SEARCH_SEC * SAMPLE_RATE);
+    boundary =
+      searchFrom +
+      quietestOffset(
+        flattenRange(recording.chunks, searchFrom, total),
+        windowSamples,
+        Math.floor(BOUNDARY_HOP_SEC * SAMPLE_RATE)
+      );
+  }
+
+  const samples = flattenRange(recording.chunks, from, final ? boundary : total);
   earheart.send("audio:partial", {
     sid: recording.sid,
     seq: recording.seq,
@@ -464,7 +489,7 @@ function sendPartial() {
 
   if (final) {
     // Freeze this chunk: future ticks send only audio recorded after it.
-    recording.committedSamples = total;
+    recording.committedSamples = boundary;
     recording.seq += 1;
   }
 }

--- a/test/chunk-boundary.test.js
+++ b/test/chunk-boundary.test.js
@@ -1,0 +1,75 @@
+// Tests for the forced chunk boundary chooser. Pure arithmetic over a sample
+// buffer (no DOM), so the renderer's decision about where to cut through
+// uninterrupted speech can be exercised directly.
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { quietestOffset } = require("../renderer/chunk-boundary");
+
+const SAMPLE_RATE = 16000;
+const WINDOW = Math.floor(0.3 * SAMPLE_RATE);
+const HOP = Math.floor(0.05 * SAMPLE_RATE);
+
+// A speech-ish region: loud everywhere except the gaps, which are near silent.
+// `gaps` are [startSec, endSec] pairs inside a `seconds`-long buffer.
+function region(seconds, gaps = []) {
+  const samples = new Float32Array(Math.floor(seconds * SAMPLE_RATE));
+  for (let i = 0; i < samples.length; i++) samples[i] = i % 2 ? 0.25 : -0.25;
+  for (const [from, to] of gaps) {
+    const a = Math.floor(from * SAMPLE_RATE);
+    const b = Math.floor(to * SAMPLE_RATE);
+    for (let i = a; i < b; i++) samples[i] = 0;
+  }
+  return samples;
+}
+
+const atSec = (offset) => offset / SAMPLE_RATE;
+
+test("a forced boundary lands in the gap between words, not on the last sample", () => {
+  // Three seconds of speech with a half-second breath at 1.5s.
+  const offset = quietestOffset(region(3, [[1.5, 2.0]]), WINDOW, HOP);
+  assert.ok(
+    atSec(offset) > 1.5 && atSec(offset) <= 2.0,
+    `expected a cut inside the 1.5-2.0s gap, got ${atSec(offset)}s`
+  );
+});
+
+test("the latest of several equally quiet gaps wins", () => {
+  // Cutting as late as possible keeps the audio handed to the next chunk small.
+  const offset = quietestOffset(region(3, [[0.5, 1.0], [2.2, 2.7]]), WINDOW, HOP);
+  assert.ok(
+    atSec(offset) > 2.2 && atSec(offset) <= 2.7,
+    `expected the later gap, got ${atSec(offset)}s`
+  );
+});
+
+test("unbroken speech cuts where the caller already was", () => {
+  const samples = region(3);
+  assert.strictEqual(quietestOffset(samples, WINDOW, HOP), samples.length);
+});
+
+test("a quieter passage wins even when nothing in range is silent", () => {
+  // No gap crosses the silence threshold; the chooser still finds the calmest
+  // stretch, which is the whole point on a noisy mic.
+  const samples = region(3);
+  for (let i = Math.floor(1.0 * SAMPLE_RATE); i < Math.floor(1.4 * SAMPLE_RATE); i++) {
+    samples[i] = samples[i] > 0 ? 0.05 : -0.05;
+  }
+  const offset = quietestOffset(samples, WINDOW, HOP);
+  assert.ok(
+    atSec(offset) > 1.0 && atSec(offset) <= 1.4,
+    `expected the calmest stretch, got ${atSec(offset)}s`
+  );
+});
+
+test("a region too short to hold a window is left alone", () => {
+  const samples = region(0.2);
+  assert.strictEqual(quietestOffset(samples, WINDOW, HOP), samples.length);
+});
+
+test("a degenerate window or hop is left alone rather than dividing by zero", () => {
+  const samples = region(3, [[1.0, 1.5]]);
+  assert.strictEqual(quietestOffset(samples, 0, HOP), samples.length);
+  assert.strictEqual(quietestOffset(samples, WINDOW, 0), samples.length);
+});

--- a/test/overlay-contract.test.js
+++ b/test/overlay-contract.test.js
@@ -48,6 +48,7 @@ test("overlay.html loads every sibling script overlay.js calls into", () => {
   // Globals must be defined before overlay.js runs, so their tags come first.
   const helpers = loaded.slice(0, loaded.indexOf("overlay.js"));
   for (const { file, fn } of [
+    { file: "chunk-boundary.js", fn: "quietestOffset" },
     { file: "transcript.js", fn: "reconcileTranscript" },
     { file: "speech-probe.js", fn: "containsSpeech" },
   ]) {


### PR DESCRIPTION
> Stacked on #103 (same file, adjacent lines). GitHub retargets this to `main` once #103 merges.

## The bug

A chunk boundary is committed either when the dictation **pauses** (trailing 0.3 s below `QUIET_RMS`) or when the **hard cap** fires after 2× the chunk length of uninterrupted speech. The pause path cuts in silence. The cap path cut at whatever sample the tick happened to land on — usually mid-word.

That word is then decoded wrong twice: the committed chunk ends inside it, and the next chunk starts inside it. Because committed chunk text is reused verbatim in the final transcript, the damage is permanent — no later pass re-reads that audio.

It fires most on a noisy mic, where the trailing-quiet test never passes and *every* boundary is a forced one.

## Measured, against the shipped Parakeet model

Reference (one decode of the whole clip):

> …Now I will keep talking for a while longer so the chunk boundary lands somewhere here. And this is the very last sentence…

**Before** — cap fires at 15.00 s:

```
chunk: …Now I will keep talking for a while longer so the chon.
tail : boundary land somewhere here. And this is the very last sentence…
```

`chunk` is destroyed and `lands` is mangled.

**After** — boundary moves back to the quietest window, 12.60 s:

```
chunk: …Now I will keep
tail : Talking for a while longer so the chunk boundary lands somewhere here. And this is the very last sentence…
```

Every word intact. The joint leaves a stray capital (`keep Talking`) that the cleanup pass normalises; with cleanup off it is a capitalisation artifact, which is a fair trade for not losing the word.

## The change

`renderer/chunk-boundary.js` — `quietestOffset()`: scan the last 3 s in 0.3 s windows at a 0.05 s hop, cut at the end of the quietest one. Ties go to the latest window, so the cut stays as late as it can. Own file, like `transcript.js`, so the arithmetic is unit-testable without a DOM.

Only forced boundaries move; a pause-triggered boundary is already sitting in silence and is untouched. Nothing is skipped: audio after the boundary stays live and ships with the next chunk.

Note it degrades gracefully — when nothing in range is quiet it still picks the calmest stretch rather than giving up, which is exactly the noisy-mic case.

## Verification

- `npm test` — 223 pass, 0 fail; 6 new cases (cut lands in the gap, latest of equal gaps wins, unbroken speech cuts where it already was, calmest-stretch fallback, too-short region, degenerate window/hop).
- `make overlay-smoke` — 29/29.
- The before/after above is a real decode through `sherpa-onnx-node` with the real model, driving this PR's `quietestOffset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)