### PR TITLE
fix(live-preview): stop a forced chunk boundary un-painting words

### DIFF
--- a/main/live-preview.js
+++ b/main/live-preview.js
@@ -45,6 +45,38 @@ function joinText(a, b) {
   return `${a} ${b}`;
 }
 
+// Words compared for content only: two decodes of the same audio agree on the
+// words but not always on their capitalization or punctuation.
+function normWord(w) {
+  return w.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+// The part of the in-progress decode that a commit did NOT take over.
+//
+// A forced boundary cuts BEHIND the audio the last in-progress tick already
+// painted — the overlay moves it back to the quietest moment in the preceding
+// seconds (see renderer/overlay.js) — so `committed`, the decode of the chunk
+// up to that boundary, stops short of `live`, the decode of everything recorded
+// at the last tick. Dropping the live tail outright would blink those trailing
+// words off the overlay until the next tick decoded them again; this keeps them
+// on screen until the next in-progress decode replaces them for real.
+//
+// Text is the only thing the two decodes can be aligned on (they share audio,
+// not offsets), so the leftover is trusted only when one word sequence really is
+// a prefix of the other. Any disagreement over the shared words means the
+// alignment is guesswork, and a wrong guess would duplicate words on screen —
+// so that falls back to "", the same one-tick blink as before.
+function residualTail(live, committed) {
+  if (!live) return "";
+  const liveWords = live.split(/\s+/);
+  const committedWords = committed ? committed.split(/\s+/) : [];
+  const shared = Math.min(liveWords.length, committedWords.length);
+  for (let i = 0; i < shared; i++) {
+    if (normWord(liveWords[i]) !== normWord(committedWords[i])) return "";
+  }
+  return liveWords.slice(committedWords.length).join(" ");
+}
+
 function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettings, isCurrent, onError }) {
   const reportError = onError || (() => {});
   // Count rather than a flag: a committed-chunk decode may legitimately overlap
@@ -62,6 +94,8 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
   // so decode cost stays flat however long the dictation runs.
   let committedRaw = ""; // text from finalized chunks (never re-decoded)
   let liveRaw = ""; // decode of the current in-progress chunk (replaced each tick)
+  // On commit it is not cleared but cut back to whatever the committed chunk
+  // left over (see residualTail), so a forced boundary can't un-paint words.
   let lastSeq = -1; // highest chunk seq we've committed
   // Final-assembly bookkeeping: committedRaw covers exactly the recording's
   // first `decodedSamples` samples — unless `broken`, which flags any hole in
@@ -154,10 +188,12 @@ function createLivePreview({ runTranscribe, runCleanup, sendToOverlay, getSettin
       const text = (raw || "").trim();
 
       if (final && seq > lastSeq) {
-        // Freeze this chunk into the committed transcript and start fresh.
+        // Freeze this chunk into the committed transcript and start fresh —
+        // keeping any painted words the chunk's boundary stopped short of, so
+        // the preview only ever grows.
         lastSeq = seq;
         committedRaw = joinText(committedRaw, text);
-        liveRaw = "";
+        liveRaw = residualTail(liveRaw, text);
         // Contiguous coverage only: the chunk must start exactly where decoded
         // coverage ends. Anything else (an earlier final dropped or failed, an
         // out-of-order commit, an unparseable buffer) breaks the snapshot for

--- a/test/live-preview.test.js
+++ b/test/live-preview.test.js
@@ -102,6 +102,79 @@ test("a growing in-progress chunk replaces only the live tail", async () => {
   assert.strictEqual(lastRaw(h), "alpha beta gamma", "tail replaced, commit preserved");
 });
 
+// A FORCED chunk boundary (the hard cap, cutting through speech) is moved back
+// to the quietest moment in the preceding seconds, so the committed chunk stops
+// short of the audio the last in-progress tick already painted. Those trailing
+// words are in no accumulator, so clearing the live tail on commit would blink
+// them off the overlay for a tick. They're kept instead.
+test("a commit that stops short of the live decode keeps the words it left over", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown fox jumps");
+  await h.lp.handleAudio(1, chunk(0, false));
+  // The forced boundary lands after "brown": the committed chunk decodes to
+  // less than what's on screen.
+  h.setTranscribe(async () => "the quick brown");
+  await h.lp.handleAudio(1, chunk(0, true));
+  assert.strictEqual(lastRaw(h), "the quick brown fox jumps", "nothing blinked off");
+});
+
+test("the next in-progress decode replaces the leftover tail, not appends to it", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown fox jumps");
+  await h.lp.handleAudio(1, chunk(0, false));
+  h.setTranscribe(async () => "the quick brown");
+  await h.lp.handleAudio(1, chunk(0, true));
+  h.setTranscribe(async () => "fox jumps over");
+  await h.lp.handleAudio(1, chunk(1, false));
+  assert.strictEqual(lastRaw(h), "the quick brown fox jumps over");
+});
+
+test("a commit covering the whole live decode leaves no leftover to duplicate", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown");
+  await h.lp.handleAudio(1, chunk(0, false));
+  await h.lp.handleAudio(1, chunk(0, true)); // pause boundary: same audio, same text
+  assert.strictEqual(lastRaw(h), "the quick brown");
+});
+
+test("a commit longer than the live decode leaves no leftover", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick");
+  await h.lp.handleAudio(1, chunk(0, false)); // an older, shorter tick
+  h.setTranscribe(async () => "the quick brown fox");
+  await h.lp.handleAudio(1, chunk(0, true));
+  assert.strictEqual(lastRaw(h), "the quick brown fox");
+});
+
+test("the leftover survives cleanup's capitalization and punctuation of the shared words", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown fox jumps");
+  await h.lp.handleAudio(1, chunk(0, false));
+  h.setTranscribe(async () => "The quick, brown.");
+  await h.lp.handleAudio(1, chunk(0, true));
+  assert.strictEqual(lastRaw(h), "The quick, brown. fox jumps");
+});
+
+test("decodes that disagree on the shared words drop the leftover instead of guessing", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown fox jumps");
+  await h.lp.handleAudio(1, chunk(0, false));
+  h.setTranscribe(async () => "the quick brawn");
+  await h.lp.handleAudio(1, chunk(0, true));
+  assert.strictEqual(lastRaw(h), "the quick brawn", "no duplicated words");
+});
+
+test("a stale in-progress result for a committed seq does not disturb the leftover", async () => {
+  const h = harness();
+  h.setTranscribe(async () => "the quick brown fox jumps");
+  await h.lp.handleAudio(1, chunk(0, false));
+  h.setTranscribe(async () => "the quick brown");
+  await h.lp.handleAudio(1, chunk(0, true));
+  h.setTranscribe(async () => "the quick brown fox jumps over");
+  await h.lp.handleAudio(1, chunk(0, false)); // seq 0 is already committed
+  assert.strictEqual(lastRaw(h), "the quick brown fox jumps");
+});
+
 test("handleAudio drops the partial when the session isn't current", async () => {
   const h = harness({ current: false });
   await h.lp.handleAudio(1, chunk(0, false));


### PR DESCRIPTION
## What

When the hard cap forces a chunk boundary, up to ~2.7 s of already-displayed preview text vanished from the overlay for one tick and then reappeared.

#104 moved a forced boundary back to the quietest window in the last 3 s, so the committed chunk now covers *less* audio than the last in-progress tick had already painted. The commit path still cleared `liveRaw` outright, and the words between `boundary` and `total` were in no accumulator — so they blinked off until the next decode.

## How

On commit, cut the live tail back to what the committed decode didn't take over instead of clearing it (`residualTail`). The next in-progress decode replaces it for real.

The two decodes share audio, not sample offsets, so they're aligned by word content (normalized for case and punctuation) and the leftover is trusted **only** when one word sequence is a prefix of the other. Any disagreement falls back to `""` — the old one-tick blink, rather than a guess that duplicates words on screen.

Display-only: `committedRaw`, the final-assembly snapshot (`snapshotFinal`) and the cleanup path are untouched. No words can be lost by this.

## Tests

7 new cases in `test/live-preview.test.js` covering: the leftover is kept, the next tick replaces (not appends to) it, a pause commit covering the whole live decode leaves nothing to duplicate, a commit longer than the live decode, punctuation/capitalization differences on the shared words, disagreeing decodes drop the leftover, and a stale in-progress result for a committed seq leaves it alone. Three of them fail without the fix.

Ran locally, all green:

- `npm test` — 251 pass, 0 fail
- `make smoke`
- `npx electron scripts/engine-smoke.js`
- `npx electron scripts/overlay-smoke.js` — 29/29
- `npx electron scripts/settings-smoke.js` — 15/15

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)