### PR TITLE
chore(speech-probe): trim exports, dedupe RMS, pin the thresholds

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules

--- a/renderer/overlay.js
+++ b/renderer/overlay.js
@@ -473,17 +473,17 @@ function sendPartial() {
   }
 
   const samples = flattenRange(recording.chunks, from, final ? boundary : total);
+  // Did the user speak inside this chunk? Paired with the decode on the main
+  // side: speech in, no text out, means the words are still in the audio and it
+  // must be decoded again (see speech-probe.js and main/live-preview.js).
+  // Probed for committed chunks only — the rule lives in speech-probe.js.
+  const hasSpeech = chunkSpeechVerdict(final, samples, SAMPLE_RATE);
   earheart.send("audio:partial", {
     sid: recording.sid,
     seq: recording.seq,
     final,
     fromSample: from,
-    // Did the user speak inside this chunk? Paired with the decode on the main
-    // side: speech in, no text out, means the words are still in the audio and
-    // it must be decoded again (see speech-probe.js and main/live-preview.js).
-    // Only the committed send is assembled into the final transcript, so only
-    // it needs the probe — an in-progress tick is replaceable cosmetics.
-    hasSpeech: final ? containsSpeech(samples, SAMPLE_RATE) : false,
+    hasSpeech,
     wav: encodeWav([samples]),
   });
 

--- a/renderer/speech-probe.js
+++ b/renderer/speech-probe.js
@@ -93,6 +93,16 @@ function containsSpeech(samples, sampleRate) {
   return false;
 }
 
+// The verdict that ships with a chunk on `audio:partial`. Only a committed
+// chunk is assembled into the final transcript, so only it is worth probing —
+// an in-progress tick is replaceable cosmetics, and probing one would run this
+// scan over the growing live buffer on every interval for an answer nobody
+// reads. Kept here rather than inline at the send site so the "committed only"
+// rule is testable.
+function chunkSpeechVerdict(final, samples, sampleRate) {
+  return final ? containsSpeech(samples, sampleRate) : false;
+}
+
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = { containsSpeech };
+  module.exports = { containsSpeech, chunkSpeechVerdict };
 }

--- a/renderer/speech-probe.js
+++ b/renderer/speech-probe.js
@@ -94,12 +94,5 @@ function containsSpeech(samples, sampleRate) {
 }
 
 if (typeof module !== "undefined" && module.exports) {
-  module.exports = {
-    containsSpeech,
-    SPEECH_WINDOW_SEC,
-    SPEECH_RMS,
-    SPEECH_OVER_FLOOR,
-    SILENCE_RMS,
-    SPEECH_MIN_SEC,
-  };
+  module.exports = { containsSpeech };
 }

--- a/renderer/speech-probe.js
+++ b/renderer/speech-probe.js
@@ -41,6 +41,13 @@ const SILENCE_RMS = 0.0015;
 // The shortest thing worth calling speech. A word, not a transient.
 const SPEECH_MIN_SEC = 0.6;
 
+// Root mean square of samples in [from, to).
+function rms(samples, from, to) {
+  let sum = 0;
+  for (let i = from; i < to; i++) sum += samples[i] * samples[i];
+  return Math.sqrt(sum / (to - from));
+}
+
 // RMS per fixed-size window, in order. A chunk too short to hold one full
 // window is measured whole rather than skipped: reporting "no speech" because
 // there was no room to look is the one answer that loses words.
@@ -48,15 +55,9 @@ function windowRmsSeries(samples, sampleRate) {
   const size = Math.max(1, Math.floor(SPEECH_WINDOW_SEC * sampleRate));
   const out = [];
   for (let start = 0; start + size <= samples.length; start += size) {
-    let sum = 0;
-    for (let i = start; i < start + size; i++) sum += samples[i] * samples[i];
-    out.push(Math.sqrt(sum / size));
+    out.push(rms(samples, start, start + size));
   }
-  if (!out.length && samples.length) {
-    let sum = 0;
-    for (let i = 0; i < samples.length; i++) sum += samples[i] * samples[i];
-    out.push(Math.sqrt(sum / samples.length));
-  }
+  if (!out.length && samples.length) out.push(rms(samples, 0, samples.length));
   return out;
 }
 
@@ -86,8 +87,8 @@ function containsSpeech(samples, sampleRate) {
     Math.min(series.length, Math.round(SPEECH_MIN_SEC / SPEECH_WINDOW_SEC))
   );
   let loud = 0;
-  for (const rms of series) {
-    if (rms >= threshold && ++loud >= needed) return true;
+  for (const windowRms of series) {
+    if (windowRms >= threshold && ++loud >= needed) return true;
   }
   return false;
 }

--- a/test/overlay-contract.test.js
+++ b/test/overlay-contract.test.js
@@ -50,7 +50,7 @@ test("overlay.html loads every sibling script overlay.js calls into", () => {
   for (const { file, fn } of [
     { file: "chunk-boundary.js", fn: "quietestOffset" },
     { file: "transcript.js", fn: "reconcileTranscript" },
-    { file: "speech-probe.js", fn: "containsSpeech" },
+    { file: "speech-probe.js", fn: "chunkSpeechVerdict" },
   ]) {
     assert.ok(new RegExp(`\\b${fn}\\(`).test(js), `overlay.js should call ${fn}()`);
     assert.ok(helpers.includes(file), `overlay.html must load ${file} before overlay.js`);

--- a/test/speech-probe.test.js
+++ b/test/speech-probe.test.js
@@ -72,6 +72,34 @@ test("a single loud transient does not carry speech", () => {
   assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), false);
 });
 
+// The two cases below pin decision boundaries rather than comfortable
+// middles. Both were checked by mutation: without them, tightening the
+// threshold comparison to `>` or raising the window minimum to 3 leaves the
+// whole suite green.
+
+test("a window landing exactly on the threshold counts as speech", () => {
+  // 0.001953125 is 2^-9, so every RMS below is computed exactly: a window of
+  // constant magnitude f has RMS exactly f, and one at 3f has RMS exactly 3f.
+  // The room is f throughout, so the relative bar sits at exactly 3f — the
+  // loud windows land ON the threshold, not above it.
+  const floorAmp = 0.001953125;
+  const chunk = level(12, floorAmp);
+  speakInto(chunk, 0, 0.6, 3 * floorAmp);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), true);
+});
+
+test("two loud windows are speech, one is not", () => {
+  // 0.3 s windows: [0, 0.6) is exactly two, [0, 0.3) exactly one. The bar is
+  // 0.6 s of audio, so two clears it and one must not — in both directions.
+  const two = level(12, 0);
+  speakInto(two, 0, 0.6, 0.05);
+  assert.strictEqual(containsSpeech(two, SAMPLE_RATE), true);
+
+  const one = level(12, 0);
+  speakInto(one, 0, 0.3, 0.05);
+  assert.strictEqual(containsSpeech(one, SAMPLE_RATE), false);
+});
+
 test("a chunk too short to hold a window is still measured", () => {
   // Never answer "no speech" because there was no room to look.
   assert.strictEqual(containsSpeech(level(0.2, 0.05), SAMPLE_RATE), true);

--- a/test/speech-probe.test.js
+++ b/test/speech-probe.test.js
@@ -10,7 +10,7 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
 
-const { containsSpeech } = require("../renderer/speech-probe");
+const { containsSpeech, chunkSpeechVerdict } = require("../renderer/speech-probe");
 
 const SAMPLE_RATE = 16000;
 
@@ -104,4 +104,16 @@ test("a chunk too short to hold a window is still measured", () => {
   // Never answer "no speech" because there was no room to look.
   assert.strictEqual(containsSpeech(level(0.2, 0.05), SAMPLE_RATE), true);
   assert.strictEqual(containsSpeech(level(0.2, 0), SAMPLE_RATE), false);
+});
+
+// The send site ships this verdict on `audio:partial`; only the committed
+// chunk is assembled into the final transcript, so only it is probed.
+test("only a committed chunk is probed", () => {
+  const speech = level(12, 0.05);
+  const silence = level(12, 0);
+  assert.strictEqual(chunkSpeechVerdict(true, speech, SAMPLE_RATE), true);
+  assert.strictEqual(chunkSpeechVerdict(true, silence, SAMPLE_RATE), false);
+  // An in-progress tick answers false without looking — probing the growing
+  // live buffer every interval would burn the scan for an answer nobody reads.
+  assert.strictEqual(chunkSpeechVerdict(false, speech, SAMPLE_RATE), false);
 });


### PR DESCRIPTION
Follow-ups from a review pass over #103, which merged before these landed. No behavior change — the probe answers exactly what it answered before.

## What changed

- **`refactor`** — `windowRmsSeries` spelled `sqrt(sum-of-squares/count)` twice, once for the window loop and once for the whole-buffer fallback, differing only in bounds. One `rms(samples, from, to)` covers both.
- **`chore`** — the five threshold constants were exported but nothing required them. `transcript.js` and `hotkey-capture.js` each export exactly their one public function; match that.
- **`test`** — two boundary cases. The suite exercised comfortable middles only: mutating the comparison to `>` or raising the window minimum to three left all nine cases green. The first new case builds the room out of `2^-9`, so every window RMS is computed exactly and the loud windows land **on** the relative bar rather than above it. The second uses spans of exactly one and exactly two 0.3 s windows, pinning the 0.6 s minimum from both sides.
- **`test`** — the "probe committed chunks only" rule moved from an inline ternary at the send site into `speech-probe.js`, where it can be tested. Nothing covered it before: `overlay.js` has no unit test, the contract test only checks the call appears, and overlay-smoke starts with `livePreview` disabled, which leaves `sendPartial` unscheduled entirely.

## One wrinkle worth knowing

The verdict is computed into a local before `earheart.send` rather than inline in the payload. `ipc-contract.test.js` reads the send site's object literal to compare its keys against main's destructure, and a multi-argument call inside that literal reads as a payload key — `SAMPLE_RATE` was reported as a dropped field until the call moved out.

## Verification

- `npm test` — 247 pass, 0 fail, 1 skipped.
- `make overlay-smoke` — 29/29.
- The two new threshold cases were mutation-checked: `>=` → `>` and window minimum 2 → 3 both fail now, and both passed before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)