### PR TITLE
fix: untrack the node_modules symlink committed to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Node
-node_modules/
+node_modules
 dist/
 npm-debug.log*
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules


### PR DESCRIPTION
## What

`main` currently carries `node_modules` as a **tracked symlink pointing at its own absolute path**:

```
$ git ls-tree HEAD node_modules
120000 blob ebb9060	node_modules

$ git cat-file -p HEAD:node_modules
/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules
```

Added by `11a8501` ("test(speech-probe): pin the threshold and the window minimum") on `chore/speech-probe-followups`, merged in #107. It is on `main` and in the v0.28.3 draft.

## Why it matters

A fresh clone gets a self-referencing symlink where the dependency tree is supposed to go. Every access to it fails with `ELOOP`:

```
$ ls node_modules
ls: 'node_modules': Too many levels of symbolic links

$ node -e "require.resolve('electron')"
Error: Cannot find module 'electron'
```

That takes out `npm ci`, `require.resolve`, and anything that walks the tree. I hit it for real on this machine — the local suite went from 251 passing to 19 failures (every test that stubs Electron: `pipeline.test.js`, `host.test.js`, `engines.test.js`) until I removed it.

It also bakes a contributor's home directory path into the repository.

CI stayed green because the runner's `npm ci` rebuilds the tree over the top, so the breakage only shows up on a real checkout — which is the worst place for it to be discovered.

## How

1. `git rm --cached node_modules` — untrack the symlink and delete it from the working tree.
2. `.gitignore:2` — `node_modules/` → `node_modules`.

The trailing slash is the root cause: it matches **directories only**, so a symlink by that name was never ignored and `git add -A` swept it straight in. Without the slash the name is ignored whatever it happens to be, so this cannot recur.

## Tests

```
npm test    # 255 tests, 254 pass, 1 skipped, 0 fail
```

Verified the ignore rule now covers it:

```
$ git check-ignore -v node_modules
.gitignore:2:node_modules	node_modules
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)