### PR TITLE
fix(engines): don't mistake a cold model load for an idle worker

### DIFF
--- a/main/engines/index.js
+++ b/main/engines/index.js
@@ -242,11 +242,19 @@ function stopIfIdle(host) {
 // already elapsed, so nothing would re-arm it and that worker would stay
 // resident for the rest of the session.
 //
+// The busy check has to run even when the loaded-model flag says there is
+// nothing to reclaim. That flag is only set once a load RESOLVES (see
+// ensureStt), so for the several seconds a cold load takes it reads null while
+// the worker is very much working — and a `loaded === null` short-circuit would
+// skip the worker without reporting it, leaving the model resident with no
+// timer armed behind it. Ask the host directly instead: null AND idle is the
+// only combination that means "nothing to do here".
+//
 // @returns {boolean} true when nothing resident is left, false when a busy
 // worker was skipped and the caller should come back for it.
 function unloadIdle() {
-  const sttClear = loadedStt === null || stopIfIdle(sttHost);
-  const cleanupClear = loadedCleanup === null || stopIfIdle(cleanupHost);
+  const sttClear = (loadedStt === null && !sttHost.busy()) || stopIfIdle(sttHost);
+  const cleanupClear = (loadedCleanup === null && !cleanupHost.busy()) || stopIfIdle(cleanupHost);
   return sttClear && cleanupClear;
 }
 

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -790,6 +790,50 @@ test("unloadIdle reports success when there is nothing resident to skip", async 
   assert.ok(stt.stopped);
 });
 
+test("a worker mid cold-load is skipped and reported, not counted as idle", async () => {
+  // The loaded-model flag is only set once `load-stt` RESOLVES (see ensureStt),
+  // so for the seconds a cold load takes it still reads null while the worker is
+  // busy. Short-circuiting on the flag would report a COMPLETE unload for a
+  // worker that was never even asked whether it was busy — and main/pipeline.js
+  // re-arms its retry only when unloadIdle() comes back false, so the model
+  // would finish loading and sit resident with no timer behind it.
+  const { facade, hostsBySvc } = loadTwoHostFacade();
+  const stt = hostsBySvc["earheart-stt"];
+
+  // Hold `load-stt` in flight the way the real host does: busy until it settles.
+  let releaseLoad;
+  const held = new Promise((r) => (releaseLoad = r));
+  const passThrough = stt.request;
+  stt.request = async (type, payload) => {
+    if (type !== "load-stt") return passThrough(type, payload);
+    stt.inFlight++;
+    try {
+      await held;
+      return { ready: true };
+    } finally {
+      stt.inFlight--;
+    }
+  };
+
+  const loading = facade.transcribe(Buffer.from("wav"), STT_CFG);
+  await new Promise((r) => setImmediate(r)); // let ensureStt reach the pending load
+  assert.ok(stt.busy(), "precondition: the load is actually in flight");
+
+  assert.strictEqual(
+    facade.unloadIdle(),
+    false,
+    "a worker mid-load must be reported as skipped so the caller comes back for it"
+  );
+  assert.ok(!stt.stopped, "a worker mid-load must not be killed");
+
+  releaseLoad();
+  await loading;
+
+  // Once the load settles the worker is resident and evicts as usual.
+  assert.strictEqual(facade.unloadIdle(), true, "the settled worker unloads completely");
+  assert.ok(stt.stopped);
+});
+
 test("transcribe/clean reject early on an already-aborted signal without touching the worker", async () => {
   // The "pre-cancelled call returns early rather than spending a model load /
   // inference" contract: an aborted signal short-circuits before any host request.


### PR DESCRIPTION
Closes #108.

> **Stacked on #112.** Based on `fix/untrack-node-modules-symlink` because that PR restores a usable `node_modules` — without it the Electron-stubbing tests (including the one added here) cannot load at all. GitHub retargets this to `main` automatically once #112 merges. Reviewable diff is the two files below.

## What

`unloadIdle()` short-circuited on the loaded-model flag (`main/engines/index.js:248`):

```js
const sttClear = loadedStt === null || stopIfIdle(sttHost);
```

But `loadedStt` is assigned only *after* `load-stt` resolves (`main/engines/index.js:63`):

```js
if (loadedStt !== modelId) {
  await sttHost.request("load-stt", { ... });
  loadedStt = modelId;          // <- ~3-4s later for Parakeet int8
}
```

So throughout a cold load the flag reads `null` while the host is busy. The `||` skipped `stopIfIdle` entirely, `busy()` was never consulted, and the worker was reported clear.

`main/pipeline.js:88` re-arms its retry only on a `false`:

```js
if (!engines.unloadIdle()) armIdleUnload(IDLE_UNLOAD_RETRY_MS);
```

so the model finished loading and stayed resident **with no timer armed behind it** — reclaimed only after the next real dictation. ~1 GB for Parakeet int8.

Reachable: `onSettingsChanged` (`main/pipeline.js:468`) arms the timer on *every* settings save, so a Settings "test transcribe" landing inside that window hits it. That path is deliberately outside the pipeline's state machine, which is exactly why the retry exists — this bug routed around it.

## How

```js
const sttClear = (loadedStt === null && !sttHost.busy()) || stopIfIdle(sttHost);
```

Null **and** idle is the only combination that means "nothing to do here". Every other case falls through to `stopIfIdle`, which is already the single place that consults `busy()`. Same for `cleanupClear`.

Behavior is unchanged for the three states that already worked: nothing resident and idle still short-circuits without spawning or killing anything; a resident idle worker still gets exited; a resident busy worker is still skipped and reported.

## Tests

New regression test in `test/engines.test.js`, holding `load-stt` in flight the way the real host does (busy until it settles) and asserting the worker is skipped-and-reported rather than counted as idle — then that it still evicts normally once the load lands.

Verified it actually catches the bug: reverting just the two-line change fails it, and only it.

```
✖ a worker mid cold-load is skipped and reported, not counted as idle
ℹ tests 27  pass 25  fail 1
```

Full gate, all green:

- `npm test` — 256 tests, 255 pass, 1 skipped, 0 fail
- `make smoke`
- `npx electron scripts/engine-smoke.js` — worker ping + native engines load
- `npx electron scripts/overlay-smoke.js` — 29/29
- `npx electron scripts/settings-smoke.js` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)