### PR TITLE
fix(speech-probe): measure the room in a pause, not against the voice

### DIFF
--- a/renderer/speech-probe.js
+++ b/renderer/speech-probe.js
@@ -17,6 +17,16 @@
 //     without it the probe fails exactly where the decoder is likeliest to
 //     return nothing.
 //
+// The relative bar only works if the floor is measured somewhere the speaker
+// ISN'T talking, so what it really costs is pauses: the chunk has to hold at
+// least FLOOR_QUIET_WINDOWS quiet windows before the floor stops sitting on
+// speech. A chunk with no pause at all is, at this level of detail, the same
+// signal as steady room tone — same RMS in every window — and no threshold can
+// separate the two. That case stays a known limit rather than a guess: it needs
+// evidence this module doesn't have (spectral shape, or a floor carried across
+// chunks), and guessing "speech" there would force a full re-decode on every
+// noisy-room dictation.
+//
 // Both bars need SPEECH_MIN_SEC of audio to clear them before the chunk counts
 // as speech. A single click, a chair creak or one clipped sample is not a
 // sentence, and used to be enough to force a full re-decode of the recording.
@@ -40,6 +50,14 @@ const SPEECH_OVER_FLOOR = 3;
 const SILENCE_RMS = 0.0015;
 // The shortest thing worth calling speech. A word, not a transient.
 const SPEECH_MIN_SEC = 0.6;
+// How many of the quietest windows the floor has to look past. One would let a
+// single dropout in otherwise steady noise drag the floor down and call the
+// noise a voice; the 10th percentile this replaced needed SEVEN quiet windows
+// on a 20 s chunk, so a low-gain speaker pausing six times still measured their
+// floor against their own voice and came back "no speech". Three is enough
+// pauses to mean the speaker really stopped, and few enough that ordinary
+// speech clears it.
+const FLOOR_QUIET_WINDOWS = 3;
 
 // Root mean square of samples in [from, to).
 function rms(samples, from, to) {
@@ -61,14 +79,19 @@ function windowRmsSeries(samples, sampleRate) {
   return out;
 }
 
-// The room, as this chunk shows it: the 10th-percentile window rather than the
-// minimum, so one freak-quiet window can't drag the floor down and turn steady
-// noise into "speech". In a chunk holding any pause at all this lands on the
-// pause; in one that is wall-to-wall speech it lands on speech, and the
-// absolute bar is what carries the verdict there.
+// The room, as this chunk shows it: the FLOOR_QUIET_WINDOWS'th quietest window
+// rather than the minimum, so one freak-quiet window can't drag the floor down
+// and turn steady noise into "speech". In a chunk holding a few pauses this
+// lands on a pause; in one that is wall-to-wall speech it lands on speech, and
+// the absolute bar is what carries the verdict there.
+//
+// Counting windows rather than taking a percentile is deliberate: a percentile
+// scales the evidence demanded with the LENGTH of the chunk, so the 20 s chunks
+// the hard cap produces — the ones most likely to reach this probe — were the
+// ones asked for the most pauses, which is backwards.
 function noiseFloor(rmsSeries) {
   const sorted = [...rmsSeries].sort((a, b) => a - b);
-  return sorted[Math.floor(0.1 * (sorted.length - 1))];
+  return sorted[Math.min(FLOOR_QUIET_WINDOWS - 1, sorted.length - 1)];
 }
 
 function containsSpeech(samples, sampleRate) {

--- a/test/speech-probe.test.js
+++ b/test/speech-probe.test.js
@@ -100,6 +100,52 @@ test("two loud windows are speech, one is not", () => {
   assert.strictEqual(containsSpeech(one, SAMPLE_RATE), false);
 });
 
+// A speaker pausing N times and a steady noise dropping out N times are the
+// SAME signal at this level of detail, so the floor's window count is really
+// one question: how many pauses before a quiet, unbroken level is believed to
+// be a voice? The three tests below pin both sides of that answer.
+
+test("a low-gain speaker who pauses is heard, without needing to pause constantly", () => {
+  // 20 s at 0.008 RMS — never reaches the absolute bar, so only the relative
+  // bar can answer, and it can only answer if the floor is measured in a pause.
+  // The 10th percentile this replaced needed SEVEN quiet windows on a chunk
+  // this long, so a speaker pausing three times measured their floor against
+  // their own voice and came back "no speech" — and an empty decode was then
+  // believed, losing the words.
+  const chunk = level(20, 0.008);
+  for (const at of [5, 10, 15]) speakInto(chunk, at, at + 0.7, 0.0008);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), true);
+});
+
+test("one dropout in steady noise is not a voice", () => {
+  // The reason the floor looks past more than one window: a single freak-quiet
+  // window must not drag it down and turn a fan into a sentence, which would
+  // cost a full re-decode of the recording on every noisy-room dictation.
+  const chunk = level(20, 0.006);
+  speakInto(chunk, 5, 5.7, 0.0002);
+  assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), false);
+});
+
+test("steady room tone carries no speech however loud the room is", () => {
+  // Every level under the absolute bar, unbroken: the floor sits on the tone
+  // itself, so nothing stands above it. Pinned across the range because the
+  // floor change only lowers thresholds — this is the property it must not cost.
+  for (const rms of [0.002, 0.006, 0.01]) {
+    assert.strictEqual(containsSpeech(level(20, rms), SAMPLE_RATE), false, `rms=${rms}`);
+  }
+});
+
+// KNOWN LIMIT, pinned so a future change to it is deliberate rather than
+// accidental. A chunk with no pause anywhere is, by RMS alone, identical to
+// steady room tone: the same value in every window. The probe answers "no
+// speech", which keeps a noisy room from forcing a full re-decode but means a
+// low-gain speaker who never once pauses in 20 s is not covered. Separating
+// the two needs evidence this module doesn't have — spectral shape, or a floor
+// carried across chunks. See #109.
+test("a gapless low-gain chunk is indistinguishable from room tone", () => {
+  assert.strictEqual(containsSpeech(level(20, 0.008), SAMPLE_RATE), false);
+});
+
 test("a chunk too short to hold a window is still measured", () => {
   // Never answer "no speech" because there was no room to look.
   assert.strictEqual(containsSpeech(level(0.2, 0.05), SAMPLE_RATE), true);


### PR DESCRIPTION
Closes #109.

## What I found

#109 described this as a *gapless-chunk* problem. Measuring it, the real scope is much wider — and the gapless case turns out to be the part that **can't** be fixed here.

The relative bar only works if the noise floor is measured somewhere the speaker isn't talking. `noiseFloor` took the 10th percentile of the chunk's windows:

```js
return sorted[Math.floor(0.1 * (sorted.length - 1))];
```

On a 20 s chunk that is 66 windows, so the 10th percentile is the **7th quietest**. A 0.6 s pause fills at most one window on the fixed grid — so the floor only escapes the speaker's own voice after **seven separate pauses**.

Measured, 20 s at 0.008 RMS (below the absolute bar, so only the relative bar can answer), by number of 0.6 s pauses:

| pauses | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| before | no | no | no | no | no | no | no | **yes** |
| after | no | no | no | **yes** | yes | yes | yes | yes |

A low-gain speaker pausing *six times in twenty seconds* was reported as "no speech". Paired with an empty decode, `main/live-preview.js` marks those samples covered and the words are gone from the final transcript. That is a much more ordinary shape than "never pauses at all".

## How

Count the quietest windows instead of taking a percentile:

```js
return sorted[Math.min(FLOOR_QUIET_WINDOWS - 1, sorted.length - 1)];  // 3
```

A percentile scales the evidence demanded with the **length** of the chunk, so the 20 s chunks the hard cap produces — the ones most likely to reach this probe — were the ones asked for the most pauses. That's backwards; a fixed count is the property actually wanted.

Three keeps what the percentile was chosen for. A speaker pausing N times and steady noise dropping out N times are the *same signal* at this level of detail, so the window count is really one question: how many pauses before a quiet, unbroken level is believed to be a voice? One would let a single dropout turn a fan into a sentence and cost a full re-decode on every noisy-room dictation. Seven loses the words. Three is enough to mean the speaker really stopped.

**This can only lower the threshold**, so no chunk that already reported speech can start reporting silence. It cannot introduce new word loss — only additional re-decodes.

## What this deliberately does NOT fix

A chunk with **no pause anywhere** still reports no speech. By RMS alone it is the same signal as steady room tone — the same value in every window — and no threshold can separate them. Guessing "speech" there would force a full re-decode on every noisy-room dictation, trading the bug for the regression #104 set out to avoid.

Separating them needs evidence this module doesn't have: spectral shape, or a floor carried across chunks (the recording's quietest moment is a far better estimate of "the room" than one gapless chunk's own windows). That's a design change, not a bug fix, so it's pinned here as a known limit with a test and an explanatory comment rather than left to be rediscovered.

## Tests

Four added to `test/speech-probe.test.js`: the low-gain speaker who pauses three times is now heard; one dropout in steady noise is still not a voice; steady room tone stays silent across 0.002/0.006/0.010; and the gapless limit is pinned.

Verified the fix is what carries them — reverting just the `noiseFloor` line fails exactly one:

```
✖ a low-gain speaker who pauses is heard, without needing to pause constantly
ℹ tests 15  pass 14  fail 1
```

Full gate, all green:

- `npm test` — 260 tests, 259 pass, 1 skipped, 0 fail
- `make smoke`
- `npx electron scripts/engine-smoke.js`
- `npx electron scripts/overlay-smoke.js` — 29/29
- `npx electron scripts/settings-smoke.js` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)