### PR TITLE
docs(speech-probe): state what the window grid actually promises, and pin it

### DIFF
--- a/renderer/speech-probe.js
+++ b/renderer/speech-probe.js
@@ -48,7 +48,24 @@ const SPEECH_OVER_FLOOR = 3;
 // Below this everything is dither and dead air, whatever the floor computes to
 // — without it, digital silence would make every window "3x the floor".
 const SILENCE_RMS = 0.0015;
-// The shortest thing worth calling speech. A word, not a transient.
+// How much over-threshold audio it takes to call a chunk speech, expressed as
+// whole SPEECH_WINDOW_SEC windows below. A word, not a transient.
+//
+// The EFFECTIVE minimum is not this number, and deliberately so. The windows sit
+// on a fixed grid, so a sound landing across a boundary lights two of them while
+// the same sound landing inside one lights only one. Measured against where the
+// sound starts: from 0.5 s up every alignment answers "speech", even for a word
+// only twice the relative bar; between roughly 0.1 s and 0.45 s the answer
+// depends on the alignment, leaning toward "speech" as the length grows; and a
+// 6 ms click is rejected at all but the sliver of offsets that split it.
+//
+// That skew is left alone because it leans the way this module is supposed to
+// lean. Its bias is stated at the top — a false "speech" costs one re-decode, a
+// false "silence" costs the user a sentence — and a clipped 0.25 s "yes" being
+// believed at most alignments is worth more than the rare click that buys a
+// re-decode nobody needed. Tightening it would mean measuring duration below
+// the window (finer frames), which costs quiet speech near the threshold the
+// smoothing that lets it clear the bar at all. See #110.
 const SPEECH_MIN_SEC = 0.6;
 // How many of the quietest windows the floor has to look past. One would let a
 // single dropout in otherwise steady noise drag the floor down and call the

--- a/test/speech-probe.test.js
+++ b/test/speech-probe.test.js
@@ -13,6 +13,10 @@ const assert = require("node:assert");
 const { containsSpeech, chunkSpeechVerdict } = require("../renderer/speech-probe");
 
 const SAMPLE_RATE = 16000;
+// Mirrors the window length the probe measures in. Kept local rather than
+// imported: the sweeps below need to step across exactly one window, and the
+// module deliberately exports only the two functions its callers use.
+const WINDOW_SEC = 0.3;
 
 // A `seconds`-long buffer at a constant RMS.
 function level(seconds, amplitude) {
@@ -144,6 +148,46 @@ test("steady room tone carries no speech however loud the room is", () => {
 // carried across chunks. See #109.
 test("a gapless low-gain chunk is indistinguishable from room tone", () => {
   assert.strictEqual(containsSpeech(level(20, 0.008), SAMPLE_RATE), false);
+});
+
+// The window grid decides how a sound of a given length is counted, so the
+// contract worth pinning is where the answer stops depending on WHERE the sound
+// landed. Both tests sweep the offset across a full window.
+
+test("a quiet 0.5s word is heard at every window alignment", () => {
+  // The property a caller can rely on: past this length the verdict is a
+  // function of the audio, not of where the recording happened to start.
+  // Deliberately quiet — 0.004 against a 0.0006 room clears the relative bar
+  // by about 2x, so this fails if the bar moves, if the window changes size, or
+  // if the grid stops catching a word that straddles it. A loud burst would
+  // sail over every such regression and pin nothing.
+  //
+  // 0.5 s is where the grid stops mattering, measured, and it is longer than
+  // the 0.6/0.3 = 2 windows the constants suggest because a word lying across a
+  // boundary lights both. Shorter words are still usually heard — 0.4 s at this
+  // level answers "speech" at all but a sliver of alignments — but 0.5 s is the
+  // point where "usually" becomes "always", so it is what can be promised.
+  for (let offset = 0; offset < WINDOW_SEC; offset += 0.03) {
+    const chunk = speakInto(level(10, 0.0006), 4 + offset, 4 + offset + 0.5, 0.004);
+    assert.strictEqual(containsSpeech(chunk, SAMPLE_RATE), true, `offset=${offset.toFixed(2)}`);
+  }
+});
+
+test("a lone click is rejected wherever it lands inside a window", () => {
+  // Transient rejection is why SPEECH_MIN_SEC exists: a keyboard tap must not
+  // buy a full re-decode of the recording. It survives the sweep everywhere the
+  // click sits inside a single window — which is every alignment except the
+  // narrow band that splits it across two. That residue is tolerated on
+  // purpose (see SPEECH_MIN_SEC): erring toward "speech" costs one re-decode,
+  // erring the other way costs words.
+  let heard = 0;
+  const offsets = [];
+  for (let offset = 0; offset < WINDOW_SEC; offset += 0.005) offsets.push(offset);
+  for (const offset of offsets) {
+    const chunk = speakInto(level(10, 0.0006), 4 + offset, 4 + offset + 0.006, 0.5);
+    if (containsSpeech(chunk, SAMPLE_RATE)) heard++;
+  }
+  assert.ok(heard <= offsets.length * 0.05, `click heard at ${heard}/${offsets.length} offsets`);
 });
 
 test("a chunk too short to hold a window is still measured", () => {


### PR DESCRIPTION
Closes #110.

> **Stacked on #115** (same file). GitHub retargets this to `main` once #115 merges; reviewable diff is the two files below.
>
> `docs:` prefix — no arithmetic changes, ships no release.

## The report was backwards

#110 said a short utterance's verdict depends on grid alignment, and read that as short words being **silently lost**. Sweeping every offset within a window says the skew runs the other way:

| duration | share of offsets answering "speech" (quiet word, ~2× the relative bar) |
| --- | --- |
| 0.30 s | 63% |
| 0.40 s | 97% |
| 0.50 s | **100%** |

A sound lying across a boundary lights **two** windows where the same sound inside one lights only one. So short sounds are believed *more* often than their length warrants — not less. The one real cost is the mirror image of what #110 claimed: a 6 ms click is called a sentence at the sliver of offsets that split it exactly, buying a full re-decode nobody needed.

That is the direction this module says it wants to err in — "a false 'speech' costs one full re-decode at stop, a false 'silence' costs the user a sentence. When in doubt, say speech." A clipped 0.25 s "yes" being believed at most alignments is worth more than the rare stray re-decode.

**So no arithmetic changed.** Tightening it would mean measuring duration below the window — finer frames — which costs quiet speech near the threshold exactly the smoothing that lets it clear the bar at all. That is a redesign with word-loss risk, traded against a latency wart. Not worth it.

## What was actually wrong

The description. `SPEECH_MIN_SEC` read as "The shortest thing worth calling speech" while the real floor is neither 0.6 s nor the `0.6 / 0.3 = 2` windows it implies — it is **~0.5 s**, and below that the answer depends on alignment.

That gap is what made #110 wrong, and it is what made the module header's own reasoning wrong. It is now written down with the numbers behind it.

## Tests

Two, each sweeping the offset across a full window:

- a quiet 0.5 s word is heard at **every** alignment — the property a caller can actually rely on;
- a lone 6 ms click is rejected at all but a sliver — transient rejection, the reason `SPEECH_MIN_SEC` exists.

Both are mutation-checked rather than assumed:

| mutation | caught by |
| --- | --- |
| `SPEECH_OVER_FLOOR` 3 → 12 | quiet-word sweep |
| `SILENCE_RMS` 0.0015 → 0.01 | quiet-word sweep |
| `SPEECH_WINDOW_SEC` 0.3 → 0.6 | click sweep |
| `SPEECH_MIN_SEC` 0.6 → 0.3 | click sweep |

Worth flagging: my first draft of both tests passed **vacuously**. They swept to `SPEECH_WINDOW_SEC` imported from the module, which #107 stopped exporting — so the bound was `undefined`, the loops ran zero times, and both tests were green while asserting nothing. Mutation testing is what surfaced it; the sweep bound is now a local constant. The same check also corrected the boundary from 0.4 s to 0.5 s, which a loud-burst fixture had hidden.

Full gate, all green:

- `npm test` — 262 tests, 261 pass, 1 skipped, 0 fail
- `make smoke`
- `npx electron scripts/overlay-smoke.js` — 29/29
- `npx electron scripts/settings-smoke.js` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)