### PR TITLE
ci: fail on tracked symlinks and committed dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,42 @@ jobs:
         if: runner.os != 'Linux'
         run: npx electron scripts/settings-smoke.js --no-sandbox
 
+  # A tracked symlink is the one breakage the jobs above structurally cannot
+  # catch: they run `npm ci`, which rebuilds node_modules over whatever the
+  # checkout put there, so a self-referencing `node_modules` symlink committed
+  # to the tree stays green here and only fails on a real clone (ELOOP on every
+  # access — npm ci, require.resolve, anything walking the tree). That is
+  # exactly how one reached main in #107. This job looks at the index instead of
+  # the working tree, so nothing can paper over it.
+  #
+  # Own job rather than a step in `app`: it needs no Node and no Electron, and
+  # as a step it would run three times over for the OS matrix.
+  repo-hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: No tracked symlinks
+        run: |
+          # Mode 120000 is git's symlink mode. The repo has none, and none is
+          # the intended steady state — if a symlink is ever wanted here on
+          # purpose, allow it explicitly rather than dropping this check.
+          found=$(git ls-files -s | awk '$1 == "120000" { print $4 }')
+          if [ -n "$found" ]; then
+            echo "::error::Tracked symlink(s) found — these break a fresh clone:"
+            echo "$found" | sed 's/^/  /'
+            exit 1
+          fi
+      - name: No committed dependency or build output
+        run: |
+          # .gitignore covers these, but `git add -f` (or an ignore rule that
+          # misses, as `node_modules/` did for a symlink) still gets past it.
+          found=$(git ls-files | grep -E '^(node_modules|dist)(/|$)' || true)
+          if [ -n "$found" ]; then
+            echo "::error::Dependency/build paths are committed:"
+            echo "$found" | head -20 | sed 's/^/  /'
+            exit 1
+          fi
+
   stt-server:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Closes the hole that let #107's `node_modules` symlink onto `main` (fixed in #112).

> `ci:` prefix — ships no release.

## Why CI missed it

#107 committed `node_modules` as a symlink pointing at its own absolute path, and CI stayed green. It **structurally could not** have caught it: every job runs `npm ci`, which rebuilds `node_modules` over whatever the checkout produced, so the broken link was never read.

It only failed on a real clone — `ELOOP` on every access, taking out `npm ci`, `require.resolve`, and anything walking the tree. That took my checkout from 251 passing to 19 failures, and the worst part is where it surfaces: on someone else's machine, long after merge.

## What this adds

A `repo-hygiene` job that inspects the **index**, not the working tree, so nothing downstream can paper over it:

1. **No tracked symlinks** — mode `120000` in `git ls-files -s`.
2. **No committed `node_modules`/`dist`** — overlaps `.gitignore`, but survives `git add -f` and ignore rules that miss. `node_modules/` with a trailing slash matches *directories only*, which is exactly how the symlink got in.

Own job rather than a step in `app`: it needs neither Node nor Electron, and as a step it would run three times over for the OS matrix. Adds a few seconds.

## Verification

Ran the guards against a scratch repo reproducing each breakage:

| tree state | symlink guard | dependency guard |
| --- | --- | --- |
| clean | pass | pass |
| `node_modules` → its own path (the #107 breakage) | **fail** | **fail** |
| `node_modules/pkg/index.js` committed via `git add -f` | pass | **fail** |

And against this repo, which is clean on both since #112.

`npm test` — 262 tests, 261 pass, 1 skipped, 0 fail.

## Note

The check is CI-only. If it's worth being able to run locally before pushing, a `make hygiene` target wrapping the same two commands would be a small follow-up — say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)