### PR TITLE
fix: keep the filler cut from reflowing the whole transcript

### DIFF
--- a/main/util/stumble-strip.js
+++ b/main/util/stumble-strip.js
@@ -46,38 +46,60 @@ function stripFillers(text) {
   // we"); one that only follows is the filler's own ("is uh, for" -> "is for").
   // `tail` is the sentence-ending punctuation the filler was sitting in front
   // of, which decides who the fencing comma really belonged to.
+  //
+  // A run of fillers ("um, uh") is one cut, so the seam is repaired once. The
+  // match eats the horizontal whitespace on both sides of it and the callback
+  // returns the join already correct — spacing anywhere else in the text is
+  // the user's, and is never reflowed.
   let out = marked.replace(
-    new RegExp(`(\\s*,)?[^\\S\\n]*${CUT}[^\\S\\n]*(?:,[^\\S\\n]*)?([.!?]+)?`, "g"),
+    new RegExp(`([^\\S\\n]*,)?[^\\S\\n]*(?:${CUT}[^\\S\\n]*(?:,[^\\S\\n]*)?)+([.!?]+[^\\S\\n]*)?`, "g"),
     (m, before, tail, offset, whole) => {
       // Opening a sentence? The next word has to take over the capital.
       // (":" and ";" continue a sentence, so they are not boundaries here.)
       const head = whole.slice(0, offset);
       const opensSentence = /(?:^|[.!?\n]["')\]]?\s*)$/.test(head);
+      // At the start of a line there is nothing to separate from; at the end of
+      // one there is nothing left to separate.
+      const startsLine = head === "" || head.endsWith("\n");
+      const next = whole[offset + m.length];
+      const endsLine = next === undefined || next === "\n";
+
       if (tail) {
+        // `tail` is the punctuation plus the spacing that followed it, so
+        // whichever side keeps it keeps the seam intact.
+        if (!opensSentence) {
+          // The punctuation ends the running clause and stays, without the
+          // comma that fenced the filler off ("that's it, um." -> "that's
+          // it.").
+          return endsLine ? tail.replace(/[^\S\n]+$/, "") : tail;
+        }
         // A "sentence" that was nothing but the filler takes its punctuation
         // with it — the clause before it already ended with its own ("Do it.
-        // Um! Really?" -> "Do it. Really?"). Anywhere else the punctuation ends
-        // the running clause and stays, without the comma that fenced the
-        // filler off ("that's it, um." -> "that's it.").
-        return opensSentence ? "" : tail;
+        // Um! Really?" -> "Do it. Really?") — and the next word takes over the
+        // capital it was holding ("Um... okay" -> "Okay").
+        if (endsLine) return "";
+        return startsLine ? CAP : ` ${CAP}`;
       }
-      if (before) return ", ";
-      if (!opensSentence) return " ";
-      // At the very start of a line there is nothing to separate from.
-      return head === "" || head.endsWith("\n") ? CAP : ` ${CAP}`;
+      if (before) {
+        // A comma with nothing left to fence off on either side goes too.
+        if (startsLine) return "";
+        // The clause keeps its comma, but not a second one and not a space in
+        // front of punctuation that follows.
+        if (endsLine || next === ",") return endsLine ? "," : "";
+        return /[.;:!?]/.test(next) ? "," : ", ";
+      }
+      if (endsLine) return "";
+      if (startsLine) return CAP;
+      if (opensSentence) return ` ${CAP}`;
+      // No space in front of the punctuation the filler was hiding.
+      return /[,.;:!?]/.test(next) ? "" : " ";
     }
   );
 
   out = out
     .replace(new RegExp(`${CAP}(\\p{Ll})`, "gu"), (m, ch) => ch.toUpperCase())
     .split(CAP)
-    .join("")
-    .replace(/[^\S\n]{2,}/g, " ")
-    .replace(/[^\S\n]+([,.;:!?])/g, "$1")
-    .replace(/,[^\S\n]*,/g, ",")
-    .replace(/[^\S\n]+$/gm, "")
-    .replace(/^[^\S\n]*,[^\S\n]*/gm, "")
-    .trim();
+    .join("");
 
   return out.length > 0 ? out : text;
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -338,6 +338,24 @@ test("stripFillers leaves real words, acronyms and text without fillers alone", 
   assert.strictEqual(stripFillers(""), "");
 });
 
+test("stripFillers repairs the seam only, leaving the rest of the spacing alone", () => {
+  // Cutting a filler used to reflow the whole transcript: indentation, aligned
+  // columns and the trailing newline are the user's, not the filler's.
+  assert.strictEqual(
+    stripFillers("um, hello\n  step one\n  step two"),
+    "Hello\n  step one\n  step two"
+  );
+  assert.strictEqual(stripFillers("uh okay\nfoo    bar"), "Okay\nfoo    bar");
+  assert.strictEqual(stripFillers("um, hello\n"), "Hello\n");
+  assert.strictEqual(stripFillers("a  b um c"), "a  b c");
+  // A line break the filler did not own survives the comma that fenced it.
+  assert.strictEqual(stripFillers("foo\n, um bar"), "foo\nbar");
+  // A run of fillers is one cut, so the next word still takes the capital.
+  assert.strictEqual(stripFillers("um um hello"), "Hello");
+  assert.strictEqual(stripFillers("um, uh, hello"), "Hello");
+  assert.strictEqual(stripFillers("um... okay"), "Okay");
+});
+
 test("collapseRepeats collapses a re-spoken word but not a deliberate one", () => {
   assert.strictEqual(
     collapseRepeats("The the admin will add it."),


### PR DESCRIPTION
Last of the findings from the #119 review: `stripFillers` repaired the
gap a removed filler left by running global regexes over the whole text
— `[^\S\n]{2,}` → one space, trailing whitespace off every line, then a
`.trim()`. One `um` anywhere was enough to rewrite spacing the filler
never touched.

```js
stripFillers("um, hello\n  step one")   // before: "Hello\n step one"
stripFillers("uh okay\nfoo    bar")     // before: "Okay\nfoo bar"
stripFillers("um, hello\n")             // before: "Hello"  (newline gone)
```

The same text with the filler removed by hand came back untouched, so
the reflow was purely a side effect of the cut.

## What changed

The seam is repaired where it is made. The match already eats the
horizontal whitespace on both sides of the filler, so the replacement
callback now reads what follows — end of line, punctuation, another
comma — and returns the join already correct. All five global passes and
the `.trim()` are gone.

Two things fell out of doing it locally:

- A run of fillers is one cut instead of several, so the next word still
  takes over the capital: `"um um hello"` → `"Hello"` (was `"hello"`).
- Sentence-ending punctuation carries the spacing that followed it, so a
  filler that was a whole sentence hands the capital over too:
  `"um... okay"` → `"Okay"` (was `"okay"`).

## Verification

Diffed old against new over 42 inputs (the hand-written edge cases plus
every `SHORT`/`REPORTED`/`FLUENT` dictation and model output in
`scripts/dictation-corpus.js`): 8 differ, and each one is the fix or the
two improvements above. Nothing else moved.

Suite: 271 tests, 270 pass, 1 pre-existing skip. Eight regression
assertions added.