### PR TITLE
feat: resume interrupted model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,9 @@ Settings → Speech-to-text or Settings → Cleanup.
 The wizard's last step downloads the models that run on your machine — a small
 Parakeet speech model (≈ 670 MB) and a small Gemma cleanup model (≈ 800 MB) —
 showing a progress bar as it goes. It's a one-time download; everything after
-that is faster than realtime, even on CPU. You can pick a larger, higher-
-quality cleanup model in the wizard or later in Settings → Cleanup.
+that is faster than realtime, even on CPU. If a download is interrupted,
+retrying resumes from the saved partial file when possible. You can pick a
+larger, higher-quality cleanup model in the wizard or later in Settings → Cleanup.
 
 Every launch after that goes straight to the tray — no window to dismiss — and
 posts a short "ready, press *your hotkey*" notification. Click it to open

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -289,6 +289,11 @@ async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
 /**
  * Download every file of a model, reporting aggregate progress.
  *
+ * Failed or cancelled transfers leave valid partial state for the next retry;
+ * incompatible state is discarded and downloaded afresh. Progress credits all
+ * reusable on-disk bytes in its first event and never moves backward. Files are
+ * installed only after their exact size and configured checksum are verified.
+ *
  * @param {string} baseDir
  * @param {object} model - a registry entry
  * @param {object} [opts]

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -4,8 +4,9 @@
 // app; a temp dir in tests) so this module has no Electron dependency and is
 // unit-testable against a local HTTP server.
 //
-// Each file is streamed to `<name>.part`, optionally checksum-verified, then
-// renamed into place — so a half-finished download never looks complete. A
+// Each file is streamed to `<name>.part`, with resume metadata in
+// `<name>.part.json`, checksum-verified, then renamed into place — so a
+// half-finished download never looks complete. A
 // model counts as installed once every file is present and a `.complete`
 // marker has been written. The marker records each file's size as actually
 // written, so `isInstalled` can reject a model whose files were later truncated
@@ -28,6 +29,11 @@ function modelDir(baseDir, model) {
 
 function filePath(baseDir, model, file) {
   return path.join(modelDir(baseDir, model), file.name);
+}
+
+function partialPaths(dest) {
+  const part = `${dest}.part`;
+  return { part, meta: `${part}.json` };
 }
 
 // Read the completion marker. Returns the recorded {name: size} map, an empty
@@ -75,48 +81,191 @@ async function remove(baseDir, model) {
   await fsp.rm(modelDir(baseDir, model), { recursive: true, force: true });
 }
 
-// A pass-through stream that counts bytes and (optionally) hashes them, so we
-// can report progress and verify integrity in a single pass over the data.
-function makeMeter(onChunk, hash) {
+// A pass-through stream that counts bytes as they are written.
+function makeMeter(onChunk) {
   return new Transform({
     transform(chunk, _enc, cb) {
-      if (hash) hash.update(chunk);
       onChunk(chunk.length);
       cb(null, chunk);
     },
   });
 }
 
-async function downloadFile(baseDir, model, file, { onBytes, signal }) {
+async function hashFile(filename) {
+  const hash = crypto.createHash("sha256");
+  for await (const chunk of fs.createReadStream(filename)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function verifyFile(filename, file) {
+  let stat;
+  try {
+    stat = await fsp.stat(filename);
+  } catch {
+    return false;
+  }
+  if (file.bytes && stat.size !== file.bytes) return false;
+  if (file.sha256 && (await hashFile(filename)) !== file.sha256) return false;
+  return true;
+}
+
+async function discardPartial(paths) {
+  await Promise.all([
+    fsp.rm(paths.part, { force: true }),
+    fsp.rm(paths.meta, { force: true }),
+  ]);
+}
+
+async function readPartial(dest, file) {
+  const paths = partialPaths(dest);
+  let stat;
+  let meta;
+  try {
+    [stat, meta] = await Promise.all([
+      fsp.stat(paths.part),
+      fsp.readFile(paths.meta, "utf8").then(JSON.parse),
+    ]);
+  } catch {
+    await discardPartial(paths);
+    return null;
+  }
+  const expectedBytes = file.bytes || null;
+  if (
+    !meta ||
+    meta.url !== file.url ||
+    meta.expectedBytes !== expectedBytes ||
+    stat.size <= 0 ||
+    (expectedBytes && stat.size > expectedBytes)
+  ) {
+    await discardPartial(paths);
+    return null;
+  }
+  return { ...paths, size: stat.size, metadata: meta };
+}
+
+function responseMetadata(res, file, totalBytesHint) {
+  return {
+    url: file.url,
+    expectedBytes: file.bytes || null,
+    etag: res.headers.get("etag") || null,
+    lastModified: res.headers.get("last-modified") || null,
+    totalBytes: file.bytes || totalBytesHint || null,
+  };
+}
+
+function ifRangeValue(metadata) {
+  // RFC 9110 forbids weak entity tags in If-Range. Last-Modified is the next
+  // best validator; with neither, the final SHA-256 still prevents installation
+  // of bytes combined from incompatible representations.
+  if (metadata.etag && !metadata.etag.startsWith("W/")) return metadata.etag;
+  return metadata.lastModified || null;
+}
+
+function parseContentRange(value) {
+  const match = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(value || "");
+  if (!match) return null;
+  return { start: Number(match[1]), end: Number(match[2]), total: Number(match[3]) };
+}
+
+function resumedResponseIsCompatible(res, partial, file) {
+  const range = parseContentRange(res.headers.get("content-range"));
+  if (!range || range.start !== partial.size || range.end < range.start) return false;
+  if (file.bytes && range.total !== file.bytes) return false;
+  if (partial.metadata.totalBytes && range.total !== partial.metadata.totalBytes) return false;
+
+  const oldEtag = partial.metadata.etag;
+  const oldModified = partial.metadata.lastModified;
+  if (oldEtag && res.headers.get("etag") !== oldEtag) return false;
+  if (!oldEtag && oldModified && res.headers.get("last-modified") !== oldModified) return false;
+  return true;
+}
+
+async function fetchFull(file, signal) {
+  const res = await fetch(file.url, { signal });
+  if (res.status !== 200 || !res.body) {
+    throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
+  }
+  return res;
+}
+
+async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
   const dir = modelDir(baseDir, model);
   await fsp.mkdir(dir, { recursive: true });
   const dest = path.join(dir, file.name);
-  const part = `${dest}.part`;
+  const paths = partialPaths(dest);
 
-  // No HTTP range/resume: a failed or cancelled transfer discards the `.part`
-  // and the next attempt re-fetches the whole file from the start. Completed
-  // files are still skipped (below), so only the in-flight file is repeated.
-  const res = await fetch(file.url, { signal });
-  if (!res.ok || !res.body) {
-    throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
+  // A crash can happen after the last byte lands but before verification and
+  // rename. Finish that work locally instead of issuing an unsatisfiable range.
+  if (partial && file.bytes && partial.size === file.bytes) {
+    if (await verifyFile(paths.part, file)) {
+      await fsp.rename(paths.part, dest);
+      await fsp.rm(paths.meta, { force: true });
+      return;
+    }
+    await discardPartial(paths);
+    partial = null;
   }
 
-  const hash = file.sha256 ? crypto.createHash("sha256") : null;
+  let res;
+  let offset = 0;
+  if (partial) {
+    const headers = { Range: `bytes=${partial.size}-` };
+    const validator = ifRangeValue(partial.metadata);
+    if (validator) headers["If-Range"] = validator;
+    res = await fetch(file.url, { headers, signal });
+
+    if (res.status === 206 && resumedResponseIsCompatible(res, partial, file)) {
+      offset = partial.size;
+    } else if (res.status === 200 && res.body) {
+      // The host ignored Range or If-Range detected changed content. The body
+      // is already a complete representation, so safely truncate rather than
+      // append (and avoid wasting it on a second request).
+      offset = 0;
+    } else if (res.status === 206 || res.status === 416) {
+      // Malformed ranges, 416, or a changed validator on a non-compliant 206
+      // invalidate the partial. Cancel that body and explicitly fetch afresh.
+      await res.body?.cancel().catch(() => {});
+      await discardPartial(paths);
+      partial = null;
+      res = await fetchFull(file, signal);
+    } else {
+      // A temporary HTTP error says nothing about the partial's validity. Keep
+      // it for the next attempt just as we do for a dropped connection.
+      await res.body?.cancel().catch(() => {});
+      throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
+    }
+  } else {
+    res = await fetchFull(file, signal);
+  }
+
+  if (!res.body) throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
+  const range = offset ? parseContentRange(res.headers.get("content-range")) : null;
+  const contentLength = Number(res.headers.get("content-length")) || 0;
+  const responseTotal = range?.total || contentLength || null;
+  await fsp.writeFile(paths.meta, JSON.stringify(responseMetadata(res, file, responseTotal)));
+
+  let streamed = 0;
   await pipeline(
     Readable.fromWeb(res.body),
-    makeMeter(onBytes, hash),
-    fs.createWriteStream(part),
+    makeMeter((n) => {
+      streamed += n;
+      onSize(offset + streamed);
+    }),
+    fs.createWriteStream(paths.part, { flags: offset ? "a" : "w" }),
     { signal }
   );
 
-  if (hash) {
-    const got = hash.digest("hex");
-    if (got !== file.sha256) {
-      await fsp.rm(part, { force: true });
-      throw new Error(`Checksum mismatch for ${file.name}`);
-    }
+  const actualSize = (await fsp.stat(paths.part)).size;
+  if (file.bytes && actualSize !== file.bytes) {
+    await discardPartial(paths);
+    throw new Error(`Size mismatch for ${file.name}`);
   }
-  await fsp.rename(part, dest); // atomic: only a verified file lands in place
+  if (file.sha256 && (await hashFile(paths.part)) !== file.sha256) {
+    await discardPartial(paths);
+    throw new Error(`Checksum mismatch for ${file.name}`);
+  }
+  await fsp.rename(paths.part, dest); // atomic: only a verified file lands in place
+  await fsp.rm(paths.meta, { force: true });
 }
 
 /**
@@ -141,21 +290,40 @@ async function download(baseDir, model, { onProgress, signal } = {}) {
       file,
     });
 
+  // Validate and credit everything reusable before the first progress event.
+  // This makes a resumed setup open at its real on-disk byte count rather than
+  // briefly flashing zero. Credits are high-water marks: if a server forces a
+  // safe restart, fresh bytes do not make aggregate progress move backward.
+  const reusable = [];
   for (const file of model.files) {
     const dest = filePath(baseDir, model, file);
-    // Skip files already pulled in by an earlier (interrupted) run. Count the
-    // real on-disk size, not the registry's approximate `bytes`, so the
-    // aggregate progress stays monotonic when a resumed download mixes
-    // already-present files with freshly streamed ones.
     if (fs.existsSync(dest)) {
-      received += fs.statSync(dest).size;
-      report(file.name);
-      continue;
+      if (await verifyFile(dest, file)) {
+        const size = fs.statSync(dest).size;
+        reusable.push({ complete: true, partial: null, credit: size });
+        received += size;
+        continue;
+      }
+      await fsp.rm(dest, { force: true });
     }
+    const partial = await readPartial(dest, file);
+    const credit = partial?.size || 0;
+    reusable.push({ complete: false, partial, credit });
+    received += credit;
+  }
+  if (received) report(model.files.find((_, i) => !reusable[i].complete)?.name || null);
+
+  for (let i = 0; i < model.files.length; i++) {
+    const file = model.files[i];
+    const state = reusable[i];
+    if (state.complete) continue;
     await downloadFile(baseDir, model, file, {
       signal,
-      onBytes: (n) => {
-        received += n;
+      partial: state.partial,
+      onSize: (size) => {
+        if (size <= state.credit) return;
+        received += size - state.credit;
+        state.credit = size;
         report(file.name);
       },
     });

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -81,23 +81,33 @@ async function remove(baseDir, model) {
   await fsp.rm(modelDir(baseDir, model), { recursive: true, force: true });
 }
 
-// A pass-through stream that counts bytes as they are written.
-function makeMeter(onChunk) {
+// A pass-through stream that counts and hashes bytes as they are written.
+function makeMeter(onChunk, hash) {
   return new Transform({
     transform(chunk, _enc, cb) {
+      hash?.update(chunk);
       onChunk(chunk.length);
       cb(null, chunk);
     },
   });
 }
 
-async function hashFile(filename) {
+async function updateHashFromFile(filename, hash, signal) {
+  signal?.throwIfAborted();
+  for await (const chunk of fs.createReadStream(filename)) {
+    signal?.throwIfAborted();
+    hash.update(chunk);
+  }
+  signal?.throwIfAborted();
+}
+
+async function hashFile(filename, signal) {
   const hash = crypto.createHash("sha256");
-  for await (const chunk of fs.createReadStream(filename)) hash.update(chunk);
+  await updateHashFromFile(filename, hash, signal);
   return hash.digest("hex");
 }
 
-async function verifyFile(filename, file) {
+async function verifyFile(filename, file, signal) {
   let stat;
   try {
     stat = await fsp.stat(filename);
@@ -105,7 +115,7 @@ async function verifyFile(filename, file) {
     return false;
   }
   if (file.bytes && stat.size !== file.bytes) return false;
-  if (file.sha256 && (await hashFile(filename)) !== file.sha256) return false;
+  if (file.sha256 && (await hashFile(filename, signal)) !== file.sha256) return false;
   return true;
 }
 
@@ -197,7 +207,8 @@ async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
   // A crash can happen after the last byte lands but before verification and
   // rename. Finish that work locally instead of issuing an unsatisfiable range.
   if (partial && file.bytes && partial.size === file.bytes) {
-    if (await verifyFile(paths.part, file)) {
+    if (await verifyFile(paths.part, file, signal)) {
+      signal?.throwIfAborted();
       await fsp.rename(paths.part, dest);
       await fsp.rm(paths.meta, { force: true });
       return;
@@ -205,6 +216,9 @@ async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
     await discardPartial(paths);
     partial = null;
   }
+
+  let hash = file.sha256 ? crypto.createHash("sha256") : null;
+  if (hash && partial) await updateHashFromFile(paths.part, hash, signal);
 
   let res;
   let offset = 0;
@@ -239,6 +253,8 @@ async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
   }
 
   if (!res.body) throw new Error(`Download failed for ${file.name}: HTTP ${res.status}`);
+  // A full response replaces, rather than extends, any previously hashed prefix.
+  if (!offset && hash) hash = crypto.createHash("sha256");
   const range = offset ? parseContentRange(res.headers.get("content-range")) : null;
   const contentLength = Number(res.headers.get("content-length")) || 0;
   const responseTotal = range?.total || contentLength || null;
@@ -250,7 +266,7 @@ async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
     makeMeter((n) => {
       streamed += n;
       onSize(offset + streamed);
-    }),
+    }, hash),
     fs.createWriteStream(paths.part, { flags: offset ? "a" : "w" }),
     { signal }
   );
@@ -260,10 +276,12 @@ async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
     await discardPartial(paths);
     throw new Error(`Size mismatch for ${file.name}`);
   }
-  if (file.sha256 && (await hashFile(paths.part)) !== file.sha256) {
+  signal?.throwIfAborted();
+  if (hash && hash.digest("hex") !== file.sha256) {
     await discardPartial(paths);
     throw new Error(`Checksum mismatch for ${file.name}`);
   }
+  signal?.throwIfAborted();
   await fsp.rename(paths.part, dest); // atomic: only a verified file lands in place
   await fsp.rm(paths.meta, { force: true });
 }
@@ -298,7 +316,7 @@ async function download(baseDir, model, { onProgress, signal } = {}) {
   for (const file of model.files) {
     const dest = filePath(baseDir, model, file);
     if (fs.existsSync(dest)) {
-      if (await verifyFile(dest, file)) {
+      if (await verifyFile(dest, file, signal)) {
         const size = fs.statSync(dest).size;
         reusable.push({ complete: true, partial: null, credit: size });
         received += size;
@@ -336,10 +354,13 @@ async function download(baseDir, model, { onProgress, signal } = {}) {
   for (const file of model.files) {
     sizes[file.name] = fs.statSync(filePath(baseDir, model, file)).size;
   }
-  await fsp.writeFile(
-    path.join(modelDir(baseDir, model), MARKER),
-    JSON.stringify({ files: sizes })
-  );
+  signal?.throwIfAborted();
+  const marker = path.join(modelDir(baseDir, model), MARKER);
+  await fsp.writeFile(marker, JSON.stringify({ files: sizes }));
+  if (signal?.aborted) {
+    await fsp.rm(marker, { force: true });
+    signal.throwIfAborted();
+  }
   onProgress?.({ received: total, total, fraction: 1, file: null });
 }
 

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -185,8 +185,16 @@ function resumedResponseIsCompatible(res, partial, file) {
 
   const oldEtag = partial.metadata.etag;
   const oldModified = partial.metadata.lastModified;
-  if (oldEtag && res.headers.get("etag") !== oldEtag) return false;
-  if (!oldEtag && oldModified && res.headers.get("last-modified") !== oldModified) return false;
+  const strongEtag = oldEtag && !oldEtag.startsWith("W/");
+  if (strongEtag && res.headers.get("etag") !== oldEtag) return false;
+  if (!strongEtag && oldModified && res.headers.get("last-modified") !== oldModified) {
+    return false;
+  }
+  // A weak ETag cannot go in If-Range, but it is still useful as a consistency
+  // check when Last-Modified is unavailable.
+  if (!strongEtag && !oldModified && oldEtag && res.headers.get("etag") !== oldEtag) {
+    return false;
+  }
   return true;
 }
 

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -5,11 +5,12 @@
 // unit-testable against a local HTTP server.
 //
 // Each file is streamed to `<name>.part`, with resume metadata in
-// `<name>.part.json`, checksum-verified, then renamed into place — so a
-// half-finished download never looks complete. A
-// model counts as installed once every file is present and a `.complete`
-// marker has been written. The marker records each file's size as actually
-// written, so `isInstalled` can reject a model whose files were later truncated
+// `<name>.part.json`, then validated against its configured size and optional
+// SHA-256 checksum before being renamed into place — so a half-finished
+// download never looks complete. A model counts as installed once every file
+// is present and a `.complete` marker has been written. The marker records each
+// file's size as actually written, so `isInstalled` can reject a model whose
+// files were later truncated
 // (e.g. a disk filling up) rather than trusting mere file presence.
 
 const fs = require("node:fs");

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -145,7 +145,8 @@ async function readPartial(dest, file) {
     meta.url !== file.url ||
     meta.expectedBytes !== expectedBytes ||
     stat.size <= 0 ||
-    (expectedBytes && stat.size > expectedBytes)
+    (expectedBytes && stat.size > expectedBytes) ||
+    (!file.sha256 && !ifRangeValue(meta))
   ) {
     await discardPartial(paths);
     return null;
@@ -167,8 +168,12 @@ function ifRangeValue(metadata) {
   // RFC 9110 forbids weak entity tags in If-Range. Last-Modified is the next
   // best validator; with neither, the final SHA-256 still prevents installation
   // of bytes combined from incompatible representations.
-  if (metadata.etag && !metadata.etag.startsWith("W/")) return metadata.etag;
-  return metadata.lastModified || null;
+  const etag = typeof metadata.etag === "string" ? metadata.etag : null;
+  const lastModified = typeof metadata.lastModified === "string"
+    ? metadata.lastModified
+    : null;
+  if (etag && !etag.startsWith("W/")) return etag;
+  return lastModified;
 }
 
 function parseContentRange(value) {
@@ -183,8 +188,12 @@ function resumedResponseIsCompatible(res, partial, file) {
   if (file.bytes && range.total !== file.bytes) return false;
   if (partial.metadata.totalBytes && range.total !== partial.metadata.totalBytes) return false;
 
-  const oldEtag = partial.metadata.etag;
-  const oldModified = partial.metadata.lastModified;
+  const oldEtag = typeof partial.metadata.etag === "string"
+    ? partial.metadata.etag
+    : null;
+  const oldModified = typeof partial.metadata.lastModified === "string"
+    ? partial.metadata.lastModified
+    : null;
   const strongEtag = oldEtag && !oldEtag.startsWith("W/");
   if (strongEtag && res.headers.get("etag") !== oldEtag) return false;
   if (!strongEtag && oldModified && res.headers.get("last-modified") !== oldModified) {

--- a/main/engines/registry.js
+++ b/main/engines/registry.js
@@ -9,9 +9,9 @@
 // manager streams each URL to disk and the engines load the files in place.
 //
 // `bytes` is the exact file size, used for the wizard's progress bar. `sha256`
-// is the file's verified checksum: the download manager hashes each file as it
-// streams and rejects a mismatch, which is the real guard against a corrupted,
-// tampered, or wrong file being loaded into the native runtimes. Every URL is
+// is the file's verified checksum: the download manager hashes every byte of
+// the completed file and rejects a mismatch, which is the real guard against a
+// corrupted, tampered, or wrong file being loaded into the native runtimes. Every URL is
 // pinned to an immutable Hugging Face commit (`resolve/<commit>/…`) rather than
 // a moving branch, so the bytes are reproducible and the checksum can't drift.
 //

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -787,6 +787,47 @@ test("weak ETags use Last-Modified to validate resumed content", async () => {
   }
 });
 
+test("a checksum-less partial without a strong validator restarts from zero", async () => {
+  const oldBody = Buffer.from("old-unvalidated-content-".repeat(32));
+  const newBody = Buffer.from("new-unvalidated-content-".repeat(32));
+  assert.strictEqual(oldBody.length, newBody.length);
+  const cut = 128;
+  const ranges = [];
+  const server = http.createServer((req, res) => {
+    ranges.push(req.headers.range);
+    res.setHeader("etag", 'W/"shared"');
+    res.setHeader("content-length", newBody.length);
+    res.end(newBody);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "weak-only",
+        files: [{ name: "model.gguf", bytes: newBody.length, url: `${base}/model.gguf` }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, oldBody.subarray(0, cut));
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: oldBody.length,
+        etag: 'W/"shared"',
+        lastModified: null,
+        totalBytes: oldBody.length,
+      }));
+
+      await manager.download(dir, model);
+      assert.deepStrictEqual(ranges, [undefined]);
+      assert.deepStrictEqual(fs.readFileSync(dest), newBody);
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("an unsatisfiable range discards the partial and retries from zero", async () => {
   const full = Buffer.from("range-no-longer-valid-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -662,6 +662,45 @@ test("cancellation while hashing preserves the complete partial", async () => {
   }
 });
 
+test("an exact-size verified partial completes without a network request", async () => {
+  const full = Buffer.from("complete-before-rename-".repeat(32));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  let hits = 0;
+  const server = http.createServer((_req, res) => {
+    hits++;
+    res.end(full);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "complete-partial",
+        files: [{ name: "m.gguf", bytes: full.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, full);
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: full.length,
+        etag: '"stable"',
+        lastModified: null,
+        totalBytes: full.length,
+      }));
+
+      await manager.download(dir, model);
+      assert.strictEqual(hits, 0);
+      assert.deepStrictEqual(fs.readFileSync(dest), full);
+      assert.ok(!fs.existsSync(`${dest}.part`));
+      assert.ok(!fs.existsSync(`${dest}.part.json`));
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("corrupted resumed bytes fail the full checksum and are discarded", async () => {
   const full = Buffer.from("checksum-all-bytes-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -333,6 +333,39 @@ test("download skips files already on disk and remove frees them", async () => {
   }
 });
 
+test("download replaces an existing file that fails checksum validation", async () => {
+  const good = Buffer.from("verified destination");
+  const bad = Buffer.from("corrupted destinatio");
+  assert.strictEqual(bad.length, good.length);
+  const sha = crypto.createHash("sha256").update(good).digest("hex");
+  let hits = 0;
+  const server = http.createServer((_req, res) => {
+    hits++;
+    res.setHeader("content-length", good.length);
+    res.end(good);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "replace-corrupt",
+        files: [{ name: "a.bin", bytes: good.length, url: `${base}/a.bin`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(dest, bad);
+
+      await manager.download(dir, model);
+      assert.strictEqual(hits, 1);
+      assert.deepStrictEqual(fs.readFileSync(dest), good);
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("isInstalled rejects a model whose file was truncated after download", async () => {
   const a = Buffer.from("the-whole-file-".repeat(20));
   const { server, base } = await serveFiles({ "/a.bin": a });

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -879,6 +879,70 @@ test("corrupted resumed bytes fail the full checksum and are discarded", async (
   }
 });
 
+test("invalid partial metadata is discarded before a full download", async () => {
+  const full = Buffer.from("fresh-representation-".repeat(32));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  const ranges = [];
+  const server = http.createServer((req, res) => {
+    ranges.push(req.headers.range);
+    res.setHeader("content-length", full.length);
+    res.end(full);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  const cases = [
+    { name: "missing-metadata", metadata: null },
+    { name: "malformed-metadata", metadata: "{" },
+    { name: "wrong-url", metadata: { url: `${base}/other.bin` } },
+    { name: "wrong-expected-size", metadata: { expectedBytes: full.length + 1 } },
+    { name: "zero-byte-partial", body: Buffer.alloc(0) },
+    { name: "oversized-partial", body: Buffer.alloc(full.length + 1) },
+  ];
+  try {
+    await withTmp(async (dir) => {
+      for (const scenario of cases) {
+        const file = {
+          name: `${scenario.name}.bin`,
+          bytes: full.length,
+          url: `${base}/${scenario.name}.bin`,
+          sha256: sha,
+        };
+        const model = { kind: "stt", id: scenario.name, files: [file] };
+        const dest = manager.filePath(dir, model, file);
+        const metadata = {
+          url: file.url,
+          expectedBytes: full.length,
+          etag: '"stable"',
+          lastModified: null,
+          totalBytes: full.length,
+          ...(typeof scenario.metadata === "object" ? scenario.metadata : {}),
+        };
+        await fsp.mkdir(path.dirname(dest), { recursive: true });
+        await fsp.writeFile(
+          `${dest}.part`,
+          scenario.body === undefined ? full.subarray(0, 100) : scenario.body
+        );
+        if (scenario.metadata !== null) {
+          await fsp.writeFile(
+            `${dest}.part.json`,
+            typeof scenario.metadata === "string"
+              ? scenario.metadata
+              : JSON.stringify(metadata)
+          );
+        }
+
+        await manager.download(dir, model);
+        assert.deepStrictEqual(fs.readFileSync(dest), full, scenario.name);
+        assert.ok(!fs.existsSync(`${dest}.part`), scenario.name);
+        assert.ok(!fs.existsSync(`${dest}.part.json`), scenario.name);
+      }
+      assert.deepStrictEqual(ranges, cases.map(() => undefined));
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("remove deletes partial files and their resume metadata", async () => {
   await withTmp(async (dir) => {
     const model = {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -277,6 +277,63 @@ test("download streams files, reports progress, and marks complete", async () =>
   }
 });
 
+test("multi-file resume credits complete and partial files together", async () => {
+  const complete = Buffer.from("already-verified-file");
+  const resumed = Buffer.from("partially-downloaded-file-".repeat(32));
+  const completeSha = crypto.createHash("sha256").update(complete).digest("hex");
+  const resumedSha = crypto.createHash("sha256").update(resumed).digest("hex");
+  const cut = 180;
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    requests.push({ url: req.url, range: req.headers.range });
+    assert.strictEqual(req.url, "/partial.bin");
+    assert.strictEqual(req.headers.range, `bytes=${cut}-`);
+    res.statusCode = 206;
+    res.setHeader("etag", '"stable"');
+    res.setHeader("content-range", `bytes ${cut}-${resumed.length - 1}/${resumed.length}`);
+    res.setHeader("content-length", resumed.length - cut);
+    res.end(resumed.subarray(cut));
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "multi-resume",
+        files: [
+          { name: "complete.bin", bytes: complete.length,
+            url: `${base}/complete.bin`, sha256: completeSha },
+          { name: "partial.bin", bytes: resumed.length,
+            url: `${base}/partial.bin`, sha256: resumedSha },
+        ],
+      };
+      const completeDest = manager.filePath(dir, model, model.files[0]);
+      const partialDest = manager.filePath(dir, model, model.files[1]);
+      await fsp.mkdir(path.dirname(completeDest), { recursive: true });
+      await fsp.writeFile(completeDest, complete);
+      await fsp.writeFile(`${partialDest}.part`, resumed.subarray(0, cut));
+      await fsp.writeFile(`${partialDest}.part.json`, JSON.stringify({
+        url: model.files[1].url,
+        expectedBytes: resumed.length,
+        etag: '"stable"',
+        lastModified: null,
+        totalBytes: resumed.length,
+      }));
+
+      const progress = [];
+      await manager.download(dir, model, { onProgress: (p) => progress.push(p.received) });
+      assert.deepStrictEqual(requests, [{ url: "/partial.bin", range: `bytes=${cut}-` }]);
+      assert.strictEqual(progress[0], complete.length + cut);
+      for (let i = 1; i < progress.length; i++) assert.ok(progress[i] >= progress[i - 1]);
+      assert.deepStrictEqual(fs.readFileSync(completeDest), complete);
+      assert.deepStrictEqual(fs.readFileSync(partialDest), resumed);
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("download verifies sha256 and rejects a mismatch", async () => {
   const good = Buffer.from("trustworthy bytes");
   const sha = crypto.createHash("sha256").update(good).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -406,21 +406,28 @@ test("isInstalled accepts a legacy or malformed marker as presence-only", async 
   }
 });
 
-test("an aborted download leaves no .part and a retry succeeds", async () => {
+test("a transient failure retains bytes and retries with Range and If-Range", async () => {
   const full = Buffer.from("the-full-payload-".repeat(64));
-  // First request: send a few bytes then destroy the socket mid-stream so the
-  // transfer fails. Later requests: serve the whole file.
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  const cut = 128;
   let attempt = 0;
+  const requests = [];
   const server = http.createServer((req, res) => {
     attempt++;
+    requests.push({ range: req.headers.range, ifRange: req.headers["if-range"] });
+    res.setHeader("etag", '"version-1"');
     if (attempt === 1) {
       res.setHeader("content-length", full.length);
-      res.write(full.subarray(0, 8));
-      res.socket.destroy(); // abrupt failure, like a dropped connection
+      res.flushHeaders();
+      res.write(full.subarray(0, cut));
+      setTimeout(() => res.destroy(), 10); // abrupt failure, like a dropped connection
       return;
     }
-    res.setHeader("content-length", full.length);
-    res.end(full);
+    assert.strictEqual(req.headers.range, `bytes=${cut}-`);
+    res.statusCode = 206;
+    res.setHeader("content-range", `bytes ${cut}-${full.length - 1}/${full.length}`);
+    res.setHeader("content-length", full.length - cut);
+    res.end(full.subarray(cut));
   });
   await new Promise((r) => server.listen(0, "127.0.0.1", r));
   const base = `http://127.0.0.1:${server.address().port}`;
@@ -428,24 +435,234 @@ test("an aborted download leaves no .part and a retry succeeds", async () => {
     await withTmp(async (dir) => {
       const model = {
         kind: "cleanup", id: "resume",
-        files: [{ name: "m.gguf", bytes: full.length, url: `${base}/m.gguf` }],
+        files: [{ name: "m.gguf", bytes: full.length, url: `${base}/m.gguf`, sha256: sha }],
       };
       const dest = manager.filePath(dir, model, model.files[0]);
 
       await assert.rejects(() => manager.download(dir, model));
-      // No half-written .part is left behind to masquerade as a real file, and
-      // the model is not considered installed.
-      assert.ok(!fs.existsSync(`${dest}.part`), "stray .part should be discarded");
+      assert.strictEqual(fs.statSync(`${dest}.part`).size, cut);
+      assert.ok(fs.existsSync(`${dest}.part.json`));
       assert.strictEqual(manager.isInstalled(dir, model), false);
 
-      // A second attempt re-fetches the whole file and completes.
-      await manager.download(dir, model);
+      const progress = [];
+      await manager.download(dir, model, { onProgress: (p) => progress.push(p.received) });
       assert.strictEqual(manager.isInstalled(dir, model), true);
+      assert.deepStrictEqual(fs.readFileSync(dest), full);
+      assert.strictEqual(requests[1].ifRange, '"version-1"');
+      assert.strictEqual(progress[0], cut, "retry begins at reusable on-disk bytes");
+      for (let i = 1; i < progress.length; i++) {
+        assert.ok(progress[i] >= progress[i - 1], "resume progress must be monotonic");
+      }
+      assert.ok(!fs.existsSync(`${dest}.part.json`));
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("a server that ignores Range safely overwrites rather than appends", async () => {
+  const full = Buffer.from("ignore-range-".repeat(80));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  const cut = 96;
+  let attempt = 0;
+  const ranges = [];
+  const server = http.createServer((req, res) => {
+    attempt++;
+    ranges.push(req.headers.range);
+    res.setHeader("etag", '"same"');
+    res.setHeader("content-length", full.length);
+    if (attempt === 1) {
+      res.flushHeaders();
+      res.write(full.subarray(0, cut));
+      setTimeout(() => res.destroy(), 10);
+      return;
+    }
+    res.end(full); // deliberately return 200 to the Range request
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "ignore-range",
+        files: [{ name: "a.bin", bytes: full.length, url: `${base}/a.bin`, sha256: sha }],
+      };
+      await assert.rejects(() => manager.download(dir, model));
+      const seen = [];
+      await manager.download(dir, model, { onProgress: (p) => seen.push(p.received) });
+      assert.strictEqual(ranges[1], `bytes=${cut}-`);
+      assert.deepStrictEqual(fs.readFileSync(manager.filePath(dir, model, model.files[0])), full);
+      for (let i = 1; i < seen.length; i++) assert.ok(seen[i] >= seen[i - 1]);
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("a changed validator invalidates the partial and fetches a full representation", async () => {
+  const oldBody = Buffer.from("old-content-".repeat(80));
+  const newBody = Buffer.from("new-content-".repeat(80));
+  assert.strictEqual(oldBody.length, newBody.length);
+  const sha = crypto.createHash("sha256").update(newBody).digest("hex");
+  const cut = 100;
+  let attempt = 0;
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    attempt++;
+    requests.push({ range: req.headers.range, ifRange: req.headers["if-range"] });
+    if (attempt === 1) {
+      res.setHeader("etag", '"old"');
+      res.setHeader("content-length", oldBody.length);
+      res.flushHeaders();
+      res.write(oldBody.subarray(0, cut));
+      setTimeout(() => res.destroy(), 10);
+      return;
+    }
+    res.setHeader("etag", '"new"');
+    if (attempt === 2) {
+      // A non-compliant server sends a range despite the failed If-Range. The
+      // changed ETag must still be noticed before any bytes are appended.
+      res.statusCode = 206;
+      res.setHeader("content-range", `bytes ${cut}-${newBody.length - 1}/${newBody.length}`);
+      res.setHeader("content-length", newBody.length - cut);
+      res.end(newBody.subarray(cut));
+      return;
+    }
+    res.setHeader("content-length", newBody.length);
+    res.end(newBody);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "changed",
+        files: [{ name: "m.gguf", bytes: newBody.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      await assert.rejects(() => manager.download(dir, model));
+      await manager.download(dir, model);
+      assert.strictEqual(attempt, 3);
+      assert.strictEqual(requests[1].ifRange, '"old"');
+      assert.strictEqual(requests[2].range, undefined);
+      assert.deepStrictEqual(fs.readFileSync(manager.filePath(dir, model, model.files[0])), newBody);
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("cancellation preserves a resumable partial", async () => {
+  const full = Buffer.from("cancel-me-".repeat(200));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  let attempt = 0;
+  let firstResponse;
+  const server = http.createServer((req, res) => {
+    attempt++;
+    res.setHeader("etag", '"cancel-v1"');
+    if (attempt === 1) {
+      firstResponse = res;
+      res.setHeader("content-length", full.length);
+      res.flushHeaders();
+      res.write(full.subarray(0, 256));
+      return;
+    }
+    const offset = Number(req.headers.range.match(/^bytes=(\d+)-$/)[1]);
+    res.statusCode = 206;
+    res.setHeader("content-range", `bytes ${offset}-${full.length - 1}/${full.length}`);
+    res.setHeader("content-length", full.length - offset);
+    res.end(full.subarray(offset));
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "cancel",
+        files: [{ name: "m.gguf", bytes: full.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      const controller = new AbortController();
+      let queued = false;
+      await assert.rejects(
+        () => manager.download(dir, model, {
+          signal: controller.signal,
+          onProgress: () => {
+            if (!queued) {
+              queued = true;
+              setTimeout(() => controller.abort(), 10);
+            }
+          },
+        }),
+        /abort/i
+      );
+      firstResponse.destroy();
+      const dest = manager.filePath(dir, model, model.files[0]);
+      const kept = fs.statSync(`${dest}.part`).size;
+      assert.ok(kept > 0 && kept < full.length);
+      assert.ok(fs.existsSync(`${dest}.part.json`));
+      await manager.download(dir, model);
       assert.deepStrictEqual(fs.readFileSync(dest), full);
     });
   } finally {
     server.close();
   }
+});
+
+test("corrupted resumed bytes fail the full checksum and are discarded", async () => {
+  const full = Buffer.from("checksum-all-bytes-".repeat(64));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  const cut = 120;
+  const server = http.createServer((req, res) => {
+    assert.strictEqual(req.headers.range, `bytes=${cut}-`);
+    res.statusCode = 206;
+    res.setHeader("etag", '"stable"');
+    res.setHeader("content-range", `bytes ${cut}-${full.length - 1}/${full.length}`);
+    res.setHeader("content-length", full.length - cut);
+    res.end(full.subarray(cut));
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "corrupt-partial",
+        files: [{ name: "a.bin", bytes: full.length, url: `${base}/a.bin`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      const corrupt = Buffer.from(full.subarray(0, cut));
+      corrupt[0] ^= 0xff;
+      await fsp.writeFile(`${dest}.part`, corrupt);
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: full.length,
+        etag: '"stable"',
+        lastModified: null,
+        totalBytes: full.length,
+      }));
+
+      await assert.rejects(() => manager.download(dir, model), /Checksum mismatch/);
+      assert.ok(!fs.existsSync(`${dest}.part`));
+      assert.ok(!fs.existsSync(`${dest}.part.json`));
+      assert.strictEqual(manager.isInstalled(dir, model), false);
+    });
+  } finally {
+    server.close();
+  }
+});
+
+test("remove deletes partial files and their resume metadata", async () => {
+  await withTmp(async (dir) => {
+    const model = {
+      kind: "cleanup", id: "remove-partial",
+      files: [{ name: "m.gguf", bytes: 10, url: "https://example.com/m.gguf" }],
+    };
+    const dest = manager.filePath(dir, model, model.files[0]);
+    await fsp.mkdir(path.dirname(dest), { recursive: true });
+    await fsp.writeFile(`${dest}.part`, "partial");
+    await fsp.writeFile(`${dest}.part.json`, "{}");
+    await manager.remove(dir, model);
+    assert.ok(!fs.existsSync(manager.modelDir(dir, model)));
+  });
 });
 
 test("engines.clean falls back to the raw transcript when cleanup is empty", async () => {

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -650,6 +650,54 @@ test("a changed validator invalidates the partial and fetches a full representat
   }
 });
 
+test("an unsatisfiable range discards the partial and retries from zero", async () => {
+  const full = Buffer.from("range-no-longer-valid-".repeat(64));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  const cut = 144;
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    requests.push(req.headers.range);
+    if (requests.length === 1) {
+      res.statusCode = 416;
+      res.setHeader("content-range", `bytes */${full.length}`);
+      res.end();
+      return;
+    }
+    res.setHeader("etag", '"replacement"');
+    res.setHeader("content-length", full.length);
+    res.end(full);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "stt", id: "range-416",
+        files: [{ name: "a.bin", bytes: full.length, url: `${base}/a.bin`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, full.subarray(0, cut));
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: full.length,
+        etag: '"old"',
+        lastModified: null,
+        totalBytes: full.length,
+      }));
+
+      await manager.download(dir, model);
+      assert.deepStrictEqual(requests, [`bytes=${cut}-`, undefined]);
+      assert.deepStrictEqual(fs.readFileSync(dest), full);
+      assert.ok(!fs.existsSync(`${dest}.part`));
+      assert.ok(!fs.existsSync(`${dest}.part.json`));
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("cancellation preserves a resumable partial", async () => {
   const full = Buffer.from("cancel-me-".repeat(200));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -1014,6 +1014,48 @@ test("an exact-size verified partial completes without a network request", async
   }
 });
 
+test("an exact-size corrupted partial is replaced by a verified download", async () => {
+  const good = Buffer.from("verified-complete-partial");
+  const bad = Buffer.from("corrupted-complete-partia");
+  assert.strictEqual(bad.length, good.length);
+  const sha = crypto.createHash("sha256").update(good).digest("hex");
+  const ranges = [];
+  const server = http.createServer((req, res) => {
+    ranges.push(req.headers.range);
+    res.setHeader("content-length", good.length);
+    res.end(good);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "corrupt-complete-partial",
+        files: [{ name: "m.gguf", bytes: good.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, bad);
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: good.length,
+        etag: '"stale"',
+        lastModified: null,
+        totalBytes: good.length,
+      }));
+
+      await manager.download(dir, model);
+      assert.deepStrictEqual(ranges, [undefined]);
+      assert.deepStrictEqual(fs.readFileSync(dest), good);
+      assert.ok(!fs.existsSync(`${dest}.part`));
+      assert.ok(!fs.existsSync(`${dest}.part.json`));
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("corrupted resumed bytes fail the full checksum and are discarded", async () => {
   const full = Buffer.from("checksum-all-bytes-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -410,6 +410,7 @@ test("a transient failure retains bytes and retries with Range and If-Range", as
   const full = Buffer.from("the-full-payload-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");
   const cut = 128;
+  let kept = 0;
   let attempt = 0;
   const requests = [];
   const server = http.createServer((req, res) => {
@@ -419,15 +420,17 @@ test("a transient failure retains bytes and retries with Range and If-Range", as
     if (attempt === 1) {
       res.setHeader("content-length", full.length);
       res.flushHeaders();
-      res.write(full.subarray(0, cut));
-      setTimeout(() => res.destroy(), 10); // abrupt failure, like a dropped connection
+      res.write(full.subarray(0, cut), () => {
+        setTimeout(() => res.destroy(), 25); // abrupt failure, like a dropped connection
+      });
       return;
     }
-    assert.strictEqual(req.headers.range, `bytes=${cut}-`);
+    const offset = Number(req.headers.range.match(/^bytes=(\d+)-$/)[1]);
+    assert.strictEqual(offset, kept);
     res.statusCode = 206;
-    res.setHeader("content-range", `bytes ${cut}-${full.length - 1}/${full.length}`);
-    res.setHeader("content-length", full.length - cut);
-    res.end(full.subarray(cut));
+    res.setHeader("content-range", `bytes ${offset}-${full.length - 1}/${full.length}`);
+    res.setHeader("content-length", full.length - offset);
+    res.end(full.subarray(offset));
   });
   await new Promise((r) => server.listen(0, "127.0.0.1", r));
   const base = `http://127.0.0.1:${server.address().port}`;
@@ -440,7 +443,8 @@ test("a transient failure retains bytes and retries with Range and If-Range", as
       const dest = manager.filePath(dir, model, model.files[0]);
 
       await assert.rejects(() => manager.download(dir, model));
-      assert.strictEqual(fs.statSync(`${dest}.part`).size, cut);
+      kept = fs.statSync(`${dest}.part`).size;
+      assert.ok(kept > 0 && kept <= cut);
       assert.ok(fs.existsSync(`${dest}.part.json`));
       assert.strictEqual(manager.isInstalled(dir, model), false);
 
@@ -449,7 +453,7 @@ test("a transient failure retains bytes and retries with Range and If-Range", as
       assert.strictEqual(manager.isInstalled(dir, model), true);
       assert.deepStrictEqual(fs.readFileSync(dest), full);
       assert.strictEqual(requests[1].ifRange, '"version-1"');
-      assert.strictEqual(progress[0], cut, "retry begins at reusable on-disk bytes");
+      assert.strictEqual(progress[0], kept, "retry begins at reusable on-disk bytes");
       for (let i = 1; i < progress.length; i++) {
         assert.ok(progress[i] >= progress[i - 1], "resume progress must be monotonic");
       }
@@ -464,6 +468,7 @@ test("a server that ignores Range safely overwrites rather than appends", async 
   const full = Buffer.from("ignore-range-".repeat(80));
   const sha = crypto.createHash("sha256").update(full).digest("hex");
   const cut = 96;
+  let kept = 0;
   let attempt = 0;
   const ranges = [];
   const server = http.createServer((req, res) => {
@@ -473,8 +478,7 @@ test("a server that ignores Range safely overwrites rather than appends", async 
     res.setHeader("content-length", full.length);
     if (attempt === 1) {
       res.flushHeaders();
-      res.write(full.subarray(0, cut));
-      setTimeout(() => res.destroy(), 10);
+      res.write(full.subarray(0, cut), () => setTimeout(() => res.destroy(), 25));
       return;
     }
     res.end(full); // deliberately return 200 to the Range request
@@ -488,10 +492,13 @@ test("a server that ignores Range safely overwrites rather than appends", async 
         files: [{ name: "a.bin", bytes: full.length, url: `${base}/a.bin`, sha256: sha }],
       };
       await assert.rejects(() => manager.download(dir, model));
+      const dest = manager.filePath(dir, model, model.files[0]);
+      kept = fs.statSync(`${dest}.part`).size;
+      assert.ok(kept > 0 && kept <= cut);
       const seen = [];
       await manager.download(dir, model, { onProgress: (p) => seen.push(p.received) });
-      assert.strictEqual(ranges[1], `bytes=${cut}-`);
-      assert.deepStrictEqual(fs.readFileSync(manager.filePath(dir, model, model.files[0])), full);
+      assert.strictEqual(ranges[1], `bytes=${kept}-`);
+      assert.deepStrictEqual(fs.readFileSync(dest), full);
       for (let i = 1; i < seen.length; i++) assert.ok(seen[i] >= seen[i - 1]);
     });
   } finally {
@@ -505,6 +512,7 @@ test("a changed validator invalidates the partial and fetches a full representat
   assert.strictEqual(oldBody.length, newBody.length);
   const sha = crypto.createHash("sha256").update(newBody).digest("hex");
   const cut = 100;
+  let kept = 0;
   let attempt = 0;
   const requests = [];
   const server = http.createServer((req, res) => {
@@ -514,18 +522,19 @@ test("a changed validator invalidates the partial and fetches a full representat
       res.setHeader("etag", '"old"');
       res.setHeader("content-length", oldBody.length);
       res.flushHeaders();
-      res.write(oldBody.subarray(0, cut));
-      setTimeout(() => res.destroy(), 10);
+      res.write(oldBody.subarray(0, cut), () => setTimeout(() => res.destroy(), 25));
       return;
     }
     res.setHeader("etag", '"new"');
     if (attempt === 2) {
       // A non-compliant server sends a range despite the failed If-Range. The
       // changed ETag must still be noticed before any bytes are appended.
+      const offset = Number(req.headers.range.match(/^bytes=(\d+)-$/)[1]);
+      assert.strictEqual(offset, kept);
       res.statusCode = 206;
-      res.setHeader("content-range", `bytes ${cut}-${newBody.length - 1}/${newBody.length}`);
-      res.setHeader("content-length", newBody.length - cut);
-      res.end(newBody.subarray(cut));
+      res.setHeader("content-range", `bytes ${offset}-${newBody.length - 1}/${newBody.length}`);
+      res.setHeader("content-length", newBody.length - offset);
+      res.end(newBody.subarray(offset));
       return;
     }
     res.setHeader("content-length", newBody.length);
@@ -540,11 +549,14 @@ test("a changed validator invalidates the partial and fetches a full representat
         files: [{ name: "m.gguf", bytes: newBody.length, url: `${base}/m.gguf`, sha256: sha }],
       };
       await assert.rejects(() => manager.download(dir, model));
+      const dest = manager.filePath(dir, model, model.files[0]);
+      kept = fs.statSync(`${dest}.part`).size;
+      assert.ok(kept > 0 && kept <= cut);
       await manager.download(dir, model);
       assert.strictEqual(attempt, 3);
       assert.strictEqual(requests[1].ifRange, '"old"');
       assert.strictEqual(requests[2].range, undefined);
-      assert.deepStrictEqual(fs.readFileSync(manager.filePath(dir, model, model.files[0])), newBody);
+      assert.deepStrictEqual(fs.readFileSync(dest), newBody);
     });
   } finally {
     server.close();

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -828,6 +828,49 @@ test("a checksum-less partial without a strong validator restarts from zero", as
   }
 });
 
+test("a checksum-less partial resumes with a matching strong ETag", async () => {
+  const full = Buffer.from("custom-model-with-strong-etag-".repeat(32));
+  const cut = 192;
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    requests.push({ range: req.headers.range, ifRange: req.headers["if-range"] });
+    res.statusCode = 206;
+    res.setHeader("etag", '"strong-v1"');
+    res.setHeader("content-range", `bytes ${cut}-${full.length - 1}/${full.length}`);
+    res.setHeader("content-length", full.length - cut);
+    res.end(full.subarray(cut));
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "strong-custom",
+        files: [{ name: "model.gguf", bytes: full.length, url: `${base}/model.gguf` }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, full.subarray(0, cut));
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: full.length,
+        etag: '"strong-v1"',
+        lastModified: null,
+        totalBytes: full.length,
+      }));
+
+      await manager.download(dir, model);
+      assert.deepStrictEqual(requests, [
+        { range: `bytes=${cut}-`, ifRange: '"strong-v1"' },
+      ]);
+      assert.deepStrictEqual(fs.readFileSync(dest), full);
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("an unsatisfiable range discards the partial and retries from zero", async () => {
   const full = Buffer.from("range-no-longer-valid-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -497,6 +497,60 @@ test("a transient failure retains bytes and retries with Range and If-Range", as
   }
 });
 
+test("a temporary HTTP error preserves partial state for a later resume", async () => {
+  const full = Buffer.from("retry-after-http-error-".repeat(64));
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  const cut = 160;
+  let attempt = 0;
+  const server = http.createServer((req, res) => {
+    attempt++;
+    assert.strictEqual(req.headers.range, `bytes=${cut}-`);
+    assert.strictEqual(req.headers["if-range"], '"stable"');
+    if (attempt === 1) {
+      res.statusCode = 503;
+      res.end("try later");
+      return;
+    }
+    res.statusCode = 206;
+    res.setHeader("etag", '"stable"');
+    res.setHeader("content-range", `bytes ${cut}-${full.length - 1}/${full.length}`);
+    res.setHeader("content-length", full.length - cut);
+    res.end(full.subarray(cut));
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "temporary-http-error",
+        files: [{ name: "m.gguf", bytes: full.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      const metadata = JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: full.length,
+        etag: '"stable"',
+        lastModified: null,
+        totalBytes: full.length,
+      });
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, full.subarray(0, cut));
+      await fsp.writeFile(`${dest}.part.json`, metadata);
+
+      await assert.rejects(() => manager.download(dir, model), /HTTP 503/);
+      assert.deepStrictEqual(fs.readFileSync(`${dest}.part`), full.subarray(0, cut));
+      assert.strictEqual(fs.readFileSync(`${dest}.part.json`, "utf8"), metadata);
+
+      await manager.download(dir, model);
+      assert.strictEqual(attempt, 2);
+      assert.deepStrictEqual(fs.readFileSync(dest), full);
+      assert.strictEqual(manager.isInstalled(dir, model), true);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("a server that ignores Range safely overwrites rather than appends", async () => {
   const full = Buffer.from("ignore-range-".repeat(80));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -619,6 +619,49 @@ test("cancellation preserves a resumable partial", async () => {
   }
 });
 
+test("cancellation while hashing preserves the complete partial", async () => {
+  const full = Buffer.alloc(32 * 1024 * 1024, 0x5a);
+  const sha = crypto.createHash("sha256").update(full).digest("hex");
+  let hits = 0;
+  const server = http.createServer((_req, res) => {
+    hits++;
+    res.end(full);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    await withTmp(async (dir) => {
+      const model = {
+        kind: "cleanup", id: "cancel-hash",
+        files: [{ name: "m.gguf", bytes: full.length, url: `${base}/m.gguf`, sha256: sha }],
+      };
+      const dest = manager.filePath(dir, model, model.files[0]);
+      await fsp.mkdir(path.dirname(dest), { recursive: true });
+      await fsp.writeFile(`${dest}.part`, full);
+      await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+        url: model.files[0].url,
+        expectedBytes: full.length,
+        etag: '"stable"',
+        lastModified: null,
+        totalBytes: full.length,
+      }));
+
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 0);
+      await assert.rejects(
+        () => manager.download(dir, model, { signal: controller.signal }),
+        /abort/i
+      );
+      assert.strictEqual(hits, 0);
+      assert.ok(!fs.existsSync(dest));
+      assert.strictEqual(fs.statSync(`${dest}.part`).size, full.length);
+      assert.ok(fs.existsSync(`${dest}.part.json`));
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("corrupted resumed bytes fail the full checksum and are discarded", async () => {
   const full = Buffer.from("checksum-all-bytes-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -650,6 +650,86 @@ test("a changed validator invalidates the partial and fetches a full representat
   }
 });
 
+test("weak ETags use Last-Modified to validate resumed content", async () => {
+  const oldDate = "Wed, 21 Oct 2015 07:28:00 GMT";
+  const newDate = "Thu, 22 Oct 2015 07:28:00 GMT";
+  const stable = Buffer.from("stable-weak-validator-".repeat(32));
+  const oldBody = Buffer.from("old-weak-content-".repeat(32));
+  const newBody = Buffer.from("new-weak-content-".repeat(32));
+  assert.strictEqual(oldBody.length, newBody.length);
+  const cut = 128;
+  const requests = [];
+  let changedAttempts = 0;
+  const server = http.createServer((req, res) => {
+    requests.push({ url: req.url, range: req.headers.range, ifRange: req.headers["if-range"] });
+    res.setHeader("etag", 'W/"shared"');
+    if (req.url === "/stable.bin") {
+      res.statusCode = 206;
+      res.setHeader("last-modified", oldDate);
+      res.setHeader("content-range", `bytes ${cut}-${stable.length - 1}/${stable.length}`);
+      res.setHeader("content-length", stable.length - cut);
+      res.end(stable.subarray(cut));
+      return;
+    }
+    changedAttempts++;
+    res.setHeader("last-modified", newDate);
+    if (changedAttempts === 1) {
+      res.statusCode = 206;
+      res.setHeader("content-range", `bytes ${cut}-${newBody.length - 1}/${newBody.length}`);
+      res.setHeader("content-length", newBody.length - cut);
+      res.end(newBody.subarray(cut));
+      return;
+    }
+    res.setHeader("content-length", newBody.length);
+    res.end(newBody);
+  });
+  await new Promise((r) => server.listen(0, "127.0.0.1", r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  async function seed(dir, model, body) {
+    const dest = manager.filePath(dir, model, model.files[0]);
+    await fsp.mkdir(path.dirname(dest), { recursive: true });
+    await fsp.writeFile(`${dest}.part`, body.subarray(0, cut));
+    await fsp.writeFile(`${dest}.part.json`, JSON.stringify({
+      url: model.files[0].url,
+      expectedBytes: body.length,
+      etag: 'W/"shared"',
+      lastModified: oldDate,
+      totalBytes: body.length,
+    }));
+    return dest;
+  }
+
+  try {
+    await withTmp(async (dir) => {
+      const stableModel = {
+        kind: "stt", id: "weak-stable",
+        files: [{ name: "stable.bin", bytes: stable.length, url: `${base}/stable.bin` }],
+      };
+      const stableDest = await seed(dir, stableModel, stable);
+      await manager.download(dir, stableModel);
+      assert.deepStrictEqual(fs.readFileSync(stableDest), stable);
+
+      const changedModel = {
+        kind: "cleanup", id: "weak-changed",
+        // Deliberately checksum-less: remote validators must prevent mixed bytes.
+        files: [{ name: "changed.bin", bytes: newBody.length, url: `${base}/changed.bin` }],
+      };
+      const changedDest = await seed(dir, changedModel, oldBody);
+      await manager.download(dir, changedModel);
+      assert.deepStrictEqual(fs.readFileSync(changedDest), newBody);
+
+      assert.deepStrictEqual(requests, [
+        { url: "/stable.bin", range: `bytes=${cut}-`, ifRange: oldDate },
+        { url: "/changed.bin", range: `bytes=${cut}-`, ifRange: oldDate },
+        { url: "/changed.bin", range: undefined, ifRange: undefined },
+      ]);
+    });
+  } finally {
+    server.close();
+  }
+});
+
 test("an unsatisfiable range discards the partial and retries from zero", async () => {
   const full = Buffer.from("range-no-longer-valid-".repeat(64));
   const sha = crypto.createHash("sha256").update(full).digest("hex");


### PR DESCRIPTION
## What

- retain interrupted model `.part` files with validator metadata
- resume eligible downloads with HTTP Range and If-Range
- safely restart incompatible responses while preserving full SHA-256 verification
- keep aggregate progress monotonic and remove partial state with the model

Closes #124

## Testing

- `npm test`
- `make smoke`
- `npx electron scripts/engine-smoke.js --no-sandbox`
- `npx electron scripts/overlay-smoke.js --no-sandbox`
- `npx electron scripts/settings-smoke.js --no-sandbox`