### PR TITLE
fix: restore Intel Mac downloads and architecture-compatible updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,8 @@ jobs:
       # One platform failing must not cancel the other platforms' uploads.
       fail-fast: false
       matrix:
-        # macos-latest is Apple Silicon (arm64) — the only macOS build we ship;
-        # Intel Macs run it under Rosetta. The Intel (x64) macos-13 leg was
-        # dropped: its GitHub-hosted runner repeatedly sat queued with no host,
-        # which left the publish-release gate (needs all builds) waiting forever
-        # and stranded v0.7.0/v0.8.0 as unpublished drafts.
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Each macOS build installs and tests native addons on its own CPU.
+        os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -91,9 +87,39 @@ jobs:
       - run: npm ci
       # On a tag, publish installers to the GitHub release; a plain
       # workflow_dispatch on a branch only uploads CI artifacts.
-      - run: npx electron-builder --publish ${{ startsWith(github.ref, 'refs/tags/v') && 'always' || 'never' }}
+      - if: runner.os != 'macOS'
+        run: npx electron-builder --publish ${{ startsWith(github.ref, 'refs/tags/v') && 'always' || 'never' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Build locally first: publish macOS only after the packaged app and
+      # its bundled native engines pass on the matching hardware.
+      - name: Build macOS installers
+        if: runner.os == 'macOS'
+        run: npx electron-builder --mac --publish never
+      - name: Verify packaged macOS app and engines
+        timeout-minutes: 5
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          expected=arm64
+          bundle=dist/mac-arm64/Earheart.app
+          if [[ "${{ matrix.os }}" == macos-15-intel ]]; then
+            expected=x64
+            bundle=dist/mac/Earheart.app
+          fi
+          test "$(node -p process.arch)" = "$expected"
+          "$bundle/Contents/MacOS/Earheart" --smoke-test --no-sandbox
+          EARHEART_ENGINE_ROOT="$PWD/$bundle/Contents/Resources/app.asar" \
+            npx electron scripts/engine-smoke.js --no-sandbox
+      - name: Separate the Intel update feed
+        if: matrix.os == 'macos-15-intel'
+        run: mv dist/latest-mac.yml dist/latest-mac-x64.yml
+      - name: Upload verified macOS installers and feed
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/*.dmg dist/*.zip dist/*.blockmap dist/latest-mac*.yml --clobber
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: earheart-${{ matrix.os }}
@@ -103,6 +129,7 @@ jobs:
             dist/*.dmg
             dist/*.zip
             dist/*.exe
+            dist/latest*.yml
           if-no-files-found: ignore
 
   # Flip the draft release live once every platform has uploaded its installers,

--- a/README.md
+++ b/README.md
@@ -123,7 +123,10 @@ is just the version number (e.g. `0.8.0`).
 **🍎 macOS**
 
 - **Apple Silicon (M1/M2/M3/M4):** `Earheart-<version>-arm64.dmg`
-- **Intel Macs:** `Earheart-<version>.dmg`
+- **Intel Macs (x64):** `Earheart-<version>.dmg`
+
+Each build is packaged and tested on its matching architecture. Choose the DMG
+for your Mac; the in-app updater keeps that architecture on subsequent updates.
 - Not sure which Mac you have? Click  → **About This Mac** and look at
   "Chip" / "Processor".
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -45,12 +45,10 @@ linux:
     entry:
       StartupWMClass: earheart
 
-# macOS builds on macos-latest (arm64) only; the build defaults to the host arch,
-# so the per-arch native addons (sherpa-onnx-darwin-arm64 and
-# @node-llama-cpp/mac-arm64) npm installed on that host are the ones that ship.
-# Cross-compiling x64 from this runner would bundle the wrong-arch native
-# binaries, so we don't — Intel Macs run the arm64 build under Rosetta. (The
-# x64 macos-13 runner was dropped from the release matrix; see release.yml.)
+# Build on native Apple Silicon and Intel runners so npm installs the matching
+# native addons. release.yml boots each packaged app and loads its engines
+# before uploading. Keep latest-mac.yml for existing Apple Silicon installs;
+# the Intel job publishes its metadata as latest-mac-x64.yml to avoid races.
 mac:
   target:
     - dmg

--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -378,7 +378,11 @@ async function loadcheck() {
     engines.sttError = String((err && err.message) || err);
   }
   try {
-    await import("node-llama-cpp");
+    const { getLlama } = await import("node-llama-cpp");
+    // Import alone only loads JS. Initialize the native CPU backend, without
+    // downloading or building a replacement that could mask a missing binary.
+    const check = await getLlama({ gpu: false, build: "never", skipDownload: true });
+    await check.dispose();
     engines.cleanup = true;
   } catch (err) {
     engines.cleanup = false;

--- a/main/engines/engine-worker.js
+++ b/main/engines/engine-worker.js
@@ -379,9 +379,11 @@ async function loadcheck() {
   }
   try {
     const { getLlama } = await import("node-llama-cpp");
-    // Import alone only loads JS. Initialize the native CPU backend, without
-    // downloading or building a replacement that could mask a missing binary.
-    const check = await getLlama({ gpu: false, build: "never", skipDownload: true });
+    // Import alone only loads JS. Initialize the shipped native backend,
+    // without downloading or building a replacement that masks missing files.
+    // Apple Silicon prebuilts use Metal; Intel/Linux/Windows ship a CPU build.
+    const gpu = process.platform === "darwin" && process.arch === "arm64" ? "metal" : false;
+    const check = await getLlama({ gpu, build: "never", skipDownload: true });
     await check.dispose();
     engines.cleanup = true;
   } catch (err) {

--- a/main/services/update-feed.js
+++ b/main/services/update-feed.js
@@ -11,9 +11,13 @@ const REPO_SLUG = "cleanunicorn/earheart";
 const DEFAULT_FEED_BASE = `https://github.com/${REPO_SLUG}/releases/latest/download`;
 const RELEASES_PAGE = `https://github.com/${REPO_SLUG}/releases/latest`;
 
-/** Feed file published by electron-builder for a given process.platform. */
-function feedFileFor(platform) {
-  if (platform === "darwin") return "latest-mac.yml";
+/** Architecture-specific feed; the legacy mac feed stays Apple Silicon. */
+function feedFileFor(platform, arch = process.arch) {
+  if (platform === "darwin") {
+    if (arch === "x64") return "latest-mac-x64.yml";
+    if (arch === "arm64") return "latest-mac.yml";
+    throw new Error(`Unsupported macOS architecture: ${arch}`);
+  }
   if (platform === "linux") return "latest-linux.yml";
   return "latest.yml";
 }
@@ -25,7 +29,7 @@ function feedFileFor(platform) {
  * download progress has a denominator. Throws when required keys are missing
  * so a mangled feed fails loudly instead of installing garbage.
  */
-function parseLatestYml(text) {
+function parseLatestYml(text, { platform, arch } = {}) {
   const lines = String(text).split(/\r?\n/);
   const top = {};
   const files = [];
@@ -51,6 +55,16 @@ function parseLatestYml(text) {
   const { version, path, sha512 } = top;
   if (!version || !path || !sha512) {
     throw new Error("Update feed is missing version, path or sha512");
+  }
+  // Fail closed if a mispublished macOS feed points at the other CPU (or a
+  // DMG instead of the ZIP the updater extracts). Intel uses builder's legacy
+  // unsuffixed x64 name; Apple Silicon always includes -arm64.
+  if (platform === "darwin") {
+    const suffix = arch === "arm64" ? "-arm64-mac.zip" : "-mac.zip";
+    if ((arch !== "arm64" && arch !== "x64") || !path.endsWith(suffix) ||
+        (arch === "x64" && path !== `Earheart-${version}-mac.zip`)) {
+      throw new Error(`Update artifact is incompatible with macOS ${arch}: ${path}`);
+    }
   }
   const entry = files.find((f) => f.url === path);
   const size = entry && entry.size ? Number(entry.size) : 0;

--- a/main/updates.js
+++ b/main/updates.js
@@ -268,8 +268,8 @@ async function check({ manual = false } = {}) {
   if (["checking", "downloading", "ready", "installing"].includes(state.status)) return;
   setState({ status: "checking", error: null });
   try {
-    const url = `${feedBase().replace(/\/$/, "")}/${feed.feedFileFor(process.platform)}`;
-    const info = feed.parseLatestYml(await fetchText(url));
+    const url = `${feedBase().replace(/\/$/, "")}/${feed.feedFileFor(process.platform, process.arch)}`;
+    const info = feed.parseLatestYml(await fetchText(url), { platform: process.platform, arch: process.arch });
     if (feed.compareVersions(info.version, state.current) <= 0) {
       pendingInfo = null;
       setState({ status: "idle", latest: null, progress: null, notes: [] });

--- a/scripts/engine-smoke.js
+++ b/scripts/engine-smoke.js
@@ -14,7 +14,10 @@
 //   npx electron scripts/engine-smoke.js                            # macOS/Win
 
 const { app } = require("electron");
-const { createHost } = require("../main/engines/host");
+const path = require("node:path");
+// Release CI points this at the packaged asar to verify the shipped addons.
+const engineRoot = process.env.EARHEART_ENGINE_ROOT || path.join(__dirname, "..");
+const { createHost } = require(path.join(engineRoot, "main/engines/host"));
 
 // One worker is enough to prove the addons load; the app runs two of these
 // (STT + cleanup) but they fork the same engine-worker.js.

--- a/test/update-feed.test.js
+++ b/test/update-feed.test.js
@@ -48,9 +48,15 @@ releaseDate: '2026-07-01T10:08:06.116Z'
 `;
 
 test("feedFileFor picks the platform feed", () => {
-  assert.strictEqual(feedFileFor("darwin"), "latest-mac.yml");
+  assert.strictEqual(feedFileFor("darwin", "arm64"), "latest-mac.yml");
   assert.strictEqual(feedFileFor("linux"), "latest-linux.yml");
   assert.strictEqual(feedFileFor("win32"), "latest.yml");
+});
+
+test("Intel installs (including Rosetta) use a separate feed", () => {
+  assert.strictEqual(feedFileFor("darwin", "x64"), "latest-mac-x64.yml");
+  assert.notStrictEqual(feedFileFor("darwin", "x64"), feedFileFor("darwin", "arm64"));
+  assert.throws(() => feedFileFor("darwin", "unknown"), /Unsupported/);
 });
 
 test("parseLatestYml reads the mac feed", () => {
@@ -59,6 +65,18 @@ test("parseLatestYml reads the mac feed", () => {
   assert.strictEqual(info.path, "Earheart-0.12.1-arm64-mac.zip");
   assert.ok(info.sha512.startsWith("KJ9kKheSxLn"));
   assert.strictEqual(info.size, 171973146);
+});
+
+test("macOS rejects the other architecture even if its feed was mispublished", () => {
+  const intel = MAC_YML.replaceAll("-arm64-mac.zip", "-mac.zip");
+  for (const [arch, valid, wrong] of [["arm64", MAC_YML, intel], ["x64", intel, MAC_YML]]) {
+    const info = parseLatestYml(valid, { platform: "darwin", arch });
+    assert.strictEqual(info.size, 171973146);
+    assert.throws(() => parseLatestYml(wrong, { platform: "darwin", arch }), /incompatible/);
+    assert.throws(() => parseLatestYml(valid.replaceAll(".zip", ".dmg"), {
+      platform: "darwin", arch,
+    }), /incompatible/);
+  }
 });
 
 test("parseLatestYml picks the top-level path, not the second files entry", () => {


### PR DESCRIPTION
Restore Intel macOS DMG/ZIP builds on `macos-15-intel`, with the full CI suite on that runner. macOS release jobs now boot the packaged app and load both bundled native engines before uploading; the cleanup smoke check initializes its native backend instead of only importing JavaScript.

Give Intel installs a separate `latest-mac-x64.yml` feed while preserving the existing Apple Silicon feed. The updater uses the installed process architecture and rejects incompatible macOS artifacts. Remove the reversed Rosetta claim and clarify the download matrix.

Validation: 288 unit tests passed (1 skipped), all four required Linux smoke checks passed, YAML parsed successfully, and a local Linux package passed the bundled-engine smoke check. [GitHub CI](https://github.com/cleanunicorn/earheart/actions/runs/34174407220) passed on Linux, Windows, Intel macOS, and Apple Silicon macOS. Both macOS jobs in the [release dry-run](https://github.com/cleanunicorn/earheart/actions/runs/34174417471) built DMG/ZIP artifacts and passed packaged-app/native-engine checks. No release is published by the dry-run.

Closes #126
