### PR TITLE
fix: save settings atomically

### DIFF
--- a/main/settings.js
+++ b/main/settings.js
@@ -284,8 +284,24 @@ function load() {
 
 function save(next) {
   cached = deepMerge(DEFAULTS, next);
-  fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
-  fs.writeFileSync(settingsPath(), JSON.stringify(cached, null, 2));
+  const file = settingsPath();
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  try {
+    // Write a complete replacement beside the destination, then swap it into
+    // place atomically. A crash can leave the previous settings or a harmless
+    // temp file, but never a truncated settings.json. The restrictive mode is
+    // especially important while API keys still live in this file.
+    fs.writeFileSync(tmp, JSON.stringify(cached, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // The write may have failed before the temp file was created.
+    }
+    throw err;
+  }
   return cached;
 }
 

--- a/test/settings-persistence.test.js
+++ b/test/settings-persistence.test.js
@@ -1,0 +1,81 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+function loadSettings(userData) {
+  const settingsPath = require.resolve("../main/settings");
+  const electronPath = require.resolve("electron");
+  const registryPath = require.resolve("../main/engines/registry");
+  const savedElectron = require.cache[electronPath];
+  const savedRegistry = require.cache[registryPath];
+
+  const electron = new Module(electronPath, null);
+  electron.filename = electronPath;
+  electron.loaded = true;
+  electron.exports = { app: { getPath: () => userData } };
+  require.cache[electronPath] = electron;
+
+  const registry = new Module(registryPath, null);
+  registry.filename = registryPath;
+  registry.loaded = true;
+  registry.exports = {
+    DEFAULT_STT_MODEL: "stt-default",
+    DEFAULT_CLEANUP_MODEL: "cleanup-default",
+  };
+  require.cache[registryPath] = registry;
+
+  delete require.cache[settingsPath];
+  const settings = require(settingsPath);
+  delete require.cache[settingsPath];
+  if (savedElectron) require.cache[electronPath] = savedElectron;
+  else delete require.cache[electronPath];
+  if (savedRegistry) require.cache[registryPath] = savedRegistry;
+  else delete require.cache[registryPath];
+  return settings;
+}
+
+test("settings save replaces the file and leaves no partial temp file", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-settings-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const settings = loadSettings(dir);
+
+  settings.save({ hotkey: "First" });
+  settings.save({ hotkey: "Second" });
+
+  const file = path.join(dir, "settings.json");
+  assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).hotkey, "Second");
+  assert.deepStrictEqual(
+    fs.readdirSync(dir).filter((name) => name.includes(".tmp")),
+    []
+  );
+  if (process.platform !== "win32") {
+    assert.strictEqual(fs.statSync(file).mode & 0o777, 0o600);
+  }
+});
+
+test("a failed replacement preserves the previous settings", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-settings-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const settings = loadSettings(dir);
+  settings.save({ hotkey: "Working" });
+
+  const originalRename = fs.renameSync;
+  fs.renameSync = () => {
+    throw new Error("simulated rename failure");
+  };
+  try {
+    assert.throws(() => settings.save({ hotkey: "Broken" }), /rename failure/);
+  } finally {
+    fs.renameSync = originalRename;
+  }
+
+  const file = path.join(dir, "settings.json");
+  assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).hotkey, "Working");
+  assert.deepStrictEqual(
+    fs.readdirSync(dir).filter((name) => name.includes(".tmp")),
+    []
+  );
+});


### PR DESCRIPTION
## What
- write settings to a restrictive temporary file before atomically replacing `settings.json`
- clean up temporary files when a write or rename fails
- preserve the last complete settings file across interrupted saves

This delivers the crash-safe persistence portion of #122 without mixing in credential-storage changes.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (288 pass, 1 skipped)