### PR TITLE
fix: keep the current hotkey when replacement fails

### DIFF
--- a/main/hotkeys.js
+++ b/main/hotkeys.js
@@ -25,22 +25,31 @@ const registered = new Map();
  */
 function register(name, accelerator, onTrigger) {
   const prev = registered.get(name);
-  if (prev) {
-    globalShortcut.unregister(prev);
-    registered.delete(name);
+  if (!accelerator) {
+    if (prev) {
+      globalShortcut.unregister(prev);
+      registered.delete(name);
+    }
+    return { ok: true, empty: true };
   }
-  if (!accelerator) return { ok: true, empty: true };
   // Two slots on one combo would silently shadow each other; refuse up front
   // with a clearer message than globalShortcut's generic failure.
   for (const [otherName, otherAccelerator] of registered) {
-    if (otherAccelerator === accelerator) {
+    if (otherName !== name && otherAccelerator === accelerator) {
       return {
         ok: false,
         error: `"${accelerator}" is already used by the ${otherName} hotkey`,
       };
     }
   }
+  // Saving unrelated settings re-applies the same shortcuts. Leave an already
+  // working registration alone instead of briefly dropping it.
+  if (prev === accelerator) return { ok: true };
   try {
+    // Register the replacement before releasing the old accelerator. If the
+    // new combo is invalid, occupied, or blocked by the desktop, dictation must
+    // keep working on the previous combo while the settings window asks the
+    // user to choose another one.
     const ok = globalShortcut.register(accelerator, onTrigger);
     if (!ok) {
       return {
@@ -48,6 +57,7 @@ function register(name, accelerator, onTrigger) {
         error: `Could not register "${accelerator}" (already in use, or your desktop blocks global shortcuts — see the Wayland note in Settings).`,
       };
     }
+    if (prev) globalShortcut.unregister(prev);
     registered.set(name, accelerator);
     return { ok: true };
   } catch (err) {

--- a/test/hotkeys.test.js
+++ b/test/hotkeys.test.js
@@ -1,0 +1,72 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const Module = require("node:module");
+
+function loadHotkeys(registerImpl) {
+  const hotkeysPath = require.resolve("../main/hotkeys");
+  const electronPath = require.resolve("electron");
+  const savedElectron = require.cache[electronPath];
+  const calls = { registered: [], unregistered: [] };
+  const electron = new Module(electronPath, null);
+  electron.filename = electronPath;
+  electron.loaded = true;
+  electron.exports = {
+    globalShortcut: {
+      register(accelerator, callback) {
+        calls.registered.push({ accelerator, callback });
+        return registerImpl(accelerator);
+      },
+      unregister(accelerator) {
+        calls.unregistered.push(accelerator);
+      },
+      unregisterAll() {},
+    },
+  };
+  require.cache[electronPath] = electron;
+  delete require.cache[hotkeysPath];
+  const hotkeys = require(hotkeysPath);
+  delete require.cache[hotkeysPath];
+  if (savedElectron) require.cache[electronPath] = savedElectron;
+  else delete require.cache[electronPath];
+  return { hotkeys, calls };
+}
+
+test("a rejected replacement keeps the working hotkey registered", () => {
+  const { hotkeys, calls } = loadHotkeys(
+    (accelerator) => accelerator !== "CommandOrControl+Alt+X"
+  );
+  assert.deepStrictEqual(
+    hotkeys.register("record", "CommandOrControl+Shift+Space", () => {}),
+    { ok: true }
+  );
+  assert.strictEqual(
+    hotkeys.register("record", "CommandOrControl+Alt+X", () => {}).ok,
+    false
+  );
+  assert.deepStrictEqual(calls.unregistered, []);
+});
+
+test("a successful replacement releases the previous hotkey afterwards", () => {
+  const { hotkeys, calls } = loadHotkeys(() => true);
+  hotkeys.register("record", "CommandOrControl+Shift+Space", () => {});
+  hotkeys.register("record", "CommandOrControl+Alt+X", () => {});
+  assert.deepStrictEqual(calls.unregistered, ["CommandOrControl+Shift+Space"]);
+});
+
+test("a slot collision does not unregister either existing hotkey", () => {
+  const { hotkeys, calls } = loadHotkeys(() => true);
+  hotkeys.register("record", "CommandOrControl+Shift+Space", () => {});
+  hotkeys.register("pause", "CommandOrControl+Alt+P", () => {});
+  const result = hotkeys.register("pause", "CommandOrControl+Shift+Space", () => {});
+  assert.strictEqual(result.ok, false);
+  assert.match(result.error, /record hotkey/);
+  assert.deepStrictEqual(calls.unregistered, []);
+});
+
+test("reapplying the same hotkey does not drop and reacquire it", () => {
+  const { hotkeys, calls } = loadHotkeys(() => true);
+  hotkeys.register("record", "CommandOrControl+Shift+Space", () => {});
+  hotkeys.register("record", "CommandOrControl+Shift+Space", () => {});
+  assert.strictEqual(calls.registered.length, 1);
+  assert.deepStrictEqual(calls.unregistered, []);
+});


### PR DESCRIPTION
## What
- register a replacement shortcut before releasing the working one
- preserve both shortcuts when a record/pause collision is rejected
- avoid dropping and reacquiring unchanged shortcuts on every settings save

A typo, occupied shortcut, or Wayland registration failure now leaves the previous dictation hotkey operational while the user corrects the setting.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (290 pass, 1 skipped)