### PR TITLE
fix: time out stalled remote model discovery

### DIFF
--- a/main/services/models-remote.js
+++ b/main/services/models-remote.js
@@ -6,13 +6,15 @@ function joinUrl(baseUrl, route) {
   return baseUrl.replace(/\/+$/, "") + route;
 }
 
+const DEFAULT_TIMEOUT_MS = 15000;
+
 /**
  * Fetch available model ids from an OpenAI-compatible endpoint.
  * @param {{ baseUrl: string, apiKey?: string }} cfg
- * @param {{ signal?: AbortSignal }} [opts]
+ * @param {{ signal?: AbortSignal, timeoutMs?: number }} [opts]
  * @returns {Promise<string[]>} sorted, de-duplicated model ids
  */
-async function listRemoteModels(cfg, { signal } = {}) {
+async function listRemoteModels(cfg, { signal, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
   if (!cfg || !cfg.baseUrl) throw new Error("Base URL is required");
   const url = joinUrl(cfg.baseUrl, "/models");
   // Only fetch over HTTP(S). The base URL is user-supplied and reaches here
@@ -32,8 +34,15 @@ async function listRemoteModels(cfg, { signal } = {}) {
 
   let res;
   try {
-    res = await fetch(url, { headers, signal });
+    const timeout = AbortSignal.timeout(timeoutMs);
+    res = await fetch(url, {
+      headers,
+      signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+    });
   } catch (err) {
+    if (err.name === "TimeoutError") {
+      throw new Error(`Timed out fetching models from ${url}`);
+    }
     throw new Error(`Could not reach ${url}: ${err.message}`);
   }
   if (!res.ok) {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -821,6 +821,21 @@ test("listRemoteModels wraps a network failure with the URL", async () => {
   );
 });
 
+test("listRemoteModels times out when a service never responds", async () => {
+  const server = http.createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const base = `http://127.0.0.1:${server.address().port}/v1`;
+  try {
+    await assert.rejects(
+      () => listRemoteModels({ baseUrl: base }, { timeoutMs: 20 }),
+      /Timed out fetching models/
+    );
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
 test("idle model unload defaults to a finite window and is overridable", () => {
   // Sensible default: unload after a couple of idle minutes.
   assert.strictEqual(DEFAULTS.engines.idleUnloadMinutes, 2);


### PR DESCRIPTION
## What
- cap remote `/models` discovery at 15 seconds by default
- preserve caller cancellation while adding the timeout
- return a clear timeout message instead of leaving Settings stuck on “Fetching…”

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (287 pass, 1 skipped)