### PR TITLE
fix: hide truncated cleanup reasoning

### DIFF
--- a/main/services/cleanup.js
+++ b/main/services/cleanup.js
@@ -10,7 +10,13 @@ function joinUrl(baseUrl, route) {
 
 // Reasoning models may emit <think>...</think> blocks; strip them.
 function stripThinking(text) {
-  return text.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+  return text
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    // A response can hit its token/time limit before the closing tag. Treat
+    // everything after an unmatched opener as reasoning too; clean() will
+    // fall back to the raw transcript when that leaves no answer.
+    .replace(/<think>[\s\S]*$/i, "")
+    .trim();
 }
 
 /**

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -92,6 +92,11 @@ test("stripThinking removes reasoning blocks", () => {
     stripThinking("<THINK>a</THINK>\n\n  Result  "),
     "Result"
   );
+  assert.strictEqual(stripThinking("<think>unfinished private reasoning"), "");
+  assert.strictEqual(
+    stripThinking("Answer so far.<think>unfinished private reasoning"),
+    "Answer so far."
+  );
 });
 
 test("deepMerge keeps defaults for missing keys and overrides present ones", () => {


### PR DESCRIPTION
## What
- remove unterminated `<think>` blocks from remote cleanup responses
- retain any answer text that appeared before an incomplete reasoning block
- let the existing empty-output safeguard restore the raw transcript when a response contains reasoning only

This keeps model-internal reasoning out of delivered dictation without risking the user’s words.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (286 pass, 1 skipped)