### PR TITLE
fix: quote Linux autostart executable paths

### DIFF
--- a/main/autostart.js
+++ b/main/autostart.js
@@ -23,13 +23,24 @@ const LINUX_DESKTOP_FILE = "earheart.desktop";
 // query with, so the two MUST match or the read-back state drifts.
 const LOGIN_ITEM_ARGS = ["--hidden"];
 
+// Exec= is not a shell command: the Desktop Entry spec tokenizes it itself,
+// and paths containing spaces must be quoted. Percent signs are field-code
+// markers even inside quotes, while backslash, quote, dollar and backtick need
+// escaping inside a quoted argument.
+function desktopExecArg(value) {
+  const escaped = String(value)
+    .replace(/%/g, "%%")
+    .replace(/([\\"`$])/g, "\\$1");
+  return `"${escaped}"`;
+}
+
 // The command the desktop environment should run at login. On Linux AppImages
 // the relaunchable path lives in $APPIMAGE — process.execPath points inside the
 // mounted image and would be stale next boot — so prefer it; fall back to
 // execPath for .deb installs and `npm start` development runs.
 function linuxLaunchCommand() {
   const exec = process.env.APPIMAGE || process.execPath;
-  return `${exec} --hidden`;
+  return `${desktopExecArg(exec)} --hidden`;
 }
 
 // A minimal but complete XDG autostart entry. X-GNOME-Autostart-enabled keeps
@@ -109,5 +120,6 @@ module.exports = {
   loginItemEnabled,
   linuxDesktopEntry,
   linuxLaunchCommand,
+  desktopExecArg,
   linuxAutostartPath,
 };

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -533,10 +533,10 @@ test("start-on-boot defaults to off and survives the merge both ways", () => {
 });
 
 test("linux autostart entry is a valid XDG desktop file launched hidden", () => {
-  const entry = autostart.linuxDesktopEntry("/opt/Earheart.AppImage --hidden");
+  const entry = autostart.linuxDesktopEntry('"/opt/Earheart.AppImage" --hidden');
   assert.match(entry, /^\[Desktop Entry\]/);
   assert.match(entry, /\nType=Application\n/);
-  assert.match(entry, /\nExec=\/opt\/Earheart\.AppImage --hidden\n/);
+  assert.match(entry, /\nExec="\/opt\/Earheart\.AppImage" --hidden\n/);
   // GNOME treats a missing flag as disabled, so it must be present and true.
   assert.match(entry, /\nX-GNOME-Autostart-enabled=true\n/);
 });
@@ -547,10 +547,28 @@ test("linux launch command starts hidden and prefers $APPIMAGE", () => {
     process.env.APPIMAGE = "/home/u/Earheart.AppImage";
     assert.strictEqual(
       autostart.linuxLaunchCommand(),
-      "/home/u/Earheart.AppImage --hidden"
+      '"/home/u/Earheart.AppImage" --hidden'
     );
     delete process.env.APPIMAGE;
     assert.ok(autostart.linuxLaunchCommand().endsWith(" --hidden"));
+  } finally {
+    if (saved === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = saved;
+  }
+});
+
+test("linux launch command quotes AppImage paths with spaces and field codes", () => {
+  const saved = process.env.APPIMAGE;
+  try {
+    process.env.APPIMAGE = "/home/A User/Earheart 100%.AppImage";
+    assert.strictEqual(
+      autostart.linuxLaunchCommand(),
+      '"/home/A User/Earheart 100%%.AppImage" --hidden'
+    );
+    assert.strictEqual(
+      autostart.desktopExecArg('/tmp/a"b\\c$`'),
+      '"/tmp/a\\"b\\\\c\\$\\`"'
+    );
   } finally {
     if (saved === undefined) delete process.env.APPIMAGE;
     else process.env.APPIMAGE = saved;


### PR DESCRIPTION
## What
- quote the executable argument in the XDG `Exec` command
- escape Desktop Entry field codes and quoted-argument metacharacters
- cover AppImage paths containing spaces and percent signs

This prevents start-on-login from breaking when Earheart lives in a directory such as `/home/A User/Applications`.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (287 pass, 1 skipped)