### PR TITLE
fix: ignore malformed history rows

### DIFF
--- a/main/history.js
+++ b/main/history.js
@@ -12,11 +12,20 @@ function historyPath() {
   return path.join(app.getPath("userData"), "history.json");
 }
 
+function validEntries(value) {
+  if (!Array.isArray(value)) return [];
+  // A manually edited, partially recovered, or older history file may contain
+  // nulls or other JSON values. Only records with transcript text can satisfy
+  // the renderer/tray contract; ignore bad rows without hiding valid ones.
+  return value.filter(
+    (entry) => entry && typeof entry === "object" && typeof entry.text === "string"
+  );
+}
+
 function load() {
   if (cached) return cached;
   try {
-    cached = JSON.parse(fs.readFileSync(historyPath(), "utf8"));
-    if (!Array.isArray(cached)) cached = [];
+    cached = validEntries(JSON.parse(fs.readFileSync(historyPath(), "utf8")));
   } catch {
     cached = [];
   }
@@ -77,4 +86,4 @@ function clear() {
   }
 }
 
-module.exports = { add, list, clear };
+module.exports = { add, list, clear, validEntries };

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -1,0 +1,34 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const Module = require("node:module");
+
+function loadHistory() {
+  const historyPath = require.resolve("../main/history");
+  const electronPath = require.resolve("electron");
+  const savedElectron = require.cache[electronPath];
+  const electron = new Module(electronPath, null);
+  electron.filename = electronPath;
+  electron.loaded = true;
+  electron.exports = { app: { getPath: () => "/unused" } };
+  require.cache[electronPath] = electron;
+  delete require.cache[historyPath];
+  const history = require(historyPath);
+  delete require.cache[historyPath];
+  if (savedElectron) require.cache[electronPath] = savedElectron;
+  else delete require.cache[electronPath];
+  return history;
+}
+
+test("history keeps valid transcripts while ignoring malformed rows", () => {
+  const { validEntries } = loadHistory();
+  const good = { text: "Keep my words", at: "2026-09-10T00:00:00.000Z" };
+  assert.deepStrictEqual(
+    validEntries([null, 1, "text", {}, { text: 42 }, good]),
+    [good]
+  );
+});
+
+test("history treats a non-array JSON value as empty", () => {
+  const { validEntries } = loadHistory();
+  assert.deepStrictEqual(validEntries({ text: "not a history list" }), []);
+});


### PR DESCRIPTION
## What
- validate persisted history rows at the storage boundary
- ignore malformed JSON values while retaining every valid transcript
- prevent one corrupt row from breaking the History UI and tray menu

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (288 pass, 1 skipped)