### PR TITLE
fix: confine model downloads to their managed directory

### DIFF
--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -24,12 +24,32 @@ const { totalBytes } = require("./registry");
 
 const MARKER = ".complete";
 
+function assertPathSegment(value, label) {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value === "." ||
+    value === ".." ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    value.includes("\0")
+  ) {
+    throw new Error(`Invalid model ${label}`);
+  }
+  return value;
+}
+
 function modelDir(baseDir, model) {
-  return path.join(baseDir, model.kind, model.id);
+  const kind = assertPathSegment(model.kind, "kind");
+  const id = assertPathSegment(model.id, "id");
+  return path.join(baseDir, kind, id);
 }
 
 function filePath(baseDir, model, file) {
-  return path.join(modelDir(baseDir, model), file.name);
+  return path.join(
+    modelDir(baseDir, model),
+    assertPathSegment(file.name, "filename")
+  );
 }
 
 function partialPaths(dest) {
@@ -66,7 +86,7 @@ function isInstalled(baseDir, model) {
   const sizes = readMarker(dir);
   if (sizes === null) return false;
   return model.files.every((f) => {
-    const p = path.join(dir, f.name);
+    const p = filePath(baseDir, model, f);
     const expected = sizes[f.name];
     if (expected === undefined) return fs.existsSync(p); // legacy marker
     try {
@@ -219,7 +239,7 @@ async function fetchFull(file, signal) {
 async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
   const dir = modelDir(baseDir, model);
   await fsp.mkdir(dir, { recursive: true });
-  const dest = path.join(dir, file.name);
+  const dest = filePath(baseDir, model, file);
   const paths = partialPaths(dest);
 
   // A crash can happen after the last byte lands but before verification and

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -89,6 +89,25 @@ test("registry totalBytes sums the file sizes", () => {
   assert.strictEqual(registry.totalBytes(model), 15);
 });
 
+test("model paths cannot escape the managed model directory", () => {
+  const base = path.join(os.tmpdir(), "earheart-models");
+  const model = { kind: "cleanup", id: "safe-model" };
+  assert.strictEqual(
+    manager.filePath(base, model, { name: "weights.gguf" }),
+    path.join(base, "cleanup", "safe-model", "weights.gguf")
+  );
+
+  for (const id of ["../outside", "..\\outside", "..", ""]) {
+    assert.throws(() => manager.modelDir(base, { ...model, id }), /Invalid model id/);
+  }
+  for (const name of ["../outside.gguf", "..\\outside.gguf", "/tmp/outside", ""]) {
+    assert.throws(
+      () => manager.filePath(base, model, { name }),
+      /Invalid model filename/
+    );
+  }
+});
+
 test("exactly one cleanup model is marked default", () => {
   const defaults = registry.listModels("cleanup").filter((m) => m.default);
   assert.strictEqual(defaults.length, 1);


### PR DESCRIPTION
## What
- validate model kind, ID, and filename as single path segments
- reject POSIX and Windows traversal separators before any filesystem access
- route install checks and downloads through the validated path builder

This prevents a malformed custom-model record from reading or writing outside Earheart’s model directory.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (287 pass, 1 skipped)