### PR TITLE
fix: keep log rotation bounded on Windows

### DIFF
--- a/main/util/logger.js
+++ b/main/util/logger.js
@@ -35,9 +35,15 @@ function resolveDir() {
   }
 }
 
-function rotateIfLarge(file) {
+function rotateIfLarge(file, maxBytes = MAX_BYTES) {
   try {
-    if (fs.statSync(file).size > MAX_BYTES) fs.renameSync(file, `${file}.1`);
+    if (fs.statSync(file).size <= maxBytes) return;
+    const backup = `${file}.1`;
+    // POSIX rename replaces an existing file, but Windows rename does not.
+    // Remove the one retained generation first so rotation keeps working after
+    // the log has crossed the limit more than once.
+    fs.rmSync(backup, { force: true });
+    fs.renameSync(file, backup);
   } catch {
     // No existing file, or the rename failed — not worth blocking startup on.
   }
@@ -103,4 +109,5 @@ module.exports = {
   warn: (...args) => write("WARN", args),
   info: (...args) => write("INFO", args),
   getLogPath: () => logPath,
+  rotateIfLarge,
 };

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,32 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { rotateIfLarge } = require("../main/util/logger");
+
+test("log rotation replaces the previous backup generation", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-logger-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "earheart.log");
+  fs.writeFileSync(file, "new-current-log");
+  fs.writeFileSync(`${file}.1`, "old-backup");
+
+  rotateIfLarge(file, 4);
+
+  assert.strictEqual(fs.existsSync(file), false);
+  assert.strictEqual(fs.readFileSync(`${file}.1`, "utf8"), "new-current-log");
+});
+
+test("log rotation leaves a file within the limit untouched", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-logger-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "earheart.log");
+  fs.writeFileSync(file, "short");
+
+  rotateIfLarge(file, 5);
+
+  assert.strictEqual(fs.readFileSync(file, "utf8"), "short");
+  assert.strictEqual(fs.existsSync(`${file}.1`), false);
+});


### PR DESCRIPTION
## What
- replace the retained `.1` log before rotating a newly oversized log
- keep the existing 5 MB / one-generation policy working across repeated rotations
- add coverage for replacement and exact-limit behavior

Windows does not reliably overwrite an existing rename destination, which previously allowed `earheart.log` to grow without bound after its first rotation.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (288 pass, 1 skipped)