### PR TITLE
fix: time out stalled update checks

### DIFF
--- a/main/services/update-fetch.js
+++ b/main/services/update-fetch.js
@@ -1,0 +1,34 @@
+// Fetch updater metadata with a finite deadline. Kept separate from the
+// updater state machine so the network and file-feed paths are unit-testable.
+
+const fsp = require("node:fs/promises");
+const { fileURLToPath } = require("node:url");
+
+const DEFAULT_TIMEOUT_MS = 15000;
+
+/** Fetch a URL as text; supports file:// so local update feeds keep working. */
+async function fetchUpdateText(
+  url,
+  { timeoutMs = DEFAULT_TIMEOUT_MS, fetchImpl = fetch } = {}
+) {
+  if (url.startsWith("file://")) {
+    return fsp.readFile(fileURLToPath(url), "utf8");
+  }
+  try {
+    const res = await fetchImpl(url, {
+      headers: { Accept: "text/plain, */*" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.status === 404) throw new Error("No release feed found");
+    if (!res.ok) throw new Error(`Update server returned HTTP ${res.status}`);
+    return await res.text();
+  } catch (err) {
+    if (err.name === "TimeoutError") {
+      throw new Error("Update server timed out");
+    }
+    if (/^(No release feed|Update server returned)/.test(err.message)) throw err;
+    throw new Error(`Could not reach the update server: ${err.message}`);
+  }
+}
+
+module.exports = { fetchUpdateText };

--- a/main/updates.js
+++ b/main/updates.js
@@ -24,12 +24,12 @@ const crypto = require("node:crypto");
 const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const path = require("node:path");
-const { fileURLToPath } = require("node:url");
 const { spawn, spawnSync } = require("node:child_process");
 const { pipeline: streamPipeline } = require("node:stream/promises");
 const { Readable, Transform } = require("node:stream");
 
 const feed = require("./services/update-feed");
+const { fetchUpdateText } = require("./services/update-fetch");
 const releaseNotes = require("./services/release-notes");
 const settings = require("./settings");
 const windows = require("./windows");
@@ -246,22 +246,6 @@ function dispose() {
   if (downloadController) downloadController.abort();
 }
 
-/** Fetch a URL as text; supports file:// so tests can use a local dist dir. */
-async function fetchText(url) {
-  if (url.startsWith("file://")) {
-    return fsp.readFile(fileURLToPath(url), "utf8");
-  }
-  let res;
-  try {
-    res = await fetch(url, { headers: { Accept: "text/plain, */*" } });
-  } catch (err) {
-    throw new Error(`Could not reach the update server: ${err.message}`);
-  }
-  if (res.status === 404) throw new Error("No release feed found");
-  if (!res.ok) throw new Error(`Update server returned HTTP ${res.status}`);
-  return res.text();
-}
-
 async function check({ manual = false } = {}) {
   // "ready" is also off-limits: a background poll must not clobber an update
   // that's downloaded and waiting for the user to restart.
@@ -269,7 +253,7 @@ async function check({ manual = false } = {}) {
   setState({ status: "checking", error: null });
   try {
     const url = `${feedBase().replace(/\/$/, "")}/${feed.feedFileFor(process.platform)}`;
-    const info = feed.parseLatestYml(await fetchText(url));
+    const info = feed.parseLatestYml(await fetchUpdateText(url));
     if (feed.compareVersions(info.version, state.current) <= 0) {
       pendingInfo = null;
       setState({ status: "idle", latest: null, progress: null, notes: [] });
@@ -316,7 +300,7 @@ async function check({ manual = false } = {}) {
 async function fetchNotes(latest) {
   try {
     const url = `${feedBase().replace(/\/$/, "")}/release-notes.json`;
-    const entries = releaseNotes.parseFeed(await fetchText(url));
+    const entries = releaseNotes.parseFeed(await fetchUpdateText(url));
     return releaseNotes.notesBetween(entries, state.current, latest);
   } catch (err) {
     logger.info(`no release notes for ${latest}: ${err.message}`);

--- a/test/update-fetch.test.js
+++ b/test/update-fetch.test.js
@@ -1,0 +1,35 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const { fetchUpdateText } = require("../main/services/update-fetch");
+
+test("update metadata fetch times out when the server never responds", async () => {
+  const server = http.createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const url = `http://127.0.0.1:${server.address().port}/latest-linux.yml`;
+  try {
+    await assert.rejects(
+      () => fetchUpdateText(url, { timeoutMs: 20 }),
+      /Update server timed out/
+    );
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+test("local file update feeds remain supported", async (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-feed-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "latest.yml");
+  fs.writeFileSync(file, "version: 1.2.3\n");
+  assert.strictEqual(
+    await fetchUpdateText(pathToFileURL(file).href),
+    "version: 1.2.3\n"
+  );
+});


### PR DESCRIPTION
## What
- give remote update metadata requests a 15-second deadline
- report a clear timeout instead of leaving the updater stuck in `checking`
- retain local `file://` feeds for updater development and tests

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (288 pass, 1 skipped)