### PR TITLE
fix: restore the clipboard when paste is cancelled

### DIFF
--- a/main/output/deliver.js
+++ b/main/output/deliver.js
@@ -134,7 +134,15 @@ async function deliver(text, cfg, signal) {
   // Give the target app a moment to be focused (the overlay never takes
   // focus, but the clipboard write itself can need a beat on some systems).
   await sleep(cfg.pasteDelayMs ?? 150);
-  if (signal?.aborted) return { method: "cancelled" };
+  if (signal?.aborted) {
+    // Plain paste promises to put the previous clipboard back. Cancellation
+    // before the keystroke should keep that promise too, but only if another
+    // app has not replaced our transcript in the meantime.
+    if (previous !== null && clipboard.readText() === text) {
+      clipboard.writeText(previous);
+    }
+    return { method: "cancelled" };
+  }
   try {
     await simulatePaste();
   } catch (err) {

--- a/test/deliver.test.js
+++ b/test/deliver.test.js
@@ -1,0 +1,60 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const Module = require("node:module");
+
+function loadDeliver(initialClipboard) {
+  const deliverPath = require.resolve("../main/output/deliver");
+  const electronPath = require.resolve("electron");
+  const savedElectron = require.cache[electronPath];
+  let value = initialClipboard;
+  const electron = new Module(electronPath, null);
+  electron.filename = electronPath;
+  electron.loaded = true;
+  electron.exports = {
+    clipboard: {
+      readText: () => value,
+      writeText: (next) => {
+        value = next;
+      },
+    },
+    systemPreferences: {},
+    shell: {},
+  };
+  require.cache[electronPath] = electron;
+  delete require.cache[deliverPath];
+  const deliver = require(deliverPath);
+  delete require.cache[deliverPath];
+  if (savedElectron) require.cache[electronPath] = savedElectron;
+  else delete require.cache[electronPath];
+  return { deliver: deliver.deliver, clipboard: () => value, setClipboard: (v) => (value = v) };
+}
+
+test("cancelling before paste restores the previous clipboard", async () => {
+  const fake = loadDeliver("previous words");
+  const controller = new AbortController();
+  const pending = fake.deliver(
+    "new transcript",
+    { mode: "paste", restoreClipboard: true, pasteDelayMs: 10 },
+    controller.signal
+  );
+  assert.strictEqual(fake.clipboard(), "new transcript");
+  controller.abort();
+
+  assert.deepStrictEqual(await pending, { method: "cancelled" });
+  assert.strictEqual(fake.clipboard(), "previous words");
+});
+
+test("cancelling does not overwrite a newer clipboard change", async () => {
+  const fake = loadDeliver("previous words");
+  const controller = new AbortController();
+  const pending = fake.deliver(
+    "new transcript",
+    { mode: "paste", restoreClipboard: true, pasteDelayMs: 10 },
+    controller.signal
+  );
+  fake.setClipboard("copied by another app");
+  controller.abort();
+
+  assert.deepStrictEqual(await pending, { method: "cancelled" });
+  assert.strictEqual(fake.clipboard(), "copied by another app");
+});


### PR DESCRIPTION
## What
- restore the prior clipboard when plain auto-paste is cancelled during its focus delay
- preserve a newer clipboard value written by another app
- keep clipboard-only and paste-and-keep semantics unchanged

This closes a cancellation gap where the transcript displaced clipboard contents even though no paste occurred.

## Testing
- `NODE_PATH=/home/daniel/Development/github.com/cleanunicorn/earheart/node_modules npm test` (288 pass, 1 skipped)