### PR TITLE
fix: compare numeric prerelease identifiers correctly

### DIFF
--- a/main/services/update-feed.js
+++ b/main/services/update-feed.js
@@ -95,7 +95,7 @@ function compareVersions(a, b) {
     if (pa === pb) continue;
     const aNumeric = /^\d+$/.test(pa);
     const bNumeric = /^\d+$/.test(pb);
-    if (aNumeric && bNumeric) return Number(pa) < Number(pb) ? -1 : 1;
+    if (aNumeric && bNumeric) return BigInt(pa) < BigInt(pb) ? -1 : 1;
     if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
     return pa < pb ? -1 : 1;
   }

--- a/main/services/update-feed.js
+++ b/main/services/update-feed.js
@@ -69,8 +69,12 @@ function unquote(value) {
  */
 function compareVersions(a, b) {
   const split = (v) => {
-    const [core, ...pre] = String(v).trim().replace(/^v/i, "").split("-");
-    return { nums: core.split(".").map((n) => parseInt(n, 10) || 0), pre: pre.join("-") };
+    const withoutBuild = String(v).trim().replace(/^v/i, "").split("+")[0];
+    const [core, ...pre] = withoutBuild.split("-");
+    return {
+      nums: core.split(".").map((n) => parseInt(n, 10) || 0),
+      pre: pre.join("-").split(".").filter(Boolean),
+    };
   };
   const va = split(a);
   const vb = split(b);
@@ -79,10 +83,21 @@ function compareVersions(a, b) {
     const nb = vb.nums[i] || 0;
     if (na !== nb) return na < nb ? -1 : 1;
   }
-  if (va.pre !== vb.pre) {
-    if (!va.pre) return 1; // release > prerelease
-    if (!vb.pre) return -1;
-    return va.pre < vb.pre ? -1 : 1;
+  if (va.pre.length === 0 || vb.pre.length === 0) {
+    if (va.pre.length === vb.pre.length) return 0;
+    return va.pre.length === 0 ? 1 : -1; // release > prerelease
+  }
+  for (let i = 0; i < Math.max(va.pre.length, vb.pre.length); i++) {
+    if (i >= va.pre.length) return -1;
+    if (i >= vb.pre.length) return 1;
+    const pa = va.pre[i];
+    const pb = vb.pre[i];
+    if (pa === pb) continue;
+    const aNumeric = /^\d+$/.test(pa);
+    const bNumeric = /^\d+$/.test(pb);
+    if (aNumeric && bNumeric) return Number(pa) < Number(pb) ? -1 : 1;
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    return pa < pb ? -1 : 1;
   }
   return 0;
 }

--- a/test/update-feed.test.js
+++ b/test/update-feed.test.js
@@ -92,6 +92,11 @@ test("compareVersions orders releases", () => {
   assert.strictEqual(compareVersions("0.12", "0.12.0"), 0);
   assert.strictEqual(compareVersions("0.13.0-beta.1", "0.13.0"), -1);
   assert.strictEqual(compareVersions("0.13.0", "0.13.0-beta.1"), 1);
+  assert.strictEqual(compareVersions("0.13.0-beta.10", "0.13.0-beta.2"), 1);
+  assert.strictEqual(compareVersions("0.13.0-beta.1", "0.13.0-beta.alpha"), -1);
+  assert.strictEqual(compareVersions("0.13.0-beta", "0.13.0-beta.1"), -1);
+  assert.strictEqual(compareVersions("0.13.0+linux", "0.13.0+mac"), 0);
+  assert.strictEqual(compareVersions("0.13.0-beta.1+linux", "0.13.0-beta.1+mac"), 0);
 });
 
 test("assetUrl pins to the release tag by default", () => {

--- a/test/update-feed.test.js
+++ b/test/update-feed.test.js
@@ -93,6 +93,14 @@ test("compareVersions orders releases", () => {
   assert.strictEqual(compareVersions("0.13.0-beta.1", "0.13.0"), -1);
   assert.strictEqual(compareVersions("0.13.0", "0.13.0-beta.1"), 1);
   assert.strictEqual(compareVersions("0.13.0-beta.10", "0.13.0-beta.2"), 1);
+  assert.strictEqual(
+    compareVersions("0.13.0-beta.9007199254740992", "0.13.0-beta.9007199254740993"),
+    -1
+  );
+  assert.strictEqual(
+    compareVersions("0.13.0-beta.9007199254740993", "0.13.0-beta.9007199254740992"),
+    1
+  );
   assert.strictEqual(compareVersions("0.13.0-beta.1", "0.13.0-beta.alpha"), -1);
   assert.strictEqual(compareVersions("0.13.0-beta", "0.13.0-beta.1"), -1);
   assert.strictEqual(compareVersions("0.13.0+linux", "0.13.0+mac"), 0);


### PR DESCRIPTION
## What
- compare prerelease identifiers using SemVer numeric rules
- ignore build metadata when deciding whether an update is newer
- cover numeric, alphanumeric, length, and build-metadata cases

## Why
Lexical comparison treated `beta.10` as older than `beta.2`, which could suppress valid prerelease updates.

## Test
- `npm test` (286 passed, 1 skipped)