### PR TITLE
fix: ignore invalid update asset sizes

### DIFF
--- a/main/services/update-feed.js
+++ b/main/services/update-feed.js
@@ -53,7 +53,8 @@ function parseLatestYml(text) {
     throw new Error("Update feed is missing version, path or sha512");
   }
   const entry = files.find((f) => f.url === path);
-  const size = entry && entry.size ? Number(entry.size) : 0;
+  const parsedSize = entry && entry.size ? Number(entry.size) : 0;
+  const size = Number.isFinite(parsedSize) && parsedSize >= 0 ? parsedSize : 0;
   return { version, path, sha512, size };
 }
 

--- a/test/update-feed.test.js
+++ b/test/update-feed.test.js
@@ -83,6 +83,13 @@ test("parseLatestYml rejects a feed missing required keys", () => {
   );
 });
 
+test("parseLatestYml ignores an invalid asset size", () => {
+  for (const size of ["not-a-number", "-42", "Infinity"]) {
+    const feed = MAC_YML.replace("size: 171973146", `size: ${size}`);
+    assert.strictEqual(parseLatestYml(feed).size, 0);
+  }
+});
+
 test("compareVersions orders releases", () => {
   assert.strictEqual(compareVersions("0.12.1", "0.12.1"), 0);
   assert.strictEqual(compareVersions("0.12.1", "0.13.0"), -1);


### PR DESCRIPTION
## What
- accept only finite, non-negative asset sizes from the update feed
- fall back to an unknown size when metadata is malformed
- cover non-numeric, negative, and infinite values

## Why
Invalid feed metadata could otherwise leak `NaN` or a negative denominator into updater progress calculations.

## Test
- `node --test test/update-feed.test.js`