### PR TITLE
fix: reject malformed stored setting types

### DIFF
--- a/main/settings.js
+++ b/main/settings.js
@@ -187,9 +187,14 @@ function settingsPath() {
 
 function deepMerge(base, override) {
   if (override === null || override === undefined) return base;
-  if (Array.isArray(base) || typeof base !== "object") return override;
+  if (Array.isArray(base)) return Array.isArray(override) ? override : base;
+  if (base === null || typeof base !== "object") {
+    return typeof override === typeof base ? override : base;
+  }
+  if (Array.isArray(override) || typeof override !== "object") return base;
   const out = { ...base };
   for (const key of Object.keys(override)) {
+    if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
     out[key] = key in base ? deepMerge(base[key], override[key]) : override[key];
   }
   return out;

--- a/main/settings.js
+++ b/main/settings.js
@@ -195,7 +195,9 @@ function deepMerge(base, override) {
   const out = { ...base };
   for (const key of Object.keys(override)) {
     if (key === "__proto__" || key === "constructor" || key === "prototype") continue;
-    out[key] = key in base ? deepMerge(base[key], override[key]) : override[key];
+    out[key] = Object.hasOwn(base, key)
+      ? deepMerge(base[key], override[key])
+      : override[key];
   }
   return out;
 }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -109,6 +109,35 @@ test("deepMerge ignores null/undefined overrides", () => {
   assert.deepStrictEqual(deepMerge({ a: 1 }, undefined), { a: 1 });
 });
 
+test("deepMerge keeps the default shape when stored settings have wrong types", () => {
+  const base = {
+    enabled: true,
+    retries: 2,
+    endpoint: "http://localhost",
+    nested: { value: "default" },
+    items: ["default"],
+  };
+  assert.deepStrictEqual(
+    deepMerge(base, {
+      enabled: "yes",
+      retries: null,
+      endpoint: {},
+      nested: "broken",
+      items: { 0: "broken" },
+    }),
+    base
+  );
+});
+
+test("deepMerge ignores prototype-mutating keys from stored JSON", () => {
+  const stored = JSON.parse(
+    '{"nested":{"value":"custom","__proto__":{"polluted":true}},"constructor":{"polluted":true}}'
+  );
+  const merged = deepMerge({ nested: { value: "default" } }, stored);
+  assert.deepStrictEqual(merged, { nested: { value: "custom" } });
+  assert.strictEqual({}.polluted, undefined);
+});
+
 test("wavToFloat32 round-trips PCM16 samples to [-1, 1]", () => {
   const wav = encodeWav(new Int16Array([0, 16384, -16384, 32767, -32768]));
   const { samples, sampleRate } = wavToFloat32(wav);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -138,6 +138,12 @@ test("deepMerge ignores prototype-mutating keys from stored JSON", () => {
   assert.strictEqual({}.polluted, undefined);
 });
 
+test("deepMerge preserves unknown keys that share names with inherited properties", () => {
+  const merged = deepMerge({}, { toString: "stored value" });
+  assert.strictEqual(Object.hasOwn(merged, "toString"), true);
+  assert.strictEqual(merged.toString, "stored value");
+});
+
 test("wavToFloat32 round-trips PCM16 samples to [-1, 1]", () => {
   const wav = encodeWav(new Int16Array([0, 16384, -16384, 32767, -32768]));
   const { samples, sampleRate } = wavToFloat32(wav);


### PR DESCRIPTION
## What
- retain schema defaults when stored primitives, objects, or arrays have the wrong type
- ignore prototype-mutating keys while merging settings
- add regression coverage for corrupted and hostile JSON shapes

## Why
A manually edited or partially corrupted settings file could replace an expected section with an incompatible value and break consumers after startup.

## Test
- `node --test test/unit.test.js` (65 passed)