### PR TITLE
fix: save settings atomically, bound Windows log rotation, and harden history, autostart and cleanup parsing

### DIFF
--- a/main/autostart.js
+++ b/main/autostart.js
@@ -23,13 +23,24 @@ const LINUX_DESKTOP_FILE = "earheart.desktop";
 // query with, so the two MUST match or the read-back state drifts.
 const LOGIN_ITEM_ARGS = ["--hidden"];
 
+// Exec= is not a shell command: the Desktop Entry spec tokenizes it itself,
+// and paths containing spaces must be quoted. Percent signs are field-code
+// markers even inside quotes, while backslash, quote, dollar and backtick need
+// escaping inside a quoted argument.
+function desktopExecArg(value) {
+  const escaped = String(value)
+    .replace(/%/g, "%%")
+    .replace(/([\\"`$])/g, "\\$1");
+  return `"${escaped}"`;
+}
+
 // The command the desktop environment should run at login. On Linux AppImages
 // the relaunchable path lives in $APPIMAGE — process.execPath points inside the
 // mounted image and would be stale next boot — so prefer it; fall back to
 // execPath for .deb installs and `npm start` development runs.
 function linuxLaunchCommand() {
   const exec = process.env.APPIMAGE || process.execPath;
-  return `${exec} --hidden`;
+  return `${desktopExecArg(exec)} --hidden`;
 }
 
 // A minimal but complete XDG autostart entry. X-GNOME-Autostart-enabled keeps
@@ -109,5 +120,6 @@ module.exports = {
   loginItemEnabled,
   linuxDesktopEntry,
   linuxLaunchCommand,
+  desktopExecArg,
   linuxAutostartPath,
 };

--- a/main/autostart.js
+++ b/main/autostart.js
@@ -24,14 +24,17 @@ const LINUX_DESKTOP_FILE = "earheart.desktop";
 const LOGIN_ITEM_ARGS = ["--hidden"];
 
 // Exec= is not a shell command: the Desktop Entry spec tokenizes it itself,
-// and paths containing spaces must be quoted. Percent signs are field-code
-// markers even inside quotes, while backslash, quote, dollar and backtick need
-// escaping inside a quoted argument.
+// and paths containing spaces must be quoted. Two escaping layers apply, in
+// order. First the Exec quoting rules: percent signs are field-code markers
+// even inside quotes, and backslash, quote, dollar and backtick need a
+// backslash inside a quoted argument. Then the key-file string rules, which
+// run before Exec parsing when the file is read: every backslash in the value
+// must itself be doubled, or GLib rejects the entry and nothing launches.
 function desktopExecArg(value) {
-  const escaped = String(value)
+  const quoted = String(value)
     .replace(/%/g, "%%")
     .replace(/([\\"`$])/g, "\\$1");
-  return `"${escaped}"`;
+  return `"${quoted.replace(/\\/g, "\\\\")}"`;
 }
 
 // The command the desktop environment should run at login. On Linux AppImages

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -24,12 +24,32 @@ const { totalBytes } = require("./registry");
 
 const MARKER = ".complete";
 
+function assertPathSegment(value, label) {
+  if (
+    typeof value !== "string" ||
+    !value ||
+    value === "." ||
+    value === ".." ||
+    value.includes("/") ||
+    value.includes("\\") ||
+    value.includes("\0")
+  ) {
+    throw new Error(`Invalid model ${label}`);
+  }
+  return value;
+}
+
 function modelDir(baseDir, model) {
-  return path.join(baseDir, model.kind, model.id);
+  const kind = assertPathSegment(model.kind, "kind");
+  const id = assertPathSegment(model.id, "id");
+  return path.join(baseDir, kind, id);
 }
 
 function filePath(baseDir, model, file) {
-  return path.join(modelDir(baseDir, model), file.name);
+  return path.join(
+    modelDir(baseDir, model),
+    assertPathSegment(file.name, "filename")
+  );
 }
 
 function partialPaths(dest) {
@@ -66,7 +86,7 @@ function isInstalled(baseDir, model) {
   const sizes = readMarker(dir);
   if (sizes === null) return false;
   return model.files.every((f) => {
-    const p = path.join(dir, f.name);
+    const p = filePath(baseDir, model, f);
     const expected = sizes[f.name];
     if (expected === undefined) return fs.existsSync(p); // legacy marker
     try {
@@ -219,7 +239,7 @@ async function fetchFull(file, signal) {
 async function downloadFile(baseDir, model, file, { partial, onSize, signal }) {
   const dir = modelDir(baseDir, model);
   await fsp.mkdir(dir, { recursive: true });
-  const dest = path.join(dir, file.name);
+  const dest = filePath(baseDir, model, file);
   const paths = partialPaths(dest);
 
   // A crash can happen after the last byte lands but before verification and

--- a/main/engines/model-manager.js
+++ b/main/engines/model-manager.js
@@ -20,24 +20,9 @@ const crypto = require("node:crypto");
 const { Readable, Transform } = require("node:stream");
 const { pipeline } = require("node:stream/promises");
 
-const { totalBytes } = require("./registry");
+const { totalBytes, assertPathSegment } = require("./registry");
 
 const MARKER = ".complete";
-
-function assertPathSegment(value, label) {
-  if (
-    typeof value !== "string" ||
-    !value ||
-    value === "." ||
-    value === ".." ||
-    value.includes("/") ||
-    value.includes("\\") ||
-    value.includes("\0")
-  ) {
-    throw new Error(`Invalid model ${label}`);
-  }
-  return value;
-}
 
 function modelDir(baseDir, model) {
   const kind = assertPathSegment(model.kind, "kind");
@@ -82,11 +67,24 @@ function readMarker(dir) {
  * later truncated is treated as not installed.
  */
 function isInstalled(baseDir, model) {
-  const dir = modelDir(baseDir, model);
+  // A model whose id or filenames can't name a path inside the managed
+  // directory is never installed; answer false rather than throwing so one
+  // bad entry can't take down a whole model listing.
+  let dir;
+  try {
+    dir = modelDir(baseDir, model);
+  } catch {
+    return false;
+  }
   const sizes = readMarker(dir);
   if (sizes === null) return false;
   return model.files.every((f) => {
-    const p = filePath(baseDir, model, f);
+    let p;
+    try {
+      p = filePath(baseDir, model, f);
+    } catch {
+      return false;
+    }
     const expected = sizes[f.name];
     if (expected === undefined) return fs.existsSync(p); // legacy marker
     try {

--- a/main/engines/registry.js
+++ b/main/engines/registry.js
@@ -195,8 +195,60 @@ const DEFAULT_CLEANUP_MODEL = "gemma-3-1b";
 // shape as a MODELS entry, minus the sha256 we can't pre-verify for a user URL.
 let customModels = [];
 
+// A model id or filename becomes one path component under the managed models
+// directory, so it must be a single, plain segment: no separators, no dot
+// segments, none of the characters Windows refuses in a name, no reserved
+// device name, and no trailing dot or space (Windows strips those, so the
+// path checked and the path written would differ).
+const WINDOWS_RESERVED_NAME = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+
+function isPathSegment(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value !== "." &&
+    value !== ".." &&
+    !/[\\/:*?"<>|\u0000-\u001f]/.test(value) &&
+    !/[. ]$/.test(value) &&
+    !WINDOWS_RESERVED_NAME.test(value)
+  );
+}
+
+function assertPathSegment(value, label) {
+  if (!isPathSegment(value)) throw new Error(`Invalid model ${label}`);
+  return value;
+}
+
+// Every string a custom model contributes to a filesystem path. The load
+// paths (gguf.file, sherpa.*) are joined onto the model dir by the engines
+// without going through the download validation, so they are checked here.
+function customModelPathSegments(m) {
+  const sherpa = m.sherpa || {};
+  return [
+    m.id,
+    ...(Array.isArray(m.files) ? m.files.map((f) => f && f.name) : []),
+    m.gguf && m.gguf.file,
+    sherpa.encoder,
+    sherpa.decoder,
+    sherpa.joiner,
+    sherpa.tokens,
+  ].filter((s) => s !== undefined && s !== null);
+}
+
 function setCustomModels(list) {
-  customModels = Array.isArray(list) ? list.filter((m) => m && m.id && m.kind) : [];
+  customModels = [];
+  if (!Array.isArray(list)) return;
+  for (const m of list) {
+    if (!m || !m.id || !m.kind) continue;
+    // Custom models come from settings.json, which the user can edit by hand.
+    // A row that could name a path outside its managed directory is dropped
+    // rather than left to throw from every model listing.
+    if (!customModelPathSegments(m).every(isPathSegment)) {
+      console.warn(`[earheart] ignoring custom model with an invalid path segment: ${m.id}`);
+      continue;
+    }
+    customModels.push(m);
+  }
 }
 
 /** Look up a model by kind ("stt" | "cleanup") and id. */
@@ -225,6 +277,8 @@ module.exports = {
   DEFAULT_STT_MODEL,
   DEFAULT_CLEANUP_MODEL,
   setCustomModels,
+  isPathSegment,
+  assertPathSegment,
   getModel,
   listModels,
   totalBytes,

--- a/main/history.js
+++ b/main/history.js
@@ -12,11 +12,20 @@ function historyPath() {
   return path.join(app.getPath("userData"), "history.json");
 }
 
+function validEntries(value) {
+  if (!Array.isArray(value)) return [];
+  // A manually edited, partially recovered, or older history file may contain
+  // nulls or other JSON values. Only records with transcript text can satisfy
+  // the renderer/tray contract; ignore bad rows without hiding valid ones.
+  return value.filter(
+    (entry) => entry && typeof entry === "object" && typeof entry.text === "string"
+  );
+}
+
 function load() {
   if (cached) return cached;
   try {
-    cached = JSON.parse(fs.readFileSync(historyPath(), "utf8"));
-    if (!Array.isArray(cached)) cached = [];
+    cached = validEntries(JSON.parse(fs.readFileSync(historyPath(), "utf8")));
   } catch {
     cached = [];
   }
@@ -77,4 +86,4 @@ function clear() {
   }
 }
 
-module.exports = { add, list, clear };
+module.exports = { add, list, clear, validEntries };

--- a/main/services/cleanup.js
+++ b/main/services/cleanup.js
@@ -3,6 +3,7 @@
 // llama.cpp, LM Studio, vLLM, OpenRouter, OpenAI, or anything else compatible.
 
 const { resolveCleanup, remoteSamplingBody } = require("../cleanup-styles");
+const { CLEAN_RUNAWAY_MESSAGE } = require("../util/clean-budget");
 
 function joinUrl(baseUrl, route) {
   return baseUrl.replace(/\/+$/, "") + route;
@@ -53,7 +54,12 @@ async function clean(transcript, cfg, signal) {
     throw new Error(`Cleanup service error ${res.status}: ${body.slice(0, 300)}`);
   }
   const data = await res.json();
-  const content = data.choices?.[0]?.message?.content;
+  const choice = data.choices?.[0];
+  // The server cut the answer off at its token limit. A half-cleaned
+  // transcript is not a cleanup result; throwing sends the pipeline down the
+  // same raw-transcript fallback the in-process engine uses for a runaway.
+  if (choice?.finish_reason === "length") throw new Error(CLEAN_RUNAWAY_MESSAGE);
+  const content = choice?.message?.content;
   if (typeof content !== "string") {
     throw new Error("Cleanup service returned no message content");
   }

--- a/main/services/cleanup.js
+++ b/main/services/cleanup.js
@@ -10,7 +10,13 @@ function joinUrl(baseUrl, route) {
 
 // Reasoning models may emit <think>...</think> blocks; strip them.
 function stripThinking(text) {
-  return text.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+  return text
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    // A response can hit its token/time limit before the closing tag. Treat
+    // everything after an unmatched opener as reasoning too; clean() will
+    // fall back to the raw transcript when that leaves no answer.
+    .replace(/<think>[\s\S]*$/i, "")
+    .trim();
 }
 
 /**

--- a/main/services/models-remote.js
+++ b/main/services/models-remote.js
@@ -52,7 +52,15 @@ async function listRemoteModels(cfg, { signal, timeoutMs = DEFAULT_TIMEOUT_MS } 
   let body;
   try {
     body = await res.json();
-  } catch {
+  } catch (err) {
+    // The deadline covers the body too: a server that sends headers and then
+    // stalls is a timeout, not a malformed response.
+    if (err.name === "TimeoutError") {
+      throw new Error(`Timed out fetching models from ${url}`);
+    }
+    if (err.name === "AbortError") {
+      throw new Error(`Could not reach ${url}: ${err.message}`);
+    }
     throw new Error(`${url} did not return JSON`);
   }
 

--- a/main/services/models-remote.js
+++ b/main/services/models-remote.js
@@ -6,13 +6,15 @@ function joinUrl(baseUrl, route) {
   return baseUrl.replace(/\/+$/, "") + route;
 }
 
+const DEFAULT_TIMEOUT_MS = 15000;
+
 /**
  * Fetch available model ids from an OpenAI-compatible endpoint.
  * @param {{ baseUrl: string, apiKey?: string }} cfg
- * @param {{ signal?: AbortSignal }} [opts]
+ * @param {{ signal?: AbortSignal, timeoutMs?: number }} [opts]
  * @returns {Promise<string[]>} sorted, de-duplicated model ids
  */
-async function listRemoteModels(cfg, { signal } = {}) {
+async function listRemoteModels(cfg, { signal, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
   if (!cfg || !cfg.baseUrl) throw new Error("Base URL is required");
   const url = joinUrl(cfg.baseUrl, "/models");
   // Only fetch over HTTP(S). The base URL is user-supplied and reaches here
@@ -32,8 +34,15 @@ async function listRemoteModels(cfg, { signal } = {}) {
 
   let res;
   try {
-    res = await fetch(url, { headers, signal });
+    const timeout = AbortSignal.timeout(timeoutMs);
+    res = await fetch(url, {
+      headers,
+      signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+    });
   } catch (err) {
+    if (err.name === "TimeoutError") {
+      throw new Error(`Timed out fetching models from ${url}`);
+    }
     throw new Error(`Could not reach ${url}: ${err.message}`);
   }
   if (!res.ok) {

--- a/main/settings.js
+++ b/main/settings.js
@@ -284,8 +284,24 @@ function load() {
 
 function save(next) {
   cached = deepMerge(DEFAULTS, next);
-  fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
-  fs.writeFileSync(settingsPath(), JSON.stringify(cached, null, 2));
+  const file = settingsPath();
+  const tmp = `${file}.${process.pid}.tmp`;
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  try {
+    // Write a complete replacement beside the destination, then swap it into
+    // place atomically. A crash can leave the previous settings or a harmless
+    // temp file, but never a truncated settings.json. The restrictive mode is
+    // especially important while API keys still live in this file.
+    fs.writeFileSync(tmp, JSON.stringify(cached, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // The write may have failed before the temp file was created.
+    }
+    throw err;
+  }
   return cached;
 }
 

--- a/main/settings.js
+++ b/main/settings.js
@@ -283,7 +283,7 @@ function load() {
 }
 
 function save(next) {
-  cached = deepMerge(DEFAULTS, next);
+  const merged = deepMerge(DEFAULTS, next);
   const file = settingsPath();
   const tmp = `${file}.${process.pid}.tmp`;
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
@@ -292,7 +292,7 @@ function save(next) {
     // place atomically. A crash can leave the previous settings or a harmless
     // temp file, but never a truncated settings.json. The restrictive mode is
     // especially important while API keys still live in this file.
-    fs.writeFileSync(tmp, JSON.stringify(cached, null, 2), { mode: 0o600 });
+    fs.writeFileSync(tmp, JSON.stringify(merged, null, 2), { mode: 0o600 });
     fs.renameSync(tmp, file);
   } catch (err) {
     try {
@@ -302,6 +302,9 @@ function save(next) {
     }
     throw err;
   }
+  // Only now does the in-memory copy change: a failed save must leave get()
+  // agreeing with the file, not handing out values that were never persisted.
+  cached = merged;
   return cached;
 }
 

--- a/main/util/logger.js
+++ b/main/util/logger.js
@@ -38,12 +38,11 @@ function resolveDir() {
 function rotateIfLarge(file, maxBytes = MAX_BYTES) {
   try {
     if (fs.statSync(file).size <= maxBytes) return;
-    const backup = `${file}.1`;
-    // POSIX rename replaces an existing file, but Windows rename does not.
-    // Remove the one retained generation first so rotation keeps working after
-    // the log has crossed the limit more than once.
-    fs.rmSync(backup, { force: true });
-    fs.renameSync(file, backup);
+    // rename replaces an existing destination on every platform Node supports
+    // (libuv uses MOVEFILE_REPLACE_EXISTING on Windows), so the previous
+    // generation is swapped out in one step — never removed ahead of a rename
+    // that might then fail and leave nothing retained.
+    fs.renameSync(file, `${file}.1`);
   } catch {
     // No existing file, or the rename failed — not worth blocking startup on.
   }

--- a/main/util/logger.js
+++ b/main/util/logger.js
@@ -35,9 +35,15 @@ function resolveDir() {
   }
 }
 
-function rotateIfLarge(file) {
+function rotateIfLarge(file, maxBytes = MAX_BYTES) {
   try {
-    if (fs.statSync(file).size > MAX_BYTES) fs.renameSync(file, `${file}.1`);
+    if (fs.statSync(file).size <= maxBytes) return;
+    const backup = `${file}.1`;
+    // POSIX rename replaces an existing file, but Windows rename does not.
+    // Remove the one retained generation first so rotation keeps working after
+    // the log has crossed the limit more than once.
+    fs.rmSync(backup, { force: true });
+    fs.renameSync(file, backup);
   } catch {
     // No existing file, or the rename failed — not worth blocking startup on.
   }
@@ -103,4 +109,5 @@ module.exports = {
   warn: (...args) => write("WARN", args),
   info: (...args) => write("INFO", args),
   getLogPath: () => logPath,
+  rotateIfLarge,
 };

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -108,6 +108,54 @@ test("model paths cannot escape the managed model directory", () => {
   }
 });
 
+test("isInstalled answers false for a model that cannot name a managed path", () => {
+  const base = path.join(os.tmpdir(), "earheart-models");
+  assert.strictEqual(
+    manager.isInstalled(base, { kind: "cleanup", id: "../outside", files: [] }),
+    false
+  );
+  assert.strictEqual(
+    manager.isInstalled(base, {
+      kind: "cleanup",
+      id: "fine",
+      files: [{ name: "../escape.gguf" }],
+    }),
+    false
+  );
+});
+
+test("registry drops custom models whose paths could leave the model directory", () => {
+  const good = {
+    kind: "cleanup",
+    id: "custom-good",
+    label: "Good",
+    files: [{ name: "model.gguf", url: "https://example.invalid/model.gguf" }],
+    gguf: { file: "model.gguf" },
+  };
+  const bad = [
+    { ...good, id: "custom-org/name" },
+    { ...good, id: "custom-bad-1", gguf: { file: "../../evil.gguf" } },
+    { ...good, id: "custom-bad-2", files: [{ name: "..\\evil.gguf" }] },
+    { ...good, id: "custom-bad-3", kind: "stt", sherpa: { encoder: "../x.onnx" } },
+    { ...good, id: "CON" },
+    { ...good, id: "custom-bad-4", gguf: { file: "weights:v2.gguf" } },
+    { ...good, id: "trailing-dot." },
+  ];
+  try {
+    registry.setCustomModels([good, ...bad]);
+    assert.deepStrictEqual(
+      registry.listModels("cleanup").filter((m) => m.custom || m.id.startsWith("custom")).map((m) => m.id),
+      ["custom-good"]
+    );
+    assert.strictEqual(registry.getModel("stt", "custom-bad-3"), null);
+  } finally {
+    registry.setCustomModels([]);
+  }
+  for (const s of ["model.gguf", "parakeet-tdt-0.6b-v3", "encoder.int8.onnx"]) {
+    assert.ok(registry.isPathSegment(s), s);
+  }
+});
+
 test("exactly one cleanup model is marked default", () => {
   const defaults = registry.listModels("cleanup").filter((m) => m.default);
   assert.strictEqual(defaults.length, 1);

--- a/test/engines.test.js
+++ b/test/engines.test.js
@@ -89,6 +89,25 @@ test("registry totalBytes sums the file sizes", () => {
   assert.strictEqual(registry.totalBytes(model), 15);
 });
 
+test("model paths cannot escape the managed model directory", () => {
+  const base = path.join(os.tmpdir(), "earheart-models");
+  const model = { kind: "cleanup", id: "safe-model" };
+  assert.strictEqual(
+    manager.filePath(base, model, { name: "weights.gguf" }),
+    path.join(base, "cleanup", "safe-model", "weights.gguf")
+  );
+
+  for (const id of ["../outside", "..\\outside", "..", ""]) {
+    assert.throws(() => manager.modelDir(base, { ...model, id }), /Invalid model id/);
+  }
+  for (const name of ["../outside.gguf", "..\\outside.gguf", "/tmp/outside", ""]) {
+    assert.throws(
+      () => manager.filePath(base, model, { name }),
+      /Invalid model filename/
+    );
+  }
+});
+
 test("exactly one cleanup model is marked default", () => {
   const defaults = registry.listModels("cleanup").filter((m) => m.default);
   assert.strictEqual(defaults.length, 1);

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -1,0 +1,34 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const Module = require("node:module");
+
+function loadHistory() {
+  const historyPath = require.resolve("../main/history");
+  const electronPath = require.resolve("electron");
+  const savedElectron = require.cache[electronPath];
+  const electron = new Module(electronPath, null);
+  electron.filename = electronPath;
+  electron.loaded = true;
+  electron.exports = { app: { getPath: () => "/unused" } };
+  require.cache[electronPath] = electron;
+  delete require.cache[historyPath];
+  const history = require(historyPath);
+  delete require.cache[historyPath];
+  if (savedElectron) require.cache[electronPath] = savedElectron;
+  else delete require.cache[electronPath];
+  return history;
+}
+
+test("history keeps valid transcripts while ignoring malformed rows", () => {
+  const { validEntries } = loadHistory();
+  const good = { text: "Keep my words", at: "2026-09-10T00:00:00.000Z" };
+  assert.deepStrictEqual(
+    validEntries([null, 1, "text", {}, { text: 42 }, good]),
+    [good]
+  );
+});
+
+test("history treats a non-array JSON value as empty", () => {
+  const { validEntries } = loadHistory();
+  assert.deepStrictEqual(validEntries({ text: "not a history list" }), []);
+});

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,0 +1,32 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { rotateIfLarge } = require("../main/util/logger");
+
+test("log rotation replaces the previous backup generation", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-logger-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "earheart.log");
+  fs.writeFileSync(file, "new-current-log");
+  fs.writeFileSync(`${file}.1`, "old-backup");
+
+  rotateIfLarge(file, 4);
+
+  assert.strictEqual(fs.existsSync(file), false);
+  assert.strictEqual(fs.readFileSync(`${file}.1`, "utf8"), "new-current-log");
+});
+
+test("log rotation leaves a file within the limit untouched", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-logger-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "earheart.log");
+  fs.writeFileSync(file, "short");
+
+  rotateIfLarge(file, 5);
+
+  assert.strictEqual(fs.readFileSync(file, "utf8"), "short");
+  assert.strictEqual(fs.existsSync(`${file}.1`), false);
+});

--- a/test/settings-persistence.test.js
+++ b/test/settings-persistence.test.js
@@ -74,6 +74,7 @@ test("a failed replacement preserves the previous settings", (t) => {
 
   const file = path.join(dir, "settings.json");
   assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).hotkey, "Working");
+  assert.strictEqual(settings.get().hotkey, "Working");
   assert.deepStrictEqual(
     fs.readdirSync(dir).filter((name) => name.includes(".tmp")),
     []

--- a/test/settings-persistence.test.js
+++ b/test/settings-persistence.test.js
@@ -1,0 +1,81 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const Module = require("node:module");
+
+function loadSettings(userData) {
+  const settingsPath = require.resolve("../main/settings");
+  const electronPath = require.resolve("electron");
+  const registryPath = require.resolve("../main/engines/registry");
+  const savedElectron = require.cache[electronPath];
+  const savedRegistry = require.cache[registryPath];
+
+  const electron = new Module(electronPath, null);
+  electron.filename = electronPath;
+  electron.loaded = true;
+  electron.exports = { app: { getPath: () => userData } };
+  require.cache[electronPath] = electron;
+
+  const registry = new Module(registryPath, null);
+  registry.filename = registryPath;
+  registry.loaded = true;
+  registry.exports = {
+    DEFAULT_STT_MODEL: "stt-default",
+    DEFAULT_CLEANUP_MODEL: "cleanup-default",
+  };
+  require.cache[registryPath] = registry;
+
+  delete require.cache[settingsPath];
+  const settings = require(settingsPath);
+  delete require.cache[settingsPath];
+  if (savedElectron) require.cache[electronPath] = savedElectron;
+  else delete require.cache[electronPath];
+  if (savedRegistry) require.cache[registryPath] = savedRegistry;
+  else delete require.cache[registryPath];
+  return settings;
+}
+
+test("settings save replaces the file and leaves no partial temp file", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-settings-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const settings = loadSettings(dir);
+
+  settings.save({ hotkey: "First" });
+  settings.save({ hotkey: "Second" });
+
+  const file = path.join(dir, "settings.json");
+  assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).hotkey, "Second");
+  assert.deepStrictEqual(
+    fs.readdirSync(dir).filter((name) => name.includes(".tmp")),
+    []
+  );
+  if (process.platform !== "win32") {
+    assert.strictEqual(fs.statSync(file).mode & 0o777, 0o600);
+  }
+});
+
+test("a failed replacement preserves the previous settings", (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "earheart-settings-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const settings = loadSettings(dir);
+  settings.save({ hotkey: "Working" });
+
+  const originalRename = fs.renameSync;
+  fs.renameSync = () => {
+    throw new Error("simulated rename failure");
+  };
+  try {
+    assert.throws(() => settings.save({ hotkey: "Broken" }), /rename failure/);
+  } finally {
+    fs.renameSync = originalRename;
+  }
+
+  const file = path.join(dir, "settings.json");
+  assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).hotkey, "Working");
+  assert.deepStrictEqual(
+    fs.readdirSync(dir).filter((name) => name.includes(".tmp")),
+    []
+  );
+});

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -533,10 +533,10 @@ test("start-on-boot defaults to off and survives the merge both ways", () => {
 });
 
 test("linux autostart entry is a valid XDG desktop file launched hidden", () => {
-  const entry = autostart.linuxDesktopEntry("/opt/Earheart.AppImage --hidden");
+  const entry = autostart.linuxDesktopEntry('"/opt/Earheart.AppImage" --hidden');
   assert.match(entry, /^\[Desktop Entry\]/);
   assert.match(entry, /\nType=Application\n/);
-  assert.match(entry, /\nExec=\/opt\/Earheart\.AppImage --hidden\n/);
+  assert.match(entry, /\nExec="\/opt\/Earheart\.AppImage" --hidden\n/);
   // GNOME treats a missing flag as disabled, so it must be present and true.
   assert.match(entry, /\nX-GNOME-Autostart-enabled=true\n/);
 });
@@ -547,10 +547,28 @@ test("linux launch command starts hidden and prefers $APPIMAGE", () => {
     process.env.APPIMAGE = "/home/u/Earheart.AppImage";
     assert.strictEqual(
       autostart.linuxLaunchCommand(),
-      "/home/u/Earheart.AppImage --hidden"
+      '"/home/u/Earheart.AppImage" --hidden'
     );
     delete process.env.APPIMAGE;
     assert.ok(autostart.linuxLaunchCommand().endsWith(" --hidden"));
+  } finally {
+    if (saved === undefined) delete process.env.APPIMAGE;
+    else process.env.APPIMAGE = saved;
+  }
+});
+
+test("linux launch command quotes AppImage paths with spaces and field codes", () => {
+  const saved = process.env.APPIMAGE;
+  try {
+    process.env.APPIMAGE = "/home/A User/Earheart 100%.AppImage";
+    assert.strictEqual(
+      autostart.linuxLaunchCommand(),
+      '"/home/A User/Earheart 100%%.AppImage" --hidden'
+    );
+    assert.strictEqual(
+      autostart.desktopExecArg('/tmp/a"b\\c$`'),
+      '"/tmp/a\\"b\\\\c\\$\\`"'
+    );
   } finally {
     if (saved === undefined) delete process.env.APPIMAGE;
     else process.env.APPIMAGE = saved;

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -821,6 +821,21 @@ test("listRemoteModels wraps a network failure with the URL", async () => {
   );
 });
 
+test("listRemoteModels times out when a service never responds", async () => {
+  const server = http.createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const base = `http://127.0.0.1:${server.address().port}/v1`;
+  try {
+    await assert.rejects(
+      () => listRemoteModels({ baseUrl: base }, { timeoutMs: 20 }),
+      /Timed out fetching models/
+    );
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
 test("idle model unload defaults to a finite window and is overridable", () => {
   // Sensible default: unload after a couple of idle minutes.
   assert.strictEqual(DEFAULTS.engines.idleUnloadMinutes, 2);

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -92,6 +92,11 @@ test("stripThinking removes reasoning blocks", () => {
     stripThinking("<THINK>a</THINK>\n\n  Result  "),
     "Result"
   );
+  assert.strictEqual(stripThinking("<think>unfinished private reasoning"), "");
+  assert.strictEqual(
+    stripThinking("Answer so far.<think>unfinished private reasoning"),
+    "Answer so far."
+  );
 });
 
 test("deepMerge keeps defaults for missing keys and overrides present ones", () => {

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -8,7 +8,8 @@ const http = require("node:http");
 const Module = require("node:module");
 
 const { encodeWav, encodeSilenceWav, wavToFloat32, wavDurationSec } = require("../main/util/wav");
-const { stripThinking } = require("../main/services/cleanup");
+const { stripThinking, clean: remoteClean } = require("../main/services/cleanup");
+const { CLEAN_RUNAWAY_MESSAGE } = require("../main/util/clean-budget");
 const { deepMerge, migrateLegacy, DEFAULTS } = require("../main/settings");
 const { resolveCleanup } = require("../main/cleanup-styles");
 const {
@@ -97,6 +98,26 @@ test("stripThinking removes reasoning blocks", () => {
     stripThinking("Answer so far.<think>unfinished private reasoning"),
     "Answer so far."
   );
+});
+
+test("remote cleanup rejects an answer the server cut off at its token limit", async () => {
+  const reply = (finish_reason) =>
+    JSON.stringify({ choices: [{ finish_reason, message: { content: "Answer so far." } }] });
+  let finish = "length";
+  const server = http.createServer((req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.end(reply(finish));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const cfg = { baseUrl: `http://127.0.0.1:${server.address().port}/v1`, model: "m" };
+  try {
+    await assert.rejects(() => remoteClean("um hello", cfg), { message: CLEAN_RUNAWAY_MESSAGE });
+    finish = "stop";
+    assert.strictEqual(await remoteClean("um hello", cfg), "Answer so far.");
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
 });
 
 test("deepMerge keeps defaults for missing keys and overrides present ones", () => {
@@ -570,9 +591,11 @@ test("linux launch command quotes AppImage paths with spaces and field codes", (
       autostart.linuxLaunchCommand(),
       '"/home/A User/Earheart 100%%.AppImage" --hidden'
     );
+    // Exec quoting (\") then key-file escaping (\\") — GLib unescapes the
+    // key-file layer first, so a single backslash would be rejected.
     assert.strictEqual(
       autostart.desktopExecArg('/tmp/a"b\\c$`'),
-      '"/tmp/a\\"b\\\\c\\$\\`"'
+      '"/tmp/a\\\\"b\\\\\\\\c\\\\$\\\\`"'
     );
   } finally {
     if (saved === undefined) delete process.env.APPIMAGE;
@@ -842,6 +865,25 @@ test("listRemoteModels wraps a network failure with the URL", async () => {
     () => listRemoteModels({ baseUrl: "http://127.0.0.1:1/v1" }),
     /Could not reach/
   );
+});
+
+test("listRemoteModels reports a stalled response body as a timeout", async () => {
+  const server = http.createServer((req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    res.write('{"data": [');
+    // Never end the response.
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const base = `http://127.0.0.1:${server.address().port}/v1`;
+  try {
+    await assert.rejects(
+      () => listRemoteModels({ baseUrl: base }, { timeoutMs: 50 }),
+      /Timed out fetching models/
+    );
+  } finally {
+    server.closeAllConnections();
+    server.close();
+  }
 });
 
 test("listRemoteModels times out when a service never responds", async () => {


### PR DESCRIPTION
Batch of seven reviewed, CI-green fix PRs merged locally with `--no-ff` so each stays a distinct revertable merge commit. Merging this marks the originals as merged.

- #131 — fix: save settings atomically
- #133 — fix: time out stalled remote model discovery
- #134 — fix: hide truncated cleanup reasoning
- #135 — fix: quote Linux autostart executable paths
- #136 — fix: ignore malformed history rows
- #137 — fix: confine model downloads to their managed directory
- #138 — fix: keep log rotation bounded on Windows

Not in this batch: #140, #132 (behavior changes in core paths, held for a separate look), #139 (conflicts with main).

**Tests:** `npm test` on the batched branch: 297 pass, 1 skipped, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZSZV1CHQD3Zc9WaZ3hhsg