### PR TITLE
fix: persist decode calibration atomically

### DIFF
--- a/main/util/rtf.js
+++ b/main/util/rtf.js
@@ -78,10 +78,17 @@ function createPersistedRtfEstimator(filePath, options = {}) {
     inner.record(audioDurationSec, elapsedSec);
     const next = inner.estimate();
     if (next === before) return; // rejected sample (or no-op fold): nothing new
+    const tempPath = `${filePath}.${process.pid}.tmp`;
     try {
-      fs.writeFileSync(filePath, JSON.stringify({ rtf: next }));
+      fs.writeFileSync(tempPath, JSON.stringify({ rtf: next }), { mode: 0o600 });
+      fs.renameSync(tempPath, filePath);
     } catch {
       // Best effort — this session still benefits from the in-memory value.
+      try {
+        fs.unlinkSync(tempPath);
+      } catch {
+        // The temporary file may never have been created.
+      }
     }
   }
 

--- a/test/rtf.test.js
+++ b/test/rtf.test.js
@@ -80,6 +80,33 @@ test("persisted rtf: saves after record and reloads on the next construction", (
   assert.strictEqual(second.estimate(), learned);
 });
 
+test("persisted rtf: replaces state atomically through a temporary file", () => {
+  const file = tmpStateFile();
+  const writes = [];
+  const renames = [];
+  const originalWrite = fs.writeFileSync;
+  const originalRename = fs.renameSync;
+  fs.writeFileSync = (target, ...args) => {
+    writes.push(target);
+    return originalWrite(target, ...args);
+  };
+  fs.renameSync = (source, target) => {
+    renames.push([source, target]);
+    return originalRename(source, target);
+  };
+  try {
+    createPersistedRtfEstimator(file).record(10, 1);
+  } finally {
+    fs.writeFileSync = originalWrite;
+    fs.renameSync = originalRename;
+  }
+
+  assert.deepStrictEqual(writes, [`${file}.${process.pid}.tmp`]);
+  assert.deepStrictEqual(renames, [[`${file}.${process.pid}.tmp`, file]]);
+  assert.ok(fs.existsSync(file));
+  assert.ok(!fs.existsSync(`${file}.${process.pid}.tmp`));
+});
+
 test("persisted rtf: missing or corrupt state falls back to the default", () => {
   const file = tmpStateFile();
   assert.strictEqual(createPersistedRtfEstimator(file).estimate(), 0.25);


### PR DESCRIPTION
## What
- write learned decode calibration to a private temporary file
- atomically replace the prior state only after the write succeeds
- clean up an incomplete temporary file on failure

## Why
A crash during a direct write could truncate the calibration file and discard the app’s learned progress estimate on the next launch.

## Test
- `node --test test/rtf.test.js` (11 passed)