### PR TITLE
fix: validate remote service URLs

### DIFF
--- a/main/services/cleanup.js
+++ b/main/services/cleanup.js
@@ -3,10 +3,7 @@
 // llama.cpp, LM Studio, vLLM, OpenRouter, OpenAI, or anything else compatible.
 
 const { resolveCleanup, remoteSamplingBody } = require("../cleanup-styles");
-
-function joinUrl(baseUrl, route) {
-  return baseUrl.replace(/\/+$/, "") + route;
-}
+const { serviceUrl } = require("./service-url");
 
 // Reasoning models may emit <think>...</think> blocks; strip them.
 function stripThinking(text) {
@@ -20,7 +17,7 @@ function stripThinking(text) {
  * @returns {Promise<string>} cleaned text
  */
 async function clean(transcript, cfg, signal) {
-  const url = joinUrl(cfg.baseUrl, "/chat/completions");
+  const url = serviceUrl(cfg?.baseUrl, "/chat/completions");
   const headers = { "Content-Type": "application/json" };
   if (cfg.apiKey) headers.Authorization = `Bearer ${cfg.apiKey}`;
 

--- a/main/services/service-url.js
+++ b/main/services/service-url.js
@@ -1,0 +1,20 @@
+// Validate a user-supplied OpenAI-compatible service base before appending an
+// endpoint. Keep the base path (for example `/v1`) rather than using URL
+// resolution, which would replace it when the endpoint starts with a slash.
+function serviceUrl(baseUrl, route) {
+  const base = typeof baseUrl === "string" ? baseUrl.trim() : "";
+  if (!base) throw new Error("Base URL is required");
+
+  let parsed;
+  try {
+    parsed = new URL(base);
+  } catch {
+    throw new Error(`Invalid base URL: ${baseUrl}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Base URL must use http or https, got ${parsed.protocol}`);
+  }
+  return base.replace(/\/+$/, "") + route;
+}
+
+module.exports = { serviceUrl };

--- a/main/services/stt.js
+++ b/main/services/stt.js
@@ -3,9 +3,7 @@
 // works against the bundled Parakeet server, OpenAI, Groq, speaches, or any
 // other compatible service — switching is just a base URL change.
 
-function joinUrl(baseUrl, route) {
-  return baseUrl.replace(/\/+$/, "") + route;
-}
+const { serviceUrl } = require("./service-url");
 
 /**
  * @param {Buffer|ArrayBuffer} wav - WAV audio (16 kHz mono PCM16 expected)
@@ -14,7 +12,7 @@ function joinUrl(baseUrl, route) {
  * @returns {Promise<string>} transcribed text
  */
 async function transcribe(wav, cfg, signal) {
-  const url = joinUrl(cfg.baseUrl, "/audio/transcriptions");
+  const url = serviceUrl(cfg?.baseUrl, "/audio/transcriptions");
   const form = new FormData();
   const bytes = Buffer.isBuffer(wav) ? wav : Buffer.from(wav);
   form.append("file", new Blob([bytes], { type: "audio/wav" }), "audio.wav");

--- a/test/remote-services.test.js
+++ b/test/remote-services.test.js
@@ -1,0 +1,30 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { serviceUrl } = require("../main/services/service-url");
+const { transcribe } = require("../main/services/stt");
+const { clean } = require("../main/services/cleanup");
+
+test("serviceUrl preserves base paths and removes trailing slashes", () => {
+  assert.strictEqual(
+    serviceUrl(" https://api.example.test/v1/// ", "/models"),
+    "https://api.example.test/v1/models"
+  );
+});
+
+test("serviceUrl rejects missing, invalid and non-network bases", () => {
+  assert.throws(() => serviceUrl("", "/models"), /required/);
+  assert.throws(() => serviceUrl("localhost:8080", "/models"), /http or https/);
+  assert.throws(() => serviceUrl("file:///tmp/service", "/models"), /http or https/);
+});
+
+test("remote STT rejects an unsafe service URL before making a request", async () => {
+  await assert.rejects(
+    transcribe(Buffer.alloc(0), { baseUrl: "file:///tmp/transcribe" }),
+    /http or https/
+  );
+});
+
+test("remote cleanup rejects an unsafe service URL before making a request", async () => {
+  await assert.rejects(clean("keep my words", { baseUrl: "data:text/plain,no" }), /http or https/);
+});


### PR DESCRIPTION
## What
- validate transcription and cleanup base URLs before issuing requests
- accept only HTTP(S), trim whitespace, and preserve versioned base paths
- add direct coverage for both remote clients and the shared URL builder

## Why
The model-list endpoint already rejected unsafe URL schemes, but the actual STT and cleanup clients did not, leading to inconsistent behavior and opaque fetch failures.

## Test
- `npm test` (292 passed, 1 skipped)