### PR TITLE
fix(stt-server): cap audio upload size

### DIFF
--- a/stt-server/README.md
+++ b/stt-server/README.md
@@ -44,6 +44,8 @@ curl -s http://127.0.0.1:8484/v1/audio/transcriptions \
   -F file=@speech.wav -F response_format=json
 ```
 
+Audio uploads are limited to 64 MiB.
+
 ## Options
 
 | Flag | Env var | Default | Notes |

--- a/stt-server/src/earheart_stt/server.py
+++ b/stt-server/src/earheart_stt/server.py
@@ -96,6 +96,18 @@ def resample_linear(waveform: np.ndarray, src_rate: int, dst_rate: int) -> np.nd
 
 
 TARGET_SAMPLE_RATE = 16000
+MAX_UPLOAD_BYTES = 64 * 1024 * 1024
+
+
+def read_upload(file: UploadFile) -> bytes:
+    """Read one upload without allowing an unbounded in-memory allocation."""
+    data = file.file.read(MAX_UPLOAD_BYTES + 1)
+    if len(data) > MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Audio upload exceeds the {MAX_UPLOAD_BYTES // (1024 * 1024)} MiB limit",
+        )
+    return data
 
 
 def create_app(config: ServerConfig | None = None) -> FastAPI:
@@ -138,7 +150,7 @@ def create_app(config: ServerConfig | None = None) -> FastAPI:
                 "(supported: json, text, verbose_json)",
             )
 
-        waveform, sample_rate = decode_audio(file.file.read())
+        waveform, sample_rate = decode_audio(read_upload(file))
         if waveform.shape[0] == 0:
             raise HTTPException(status_code=400, detail="Empty audio file")
         waveform = resample_linear(waveform, sample_rate, TARGET_SAMPLE_RATE)

--- a/stt-server/tests/test_server.py
+++ b/stt-server/tests/test_server.py
@@ -129,6 +129,16 @@ def test_missing_upload(client, recognizer):
     recognizer.recognize.assert_not_called()
 
 
+def test_oversized_upload_is_rejected_before_decode(
+    client, recognizer, monkeypatch
+):
+    monkeypatch.setattr(server, "MAX_UPLOAD_BYTES", 1024 * 1024)
+    response = transcribe(client, b"x" * (1024 * 1024 + 1))
+    assert response.status_code == 413
+    assert response.json() == {"detail": "Audio upload exceeds the 1 MiB limit"}
+    recognizer.recognize.assert_not_called()
+
+
 @pytest.mark.parametrize("rate", [8000, 16000, 48000])
 @pytest.mark.parametrize("channels", [1, 2])
 def test_audio_is_mono_float32_at_16khz(client, recognizer, rate, channels):


### PR DESCRIPTION
## What
- cap transcription uploads at 64 MiB before audio decoding
- return an explicit HTTP 413 for oversized requests
- verify oversized input never reaches the recognizer

## Why
The server previously read an arbitrarily large multipart upload into memory, allowing one request to exhaust the process.

## Test
- `pytest -q stt-server/tests` (27 passed)