### PR TITLE
fix(wizard): make disabled cleanup fields inert

### DIFF
--- a/renderer/wizard.js
+++ b/renderer/wizard.js
@@ -105,7 +105,10 @@ async function loadMicrophones() {
 // remote config already exists in settings (collect() spreads it through).
 
 function syncCleanupEnabled() {
-  $("cleanup-fields").classList.toggle("disabled", !$("cleanup-enabled").checked);
+  const on = $("cleanup-enabled").checked;
+  const fields = $("cleanup-fields");
+  fields.classList.toggle("disabled", !on);
+  fields.inert = !on;
 }
 
 $("cleanup-enabled").addEventListener("change", syncCleanupEnabled);

--- a/test/settings-contract.test.js
+++ b/test/settings-contract.test.js
@@ -201,3 +201,14 @@ test("shared classes the wizard relies on still exist in settings.css", () => {
   const missing = shared.filter((sel) => !css.includes(sel)).sort();
   assert.deepStrictEqual(missing, [], `settings.css no longer defines: ${missing.join(", ")}`);
 });
+
+test("disabled cleanup controls are inert in settings and the wizard", () => {
+  for (const [name, source] of [["settings", js], ["wizard", wizardJs]]) {
+    const normalized = source.replace(/\s+/g, " ");
+    assert.match(
+      normalized,
+      /fields\.inert = !on/,
+      `${name} must remove disabled cleanup fields from keyboard and accessibility navigation`
+    );
+  }
+});


### PR DESCRIPTION
## What
- mark the wizard’s cleanup field group inert when cleanup is disabled
- keep its visual disabled state and accessibility state synchronized
- pin the behavior for both Settings and the setup wizard

## Why
The wizard only dimmed disabled cleanup fields; keyboard and assistive-technology users could still enter and operate those controls.

## Test
- `node --test test/settings-contract.test.js` (13 passed)