### PR TITLE
fix(stt-server): preserve tiny clips when resampling

### DIFF
--- a/stt-server/src/earheart_stt/server.py
+++ b/stt-server/src/earheart_stt/server.py
@@ -89,7 +89,9 @@ def resample_linear(waveform: np.ndarray, src_rate: int, dst_rate: int) -> np.nd
     if src_rate == dst_rate:
         return waveform
     duration = waveform.shape[0] / src_rate
-    dst_len = int(round(duration * dst_rate))
+    # A non-empty clip shorter than half a destination sample would otherwise
+    # round down to zero after it already passed the endpoint's empty check.
+    dst_len = max(1, int(round(duration * dst_rate)))
     src_t = np.linspace(0.0, duration, num=waveform.shape[0], endpoint=False)
     dst_t = np.linspace(0.0, duration, num=dst_len, endpoint=False)
     return np.interp(dst_t, src_t, waveform).astype(np.float32)

--- a/stt-server/tests/test_server.py
+++ b/stt-server/tests/test_server.py
@@ -151,6 +151,13 @@ def test_audio_is_mono_float32_at_16khz(client, recognizer, rate, channels):
     np.testing.assert_allclose(actual, expected, atol=1e-7)
 
 
+def test_resampling_keeps_a_nonempty_tiny_clip():
+    waveform = np.array([0.25], dtype=np.float32)
+    actual = server.resample_linear(waveform, 48000, 16000)
+    assert actual.dtype == np.float32
+    np.testing.assert_array_equal(actual, waveform)
+
+
 def test_model_not_loaded(loader):
     # TestClient without a context deliberately skips startup, leaving the
     # app in its initial model-loading state.


### PR DESCRIPTION
## What
- keep at least one destination sample when resampling non-empty audio
- add regression coverage for a one-sample 48 kHz clip

## Why
Very short high-rate input could round to zero samples after the endpoint had already passed its empty-audio check, sending an empty array into the recognizer.

## Test
- `pytest -q stt-server/tests` (27 passed)