### PR TITLE
feat(history): copy the original transcript

### DIFF
--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -842,6 +842,18 @@ bindAddCustomModel("cleanup");
 const HISTORY_PAGE_SIZE = 5;
 let historyPage = 0; // 0 = the newest page
 
+function historyCopyButton(label, value) {
+  const button = document.createElement("button");
+  button.className = "copy";
+  button.textContent = label;
+  button.addEventListener("click", async () => {
+    await navigator.clipboard.writeText(value);
+    button.textContent = "Copied";
+    setTimeout(() => (button.textContent = label), 1200);
+  });
+  return button;
+}
+
 async function renderHistory() {
   const items = await earheart.invoke("history:list");
   const list = $("history-list");
@@ -876,15 +888,12 @@ async function renderHistory() {
     when.textContent = `${new Date(item.at).toLocaleString()}${item.cleaned ? " · cleaned" : ""}`;
     const actions = document.createElement("span");
     actions.className = "actions";
-    const copy = document.createElement("button");
-    copy.className = "copy";
-    copy.textContent = "Copy";
-    copy.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(item.text);
-      copy.textContent = "Copied";
-      setTimeout(() => (copy.textContent = "Copy"), 1200);
-    });
-    actions.append(copy);
+    actions.append(historyCopyButton("Copy", item.text));
+    if (item.cleaned && typeof item.raw === "string" && item.raw !== item.text) {
+      const copyOriginal = historyCopyButton("Copy original", item.raw);
+      copyOriginal.title = "Copy the transcript before cleanup";
+      actions.append(copyOriginal);
+    }
     meta.append(when, actions);
     li.append(text, meta);
     list.appendChild(li);

--- a/test/settings-contract.test.js
+++ b/test/settings-contract.test.js
@@ -134,6 +134,20 @@ test("the always-visible History section stays live (no active-tab guard)", () =
   );
 });
 
+test("history exposes the preserved original when cleanup changed it", () => {
+  const normalized = js.replace(/\s+/g, " ");
+  assert.match(
+    normalized,
+    /item\.cleaned && typeof item\.raw === "string" && item\.raw !== item\.text/,
+    "the original action should appear only when cleanup produced different text"
+  );
+  assert.match(
+    normalized,
+    /historyCopyButton\("Copy original", item\.raw\)/,
+    "the original action must copy the preserved raw transcript"
+  );
+});
+
 test("every radio/checkbox group name settings.js uses exists in settings.html", () => {
   const referenced = new Set([...js.matchAll(/name="([a-z-]+)"/g)].map((m) => m[1]));
   assert.ok(referenced.size >= 3, "expected the output-mode/stt-engine/cleanup-engine groups");


### PR DESCRIPTION
## What
- show a `Copy original` action when cleanup changed a saved transcript
- copy the preserved raw words while retaining the existing primary Copy action
- reuse the established History button styling and feedback

## Why
History already saves both raw and cleaned text, but exposed only the cleaned result. Users now have a direct recovery path when cleanup rewrites something incorrectly.

## Test
- `npm test` (289 passed, 1 skipped)
- `xvfb-run -a npx electron scripts/settings-smoke.js --no-sandbox` (15/15)