### PR TITLE
feat: add a button that searches Hugging Face for compatible models

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -19,6 +19,7 @@ const {
   listSttVariants,
   buildCleanupModel,
   buildSttModel,
+  searchUrl,
 } = require("./services/hf-models");
 const { STYLES: CLEANUP_STYLES } = require("./cleanup-styles");
 const { encodeSilenceWav } = require("./util/wav");
@@ -217,6 +218,18 @@ function init({ applyHotkeys, onSettingsChanged }) {
       if (!hfDiscover[kind]) return { ok: false, error: `Unknown model kind: ${kind}` };
       const result = await hfDiscover[kind](parseRepoInput(url), fetch);
       return { ok: true, ...result };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  });
+
+  // Open the Hugging Face hub in the browser, filtered to models Earheart can
+  // run as this kind. The URL is built here from the kind, never taken from
+  // the renderer, so the bridge can't be used to open arbitrary links.
+  ipcMain.handle("models:browse-hf", async (event, { kind } = {}) => {
+    try {
+      await shell.openExternal(searchUrl(kind));
+      return { ok: true };
     } catch (err) {
       return { ok: false, error: err.message };
     }

--- a/main/services/hf-models.js
+++ b/main/services/hf-models.js
@@ -18,6 +18,23 @@
 const HF_HOSTS = new Set(["huggingface.co", "hf.co"]);
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 
+// Where "Browse Hugging Face" sends the user: the model hub filtered to what
+// the discoverers below can actually consume, trending first so the useful
+// repos surface. Cleanup runs GGUF text-generation models; STT runs the
+// sherpa-onnx exports, which the hub only knows by name (they carry no
+// library tag), so that side is a name search.
+const HF_SEARCH = {
+  cleanup: "https://huggingface.co/models?library=gguf&pipeline_tag=text-generation&sort=trending",
+  stt: "https://huggingface.co/models?search=sherpa-onnx&sort=trending",
+};
+
+/** The Hugging Face search page for models Earheart can run as `kind`. */
+function searchUrl(kind) {
+  const url = HF_SEARCH[kind];
+  if (!url) throw new Error(`Unknown model kind: ${kind}`);
+  return url;
+}
+
 /**
  * Parse what the user pasted into { owner, repo, ref }. Accepts a bare
  * "owner/model" (what the Hugging Face site shows as the repo name), the repo
@@ -522,6 +539,7 @@ function buildSttModel(repoFull, variant) {
 
 module.exports = {
   parseRepoInput,
+  searchUrl,
   listGgufQuants,
   listSttVariants,
   recommendedVariant,

--- a/main/services/hf-models.js
+++ b/main/services/hf-models.js
@@ -18,14 +18,26 @@
 const HF_HOSTS = new Set(["huggingface.co", "hf.co"]);
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 
-// Where "Browse Hugging Face" sends the user: the model hub filtered to what
-// the discoverers below can actually consume, trending first so the useful
-// repos surface. Cleanup runs GGUF text-generation models; STT runs the
-// sherpa-onnx exports, which the hub only knows by name (they carry no
-// library tag), so that side is a name search.
+// Where "Browse Hugging Face" sends the user: the model hub narrowed to repos
+// the discoverers below can turn into a working model, trending first.
+//
+// Cleanup: chat GGUFs up to 12B parameters (the largest built-in). Filter on
+// the "conversational" tag, not pipeline_tag=text-generation — the hub files
+// Gemma 3 4B/12B GGUFs under image-text-to-text, and node-llama-cpp runs
+// their text model fine, so the pipeline filter would hide two of the three
+// built-in families. The size cap keeps 27B+ models that can't clean up a
+// dictation in-process on a laptop out of the list.
+//
+// STT: sherpa-onnx exports carry no library tag, so this is a name search.
+// A bare "sherpa-onnx" matches ~550 repos, mostly streaming, CTC, TTS and
+// build artifacts the offline recognizer can't load; "…-nemo-parakeet-tdt"
+// is the Parakeet TDT family the built-ins come from, and nearly every hit is
+// a transducer bundle that loads.
 const HF_SEARCH = {
-  cleanup: "https://huggingface.co/models?library=gguf&pipeline_tag=text-generation&sort=trending",
-  stt: "https://huggingface.co/models?search=sherpa-onnx&sort=trending",
+  cleanup:
+    "https://huggingface.co/models?library=gguf&other=conversational" +
+    "&num_parameters=min:0,max:12B&sort=trending",
+  stt: "https://huggingface.co/models?search=sherpa-onnx-nemo-parakeet-tdt&sort=trending",
 };
 
 /** The Hugging Face search page for models Earheart can run as `kind`. */

--- a/preload.js
+++ b/preload.js
@@ -43,6 +43,7 @@ const INVOKE = new Set([
   "cleanup:test",
   "models:list-remote",
   "models:hf-variants",
+  "models:browse-hf",
   "models:add-custom",
   "models:remove-custom",
   "history:list",

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -212,6 +212,8 @@
                 placeholder="csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2" />
               <div class="row">
                 <button id="stt-hf-find" class="ghost" type="button">Find versions</button>
+                <button id="stt-hf-browse" class="ghost" type="button"
+                  title="Opens huggingface.co in your browser, filtered to models Earheart can run">Browse Hugging Face</button>
                 <span id="stt-hf-result" class="status" aria-live="polite"></span>
               </div>
               <div class="row" id="stt-hf-pick" hidden>
@@ -341,6 +343,8 @@
                   placeholder="unsloth/gemma-3-1b-it-GGUF" />
                 <div class="row">
                   <button id="cleanup-hf-find" class="ghost" type="button">Find versions</button>
+                <button id="cleanup-hf-browse" class="ghost" type="button"
+                  title="Opens huggingface.co in your browser, filtered to models Earheart can run">Browse Hugging Face</button>
                   <span id="cleanup-hf-result" class="status" aria-live="polite"></span>
                 </div>
                 <div class="row" id="cleanup-hf-pick" hidden>

--- a/renderer/settings.html
+++ b/renderer/settings.html
@@ -212,8 +212,7 @@
                 placeholder="csukuangfj/sherpa-onnx-nemo-parakeet-tdt-0.6b-v2" />
               <div class="row">
                 <button id="stt-hf-find" class="ghost" type="button">Find versions</button>
-                <button id="stt-hf-browse" class="ghost" type="button"
-                  title="Opens huggingface.co in your browser, filtered to models Earheart can run">Browse Hugging Face</button>
+                <button id="stt-hf-browse" class="ghost" type="button">Browse Hugging Face</button>
                 <span id="stt-hf-result" class="status" aria-live="polite"></span>
               </div>
               <div class="row" id="stt-hf-pick" hidden>
@@ -225,7 +224,8 @@
                 bundle (encoder, decoder, joiner + tokens.txt) or Whisper export
                 (encoder, decoder + tokens.txt), such as
                 <code>csukuangfj/sherpa-onnx-whisper-turbo</code>. Custom models
-                aren't checksum-verified.
+                aren't checksum-verified. Browse Hugging Face opens your browser on
+                the Parakeet TDT exports, the family the built-in models come from.
               </p>
             </div>
           </div>
@@ -343,8 +343,7 @@
                   placeholder="unsloth/gemma-3-1b-it-GGUF" />
                 <div class="row">
                   <button id="cleanup-hf-find" class="ghost" type="button">Find versions</button>
-                <button id="cleanup-hf-browse" class="ghost" type="button"
-                  title="Opens huggingface.co in your browser, filtered to models Earheart can run">Browse Hugging Face</button>
+                  <button id="cleanup-hf-browse" class="ghost" type="button">Browse Hugging Face</button>
                   <span id="cleanup-hf-result" class="status" aria-live="polite"></span>
                 </div>
                 <div class="row" id="cleanup-hf-pick" hidden>
@@ -354,7 +353,8 @@
                 <p class="hint">
                   Paste a Hugging Face GGUF model URL or owner/model. Earheart lists its
                   versions and downloads the one you pick. Custom models aren't
-                  checksum-verified.
+                  checksum-verified. Browse Hugging Face opens your browser on chat
+                  GGUF models up to 12B parameters; smaller ones clean up faster.
                 </p>
               </div>
             </div>

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -772,6 +772,17 @@ function bindAddCustomModel(kind) {
   const pick = $(`${kind}-hf-pick`);
   const variantSelect = $(`${kind}-hf-variant`);
   const addBtn = $(`${kind}-hf-add`);
+  const browseBtn = $(`${kind}-hf-browse`);
+
+  // Opens the hub in the browser, pre-filtered to this kind; the user copies
+  // a repo from there into the field above.
+  browseBtn.addEventListener("click", async () => {
+    const res = await earheart.invoke("models:browse-hf", { kind });
+    if (!res.ok) {
+      result.textContent = res.error;
+      result.className = "status err";
+    }
+  });
 
   findBtn.addEventListener("click", async () => {
     const url = urlInput.value.trim();

--- a/renderer/settings.js
+++ b/renderer/settings.js
@@ -775,12 +775,25 @@ function bindAddCustomModel(kind) {
   const browseBtn = $(`${kind}-hf-browse`);
 
   // Opens the hub in the browser, pre-filtered to this kind; the user copies
-  // a repo from there into the field above.
+  // a repo from there into the field above. Disabled while the browser is
+  // being asked, so a double-click doesn't open two tabs.
+  let browseError = null;
   browseBtn.addEventListener("click", async () => {
-    const res = await earheart.invoke("models:browse-hf", { kind });
-    if (!res.ok) {
-      result.textContent = res.error;
-      result.className = "status err";
+    browseBtn.disabled = true;
+    try {
+      const res = await earheart.invoke("models:browse-hf", { kind });
+      if (!res.ok) {
+        browseError = res.error;
+        result.textContent = res.error;
+        result.className = "status err";
+      } else if (browseError !== null && result.textContent === browseError) {
+        // Clear only our own stale error, never a Find/Add status.
+        result.textContent = "";
+        result.className = "status";
+        browseError = null;
+      }
+    } finally {
+      browseBtn.disabled = false;
     }
   });
 

--- a/scripts/settings-smoke.js
+++ b/scripts/settings-smoke.js
@@ -237,6 +237,32 @@ app.whenReady().then(async () => {
       );
     }
 
+    // 6. Both custom-model sections offer a way to find a compatible repo
+    //    without leaving the flow: an enabled "Browse Hugging Face" pill in
+    //    the same action row as "Find versions".
+    const browse = JSON.parse(
+      await js(`
+        JSON.stringify(["stt", "cleanup"].map((kind) => {
+          const btn = document.getElementById(kind + "-hf-browse");
+          const find = document.getElementById(kind + "-hf-find");
+          return {
+            kind,
+            present: !!btn,
+            enabled: !!btn && !btn.disabled,
+            label: btn ? btn.textContent.trim() : null,
+            sameRow: !!btn && !!find && btn.parentElement === find.parentElement,
+          };
+        }))
+      `)
+    );
+    for (const b of browse) {
+      check(
+        `the ${b.kind} section offers a Browse Hugging Face button`,
+        b.present && b.enabled && b.label === "Browse Hugging Face" && b.sameRow,
+        JSON.stringify(b)
+      );
+    }
+
     const failed = checks.filter((c) => !c.ok);
     console.log(
       `[settings-smoke] ${checks.length - failed.length}/${checks.length} checks passed`

--- a/test/hf-models.test.js
+++ b/test/hf-models.test.js
@@ -7,6 +7,7 @@ const assert = require("node:assert");
 
 const {
   parseRepoInput,
+  searchUrl,
   listGgufQuants,
   listSttVariants,
   recommendedVariant,
@@ -517,4 +518,19 @@ test("buildSttModel produces a registry-shaped custom entry", () => {
   assert.deepStrictEqual(model.sherpa, variant.sherpa);
   assert.match(model.note, /not checksum-verified/);
   assert.strictEqual(model.files.length, 4);
+});
+
+test("searchUrl points each kind at the hub filtered to what its discoverer accepts", () => {
+  const cleanup = new URL(searchUrl("cleanup"));
+  assert.strictEqual(cleanup.origin, "https://huggingface.co");
+  assert.strictEqual(cleanup.pathname, "/models");
+  assert.strictEqual(cleanup.searchParams.get("library"), "gguf");
+
+  const stt = new URL(searchUrl("stt"));
+  assert.strictEqual(stt.origin, "https://huggingface.co");
+  assert.strictEqual(stt.pathname, "/models");
+  assert.strictEqual(stt.searchParams.get("search"), "sherpa-onnx");
+
+  assert.throws(() => searchUrl("video"), /Unknown model kind/);
+  assert.throws(() => searchUrl(), /Unknown model kind/);
 });

--- a/test/hf-models.test.js
+++ b/test/hf-models.test.js
@@ -15,6 +15,7 @@ const {
   buildSttModel,
   quantOf,
 } = require("../main/services/hf-models");
+const registry = require("../main/engines/registry");
 
 // A fetch stub that routes by URL substring. Routes are tried in order, so put
 // more specific matches (e.g. "/tree/") first.
@@ -525,11 +526,22 @@ test("searchUrl points each kind at the hub filtered to what its discoverer acce
   assert.strictEqual(cleanup.origin, "https://huggingface.co");
   assert.strictEqual(cleanup.pathname, "/models");
   assert.strictEqual(cleanup.searchParams.get("library"), "gguf");
+  // Chat models by tag, not pipeline: the hub files the built-in Gemma 3
+  // 4B/12B GGUFs under image-text-to-text, which a text-generation filter hides.
+  assert.strictEqual(cleanup.searchParams.get("other"), "conversational");
+  assert.strictEqual(cleanup.searchParams.get("pipeline_tag"), null);
+  // Capped at the largest built-in (12B), so the list stays runnable in-process.
+  assert.strictEqual(cleanup.searchParams.get("num_parameters"), "min:0,max:12B");
 
   const stt = new URL(searchUrl("stt"));
   assert.strictEqual(stt.origin, "https://huggingface.co");
   assert.strictEqual(stt.pathname, "/models");
-  assert.strictEqual(stt.searchParams.get("search"), "sherpa-onnx");
+  // The Parakeet TDT family the built-ins come from, not every sherpa-onnx repo.
+  assert.strictEqual(stt.searchParams.get("search"), "sherpa-onnx-nemo-parakeet-tdt");
+  for (const m of registry.listModels("stt")) {
+    const repo = m.files.map((f) => f.url).find(Boolean).split("/")[4];
+    assert.ok(repo.includes(stt.searchParams.get("search")), `${repo} should match the STT search`);
+  }
 
   assert.throws(() => searchUrl("video"), /Unknown model kind/);
   assert.throws(() => searchUrl(), /Unknown model kind/);


### PR DESCRIPTION
## Progress

- [x] Plan: search URL per model kind, built in main so the renderer can't open arbitrary links
- [x] `hf-models.searchUrl(kind)` (depends on nothing)
- [x] `models:browse-hf` IPC handler → `shell.openExternal` (depends on the URL builder)
- [x] Preload allowlist entry
- [x] "Browse Hugging Face" ghost pill beside "Find versions" in both custom-model sections, wired in settings.js
- [x] Tests: unit test for `searchUrl` (incl. every built-in STT repo matches the search), settings-smoke check for both buttons; the IPC contract test covers the channel wiring
- [x] Review fixes: narrowed both searches, visible hints instead of an overstated tooltip, no double-open, stale-error clearing
- [x] Ran `make screenshots`: settings.png is unchanged (the section sits below the captured fold), so no screenshot diff
- [ ] Deferred: the wizard has no custom-model step, so no button there
- [ ] Deferred: the STT discoverer accepts streaming transducer bundles that the offline recognizer can't load (pre-existing; the narrowed search now rarely surfaces them)

## What / why

Finding a model Earheart can actually run meant leaving the app and guessing the right hub filters. Each "Add a model from Hugging Face" section now has a **Browse Hugging Face** button that opens the hub in your browser, filtered to repos that work, trending first. Copy a repo name from there, paste it above, Find versions, Add.

| Kind | Hub filter | Why |
| --- | --- | --- |
| Speech to text | `search=sherpa-onnx-nemo-parakeet-tdt` | The Parakeet TDT family the built-ins come from; a bare `sherpa-onnx` search returned ~550 repos, mostly streaming/CTC/TTS exports that don't load |
| Cleanup | `library=gguf&other=conversational&num_parameters=min:0,max:12B` | `pipeline_tag=text-generation` hid the built-in Gemma 3 4B/12B (tagged image-text-to-text); 12B is the largest built-in |

## How to test

- `npm test` (315 pass)
- `make settings-smoke` (17/17, including the two new button checks)
- Manual: Settings → Speech to text → Browse Hugging Face opens the Parakeet TDT search; Cleanup → Browse Hugging Face opens chat GGUFs ≤12B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZSZV1CHQD3Zc9WaZ3hhsg